### PR TITLE
Add scala-library dependency to some sub-projects

### DIFF
--- a/assembly/build.gradle
+++ b/assembly/build.gradle
@@ -8,7 +8,10 @@ dependencies {
     exclude group: "javax.servlet", module: "servlet-api"
   }
   compile( project(":sparkling-water-examples") )  
-  
+
+  // And Scala library
+  compile "org.scala-lang:scala-library:${scalaVersion}" 
+ 
   // Force this dependency
   runtime( "ai.h2o:h2o-flow:$h2oFlowVersion" )
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -5,5 +5,8 @@ dependencies {
   compile( project(":sparkling-water-core") ) { 
     exclude group: "javax.servlet", module: "servlet-api"
   }
+
+  // And Scala library
+  compile "org.scala-lang:scala-library:${scalaVersion}"
 }
 


### PR DESCRIPTION
Add scala-library dependency to some subprojects to pass the "gradlew idea" command in order to generate IntelliJ Idea project.
