### PR TITLE
Fix overflow problem with converting SchemaRDD with more than 128 cols

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -361,7 +361,7 @@ object H2OContext extends Logging {
   }
 
   private
-  def perSQLPartition ( keystr: String, types: Seq[(Seq[Byte], StructField, Byte)], domains: Array[Array[String]] )
+  def perSQLPartition ( keystr: String, types: Seq[(Seq[Int], StructField, Byte)], domains: Array[Array[String]] )
                       ( context: TaskContext, it: Iterator[Row] ): (Int,Long) = {
     val nchks = water.fvec.FrameUtils.createNewChunks(keystr,context.partitionId)
     val domHash = domains.map( ary =>


### PR DESCRIPTION
This fixes an apparent bug when converting SchemaRDDs with more than 128 columns to DataFrames.

The code in H2OSchemaUtils seems to convert column indexes to Bytes (from Ints), which overflows if there are more than 128 columns. This eventually resulted in an ArrayIndexOutOfBoundsException when getting the column value.

I haven't tested this extensively -- I just changed everything I could see in H2OSchemaUtils that looked like an index from a Byte to Int and verified that it fixed the error, so it certainly needs somebody who knows the code better to check it.