### PR TITLE
fix Wrong Scala import sentence

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -152,8 +152,8 @@ You can configure Sparkling Water using the following variables:
 11. Run deep learning to produce a model estimating arrival delay:
   ```scala
   import hex.deeplearning.DeepLearning
-  import hex.deeplearning.DeepLearningModel.DeepLearningParameters
-  import hex.deeplearning.DeepLearningModel.DeepLearningParameters.Activation
+  import hex.deeplearning.DeepLearningParameters  
+  import hex.deeplearning.DeepLearningParameters.Activation
   val dlParams = new DeepLearningParameters()
   dlParams._train = bigDataFrame
   dlParams._response_column = 'ArrDelay


### PR DESCRIPTION
Corrected the erroneous import statements of Scala. ( in /examples/README.md)
validated in sparkling-water-1.3.5.

if you encounter any problems please contact me.