### PR TITLE
[SW-168] a flag to control transfer of metadata from H2OFrame to DataFrame

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/DefaultSource.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/DefaultSource.scala
@@ -65,7 +65,7 @@ class DefaultSource
                                schema: StructType): H2OFrameRelation[_] = {
     val key = checkKey(parameters)
 
-    H2OFrameRelation(getFrame(key))(sqlContext)
+    H2OFrameRelation(getFrame(key), true)(sqlContext)
   }
 
   override def createRelation( sqlContext: SQLContext,

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -24,7 +24,7 @@ import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.h2o.H2OContextUtils._
 import org.apache.spark.h2o.H2OTypeUtils._
 import org.apache.spark.mllib.regression.LabeledPoint
-import org.apache.spark.rdd.{H2ORDD, H2OSchemaRDD}
+import org.apache.spark.rdd.H2ORDD
 import org.apache.spark.repl.SparkIMain
 import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorAdded}
 import org.apache.spark.sql.types._
@@ -138,9 +138,9 @@ class H2OContext (@transient val sparkContext: SparkContext) extends {
 
   /** Convert given H2O frame into DataFrame type */
   @deprecated("1.3", "Use asDataFrame")
-  def asSchemaRDD[T <: Frame](fr : T)(implicit sqlContext: SQLContext) : DataFrame = createH2OSchemaRDD(fr)
-  def asDataFrame[T <: Frame](fr : T)(implicit sqlContext: SQLContext) : DataFrame = createH2OSchemaRDD(fr)
-  def asDataFrame(s : String)(implicit sqlContext: SQLContext) : DataFrame = createH2OSchemaRDD(new H2OFrame(s))
+  def asSchemaRDD[T <: Frame](fr : T, copyMetadata: Boolean = true)(implicit sqlContext: SQLContext) : DataFrame = createH2OSchemaRDD(fr, copyMetadata)
+  def asDataFrame[T <: Frame](fr : T, copyMetadata: Boolean = true)(implicit sqlContext: SQLContext) : DataFrame = createH2OSchemaRDD(fr, copyMetadata)
+  def asDataFrame(s : String, copyMetadata: Boolean)(implicit sqlContext: SQLContext) : DataFrame = createH2OSchemaRDD(new H2OFrame(s), copyMetadata)
 
   def h2oLocalClient = this.localClientIp + ":" + this.localClientPort
 
@@ -265,12 +265,13 @@ class H2OContext (@transient val sparkContext: SparkContext) extends {
     * Create a Spark DataFrame from given H2O frame.
     *
     * @param fr  an instnace of H2O frame
+    * @param copyMetadata  copy H2O metadata into Spark DataFrame
     * @param sqlContext  running sqlContext
     * @tparam T  type of H2O frame
     * @return  a new DataFrame
     */
-  def createH2OSchemaRDD[T <: Frame](fr: T)(implicit sqlContext: SQLContext): DataFrame = {
-    val ss = new H2OFrameRelation(fr)(sqlContext)
+  def createH2OSchemaRDD[T <: Frame](fr: T, copyMetadata: Boolean)(implicit sqlContext: SQLContext): DataFrame = {
+    val ss = new H2OFrameRelation(fr, copyMetadata)(sqlContext)
     sqlContext.baseRelationToDataFrame(ss)
   }
 

--- a/core/src/main/scala/org/apache/spark/h2o/H2ORelation.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2ORelation.scala
@@ -22,9 +22,9 @@ import org.apache.spark.sql.types.StructType
 import water.DKV
 
 object DataSourceUtils {
-  def getSparkSQLSchema(key: String): StructType = {
+  def getSparkSQLSchema(key: String, copyMetadata: Boolean = true): StructType = {
     val frame = DKV.getGet[H2OFrame](key)
-    H2OSchemaUtils.createSchema(frame)
+    H2OSchemaUtils.createSchema(frame, copyMetadata)
   }
 
   def overwrite(key: String,originalFrame: H2OFrame, newDataFrame: DataFrame)(implicit h2oContext: H2OContext): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/H2OSQLContextUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/H2OSQLContextUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.h2o.H2OSchemaUtils
-import org.apache.spark.rdd.{H2OSchemaRDDInternal, RDD}
+import org.apache.spark.rdd.{H2OSchemaRDD, H2OSchemaRDDInternal, RDD}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources.{BaseRelation, PrunedScan, TableScan}
 import org.apache.spark.sql.types.StructType
@@ -36,7 +36,8 @@ object H2OSQLContextUtils {
 
 /** H2O relation implementing column filter operation.
   */
-case class H2OFrameRelation[T <: Frame](@transient h2oFrame: T)
+case class H2OFrameRelation[T <: Frame](@transient h2oFrame: T,
+                                        @transient copyMetadata: Boolean)
                                        (@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with PrunedScan /* with PrunedFilterScan */  {
 
@@ -45,7 +46,7 @@ case class H2OFrameRelation[T <: Frame](@transient h2oFrame: T)
 
   override val needConversion = false
 
-  override val schema: StructType = H2OSchemaUtils.createSchema(h2oFrame)
+  override val schema: StructType = H2OSchemaUtils.createSchema(h2oFrame, copyMetadata)
 
   override def buildScan(): RDD[Row] =
     new H2OSchemaRDDInternal(h2oFrame)(sqlContext.sparkContext).asInstanceOf[RDD[Row]]

--- a/py/pysparkling/context.py
+++ b/py/pysparkling/context.py
@@ -141,7 +141,7 @@ class H2OContext(object):
     def show(self):
         print self
 
-    def as_spark_frame(self, h2o_frame):
+    def as_spark_frame(self, h2o_frame, copy_metadata = True):
         """
         Transforms given H2OFrame to Spark DataFrame
 
@@ -155,7 +155,7 @@ class H2OContext(object):
         """
         if isinstance(h2o_frame,H2OFrame):
             j_h2o_frame = h2o_frame.get_java_h2o_frame()
-            jdf = self._jhc.asDataFrame(j_h2o_frame, self._jsqlContext)
+            jdf = self._jhc.asDataFrame(j_h2o_frame, copy_metadata, self._jsqlContext)
             return DataFrame(jdf,self._sqlContext)
 
     def as_h2o_frame(self, dataframe, framename = None):


### PR DESCRIPTION
@mklechan observed slow down of `select count(*) from h2oFrame` query after `asDataFrame` call during handling larger datasets.
The slow down was caused by Spark querying metadata which we attached during transformation
of H2OFrame to Dataset.

The fix introduces an additional option for asDataFrame call to control transfer
of metadata from H2OFrame to DataFrame.