### PR TITLE
Implementation of the conversion of RDD containing a primitive type t…

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OPrimitiveType.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OPrimitiveType.scala
@@ -1,0 +1,30 @@
+package org.apache.spark.h2o
+
+import org.apache.spark.SparkContext
+
+/**
+ * Magnet pattern (Type Class pattern) for conversion from various primitive types to their appropriate H2OFrame using
+ * the method with the same name
+ */
+trait PrimitiveType {
+  def toH2OFrame(sc: SparkContext): H2OFrame
+}
+
+
+object PrimitiveType {
+  implicit def toDataFrameFromString(rdd: RDD[String]): PrimitiveType = new PrimitiveType {
+    override def toH2OFrame(sc: SparkContext): H2OFrame = H2OContext.toH2OFrameFromRDDString(sc, rdd)
+  }
+
+  implicit def toDataFrameFromInt(rdd: RDD[Int]): PrimitiveType = new PrimitiveType {
+    override def toH2OFrame(sc: SparkContext): H2OFrame = H2OContext.toH2OFrameFromRDDInt(sc, rdd)
+  }
+
+  implicit def toDataFrameFromFloat(rdd: RDD[Float]): PrimitiveType = new PrimitiveType {
+    override def toH2OFrame(sc: SparkContext): H2OFrame = H2OContext.toH2OFrameFromRDDFloat(sc, rdd)
+  }
+
+  implicit def toDataFrameFromDouble(rdd: RDD[Double]): PrimitiveType = new PrimitiveType {
+    override def toH2OFrame(sc: SparkContext): H2OFrame = H2OContext.toH2OFrameFromRDDDouble(sc, rdd)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/h2o/H2OPrimitiveTypesUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OPrimitiveTypesUtils.scala
@@ -1,0 +1,53 @@
+package org.apache.spark.h2o
+
+import org.apache.spark.SparkContext
+import water.fvec.Vec
+import water.parser.Categorical
+
+import scala.collection.mutable
+import scala.language.implicitConversions
+
+/**
+ * Utilities to work with primitive types such as String, Integer, Double..
+ *
+ */
+object H2OPrimitiveTypesUtils {
+
+  /** Method used for obtaining column domains */
+  private[spark]
+  def collectColumnDomains[T](sc: SparkContext,
+                              rdd: RDD[T],
+                              fnames: Array[String],
+                              ftypes: Array[Class[_]]): Array[Array[String]] = {
+    val res = Array.ofDim[Array[String]](fnames.length)
+    for (idx <- 0 until ftypes.length if ftypes(idx).equals(classOf[String])) {
+      val acc = sc.accumulableCollection(new mutable.HashSet[String]())
+      rdd.foreach(r => {
+        acc += r.asInstanceOf[String]
+      })
+      res(idx) = if (acc.value.size > Categorical.MAX_ENUM_SIZE) null else acc.value.toArray.sorted
+    }
+    res
+  }
+
+  /** Method translating primitive types into Sparkling Water types
+    * This method is already prepared to handle all mentioned primitive types  */
+  private[spark]
+  def dataTypeToVecType(t: Class[_], d: Array[String]): Byte = {
+    t match {
+      case q if q == classOf[java.lang.Byte] => Vec.T_NUM
+      case q if q == classOf[java.lang.Short] => Vec.T_NUM
+      case q if q == classOf[java.lang.Integer] => Vec.T_NUM
+      case q if q == classOf[java.lang.Long] => Vec.T_NUM
+      case q if q == classOf[java.lang.Float] => Vec.T_NUM
+      case q if q == classOf[java.lang.Double] => Vec.T_NUM
+      case q if q == classOf[java.lang.Boolean] => Vec.T_NUM
+      case q if q == classOf[java.lang.String] => if (d != null && d.length < water.parser.Categorical.MAX_ENUM_SIZE) {
+        Vec.T_ENUM
+      } else {
+        Vec.T_STR
+      }
+      case q => throw new IllegalArgumentException(s"Do not understand type $q")
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/rdd/H2ORDDTest.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/H2ORDDTest.scala
@@ -116,43 +116,43 @@ class H2ORDDTest extends FunSuite with SharedSparkTestContext {
   }
 
   // PUBDEV-1173
-  ignore("RDD[Int] to H2OFrame[Numeric]") {
+  test("RDD[Int] to H2OFrame[Numeric]") {
     // Create RDD with 100 Int values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10)
     // PUBDEV-1173
-    //val dataFrame: H2OFrame = hc.asH2OFrame(rdd)
-    //assert(rdd.count == dataFrame.numRows(), "Number of rows should match")
-    //dataFrame.delete()
+    val dataFrame: H2OFrame = hc.asH2OFrame(rdd)
+    assert(rdd.count == dataFrame.numRows(), "Number of rows should match")
+    dataFrame.delete()
   }
 
   // PUBDEV-1173
-  ignore("RDD[Float] to H2OFrame[Numeric]") {
+  test("RDD[Float] to H2OFrame[Numeric]") {
     // Create RDD with 100 Float values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10).map(v => v.toFloat)
     // PUBDEV-1173
-    //val dataFrame: H2OFrame = hc.asH2OFrame(rdd)
-    //assert(rdd.count == dataFrame.numRows(), "Number of rows should match")
-    //dataFrame.delete()
+    val dataFrame: H2OFrame = hc.asH2OFrame(rdd)
+    assert(rdd.count == dataFrame.numRows(), "Number of rows should match")
+    dataFrame.delete()
   }
 
   // PUBDEV-1173
-  ignore("RDD[Double] to H2OFrame[Numeric]") {
+  test("RDD[Double] to H2OFrame[Numeric]") {
     // Create RDD with 100 Double values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10).map(v => v.toDouble)
     // PUBDEV-1173
-    //val dataFrame: H2OFrame = hc.asH2OFrame(rdd)
-    //assert(rdd.count == dataFrame.numRows(), "Number of rows should match")
-    //dataFrame.delete()
+    val dataFrame: H2OFrame = hc.asH2OFrame(rdd)
+    assert(rdd.count == dataFrame.numRows(), "Number of rows should match")
+    dataFrame.delete()
   }
 
   // PUBDEV-1173
-  ignore("RDD[String] to H2OFrame[String]") {
+  test("RDD[String] to H2OFrame[String]") {
     // Create RDD with 100 String values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10).map(v => v.toString)
     // PUBDEV-1173
-    //val dataFrame: H2OFrame = hc.asH2OFrame(rdd)
-    //assert(rdd.count == dataFrame.numRows(), "Number of rows should match")
-    //dataFrame.delete()
+    val dataFrame: H2OFrame = hc.asH2OFrame(rdd)
+    assert(rdd.count == dataFrame.numRows(), "Number of rows should match")
+    dataFrame.delete()
   }
 
 


### PR DESCRIPTION
I tried to ensure that the conversion can be made for various primitive types by the method with the name asH2OFrame using the magnet pattern ( type class pattern ).

In H2OContext, there is a new method called toH2OFrameFromPrimitive, which is private for the object, and ensures the transformation from RDD, containing primitive type, to appropriate H2OFrame. The method perPrimitivePartition, which is used by the toH2OFromPrimitive method, can be easily expanded to support more primitive types such as Short, Long or, for example, Boolean. 

The method toH2OFrameFromPrimitive can't be called directly from outside the H2OContext class or object( in order to ensure that this method is not called on an unsupported type) and therefore public method, which actually calls the toH2OFrameFromPrimitive method, for each allowed type was created. These methods can be called directly or are invoked when the method asH2OFrame is called on a RDD containing a primitive type.