### PR TITLE
Made compatible with to-be-released SPARK-1.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ configure(allprojects) { project ->
       scalaBinaryVersion = '2.10'
       // h2oBuild property is defined in gradle.properties
       h2oVersion         = "$h2oMajorVersion.$h2oBuild"
-      sparkVersion       = '1.3.0'
+      sparkVersion       = '1.4.0-SNAPSHOT'
       junitVersion       = '4.11'
     }
 }

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -213,12 +213,8 @@ class H2OContext (@transient val sparkContext: SparkContext) extends {
   }
 
   def createH2OSchemaRDD(fr: H2OFrame)(implicit sqlContext: SQLContext): DataFrame = {
-    //SparkPlan.currentContext.set(sqlContext)
     val h2oSchemaRDD = new H2OSchemaRDD(this, fr)
-    val schemaAtts = H2OSchemaUtils.createSchema(fr).fields.map( f =>
-      AttributeReference(f.name, f.dataType, f.nullable)())
-
-    new DataFrame(sqlContext, LogicalRDD(schemaAtts, h2oSchemaRDD)(sqlContext))
+    sqlContext.createDataFrame(h2oSchemaRDD, H2OSchemaUtils.createSchema(fr))
   }
 
   /** Open H2O Flow running in this client. */

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/RDD2DataFrame.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/RDD2DataFrame.scala
@@ -10,7 +10,9 @@ import org.apache.spark.sql.types.StructType
  *  H2O DataFrame into
  */
 class RDD2DataFrame extends Transformer {
-  override def transform(dataset: DataFrame, paramMap: ParamMap): DataFrame = ???
+  val uid: String = ???
 
-  override def transformSchema(schema: StructType, paramMap: ParamMap): StructType = ???
+  override def transform(dataset: DataFrame): DataFrame = ???
+
+  override def transformSchema(schema: StructType): StructType = ???
 }


### PR DESCRIPTION
A small PR to enable the use of Sparkling Water with the upcoming Spark 1.4.0 release. The key 'problem' is that a separation has been made between internal and external data types as of Spark 1.4. Using the current version of Sparkling Water will lead to a number of ClassCastExceptions when using Strings (it will try to cast them to a UTF8String which is the internal string implementation). The solution was to use the 'createDataFrame' function in SQLContext which will do the necessary data conversions (this method is also available in Spark 1.3.0 - so this can be backported).

The ML pipeline code were STUBS, and I only have made the required changes. This looks promising though.