### PR TITLE
[SWPRIVATE-12] Config for SSL and utility class for key creation

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
@@ -81,8 +81,9 @@ private[backends] trait SharedBackendUtils extends Logging with Serializable {
   // Options in form key=value
     Seq(
       ("-name", conf.cloudName.get),
-      ("-nthreads", if (conf.nthreads > 0) conf.nthreads else null))
-      .filter(x => x._2 != null)
+      ("-nthreads", if (conf.nthreads > 0) conf.nthreads else null),
+      ("-internal_security_conf", conf.sslConf.orNull)
+    ).filter(x => x._2 != null)
       .flatMap(x => Seq(x._1, x._2.toString)) ++ // Append single boolean options
       Seq(("-ga_opt_out", conf.disableGA))
         .filter(_._2).map(x => x._1)

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedH2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedH2OConf.scala
@@ -49,10 +49,13 @@ trait SharedH2OConf {
   def loginConf     = sparkConf.getOption(PROP_LOGIN_CONF._1)
   def userName      = sparkConf.getOption(PROP_USER_NAME._1)
 
+  def sslConf       = sparkConf.getOption(PROP_SSL_CONF._1)
+
   def isFailOnUnsupportedSparkParamEnabled = sparkConf.getBoolean(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._2)
   def scalaIntDefaultNum = sparkConf.getInt(PROP_SCALA_INT_DEFAULT_NUM._1, PROP_SCALA_INT_DEFAULT_NUM._2)
   def isH2OReplEnabled = sparkConf.getBoolean(PROP_REPL_ENABLED._1, PROP_REPL_ENABLED._2)
   def isClusterTopologyListenerEnabled = sparkConf.getBoolean(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._2)
+
   def isSparkVersionCheckEnabled = sparkConf.getBoolean(PROP_SPARK_VERSION_CHECK_ENABLED._1, PROP_SPARK_VERSION_CHECK_ENABLED._2)
 
   def runsInExternalClusterMode: Boolean = backendClusterMode.toLowerCase() == "external"
@@ -170,6 +173,9 @@ object SharedH2OConf {
 
   /** Enable/Disable exit on unsupported Spark parameters. */
   val PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM = ("spark.ext.h2o.fail.on.unsupported.spark.param", true)
+
+  /** Path to Java KeyStore file. */
+  val PROP_SSL_CONF = ("spark.ext.h2o.internal_security_conf", null.asInstanceOf[String])
 
   private[spark] def defaultLogDir: String = {
     System.getProperty("user.dir") + java.io.File.separator + "h2ologs"

--- a/core/src/main/scala/org/apache/spark/network/Security.scala
+++ b/core/src/main/scala/org/apache/spark/network/Security.scala
@@ -1,0 +1,37 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.spark.network
+
+import org.apache.spark.SparkContext
+import org.apache.spark.deploy.SparkHadoopUtil
+import water.network.SecurityUtils
+
+object Security {
+
+  def enableSSL(sc: SparkContext) = {
+    val sslPair = SecurityUtils.generateSSLPair()
+    val config = SecurityUtils.generateSSLConfig(sslPair)
+    if(SparkHadoopUtil.get.isYarnMode) {
+      sc.conf.set("spark.yarn.dist.files", s"${sslPair.jks.path},$config")
+    } else {
+      sc.addFile(sslPair.jks.path)
+      sc.addFile(config)
+    }
+    sc.conf.set("spark.ext.h2o.internal_security_conf", config)
+  }
+
+}


### PR DESCRIPTION
---

<a name="Security"></a>

Both Spark and H2O support basic node authentication and data
encryption.

To enable it in Spark please check [their
documentation](http://spark.apache.org/docs/latest/security.html).

Security for H2O nodes can be enabled manually by generating all
necessary files, distributing them to all worker nodes as described in
[H2O's
documentation](https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/security.rst)
and passing the "spark.ext.h2o.internal_security_conf" to spark submit:

::
```
bin/sparkling-shell /
--conf "spark.ext.h2o.internal_security_conf=ssl.properties"
```

We also provide a utility method which will automatically generate all
files and enable security on all H2O nodes:

::

```
import org.apache.spark.network.Security
import org.apache.spark.h2o._
Security.enableSSL(sc) // generate properties file, keypairs and set appropriate H2O parameters
val hc = H2OContext.getOrCreate(sc) // start the H2O cloud
```

This method will generate all files and distributed them via YARN or
Spark methods to all worker nodes. This communication will be secure if
you configured YARN/Spark security.

---
