### PR TITLE
Adapt H2OContext for usage in Spark 1.4.0+

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -220,12 +220,8 @@ class H2OContext (@transient val sparkContext: SparkContext) extends {
   }
 
   def createH2OSchemaRDD(fr: H2OFrame)(implicit sqlContext: SQLContext): DataFrame = {
-    //SparkPlan.currentContext.set(sqlContext)
     val h2oSchemaRDD = new H2OSchemaRDD(this, fr)
-    val schemaAtts = H2OSchemaUtils.createSchema(fr).fields.map( f =>
-      AttributeReference(f.name, f.dataType, f.nullable)())
-
-    new DataFrame(sqlContext, LogicalRDD(schemaAtts, h2oSchemaRDD)(sqlContext))
+    sqlContext.createDataFrame(h2oSchemaRDD, H2OSchemaUtils.createSchema(fr))
   }
 
   /** Open H2O Flow running in this client. */


### PR DESCRIPTION
A small PR to enable the use of Sparkling Water with the Spark 1.4.0. The PR will work with Spark 1.3 though.

The key 'problem' is that a separation has been made between internal and external data types as of Spark 1.4. Using the current version of Sparkling Water will lead to a number of ClassCastExceptions when using Strings (it will try to cast them to a UTF8String which is the internal String implementation).