### PR TITLE
[SW-177] REPL simplification

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/h2o/H2OIMain.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/h2o/H2OIMain.scala
@@ -17,114 +17,71 @@
 
 package org.apache.spark.repl.h2o
 
-import org.apache.spark.util.MutableURLClassLoader
-import org.apache.spark.{SparkContext, SparkEnv, HttpServer}
-import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.repl.{Main, SparkIMain}
+import org.apache.spark.util.MutableURLClassLoader
+import org.apache.spark.{HttpServer, SparkContext, SparkEnv}
 
 import scala.collection.mutable
-import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.io.PlainFile
-import scala.tools.nsc.interpreter.AbstractOrMissingHandler
-import scala.tools.nsc.{Global, Settings, io}
+import scala.tools.nsc.Settings
 
 /**
-  * SparkIMain which allows parallel interpreters to coexist. It adds each class to package which specifies the interpreter
-  * where this class was declared
+  * SparkIMain allowing multiple interpreters to coexist in parallel. Each line in repl is wrapped in a package which
+  * name contains current session id
   */
 private[repl] class H2OIMain private(initialSettings: Settings,
                interpreterWriter: IntpResponseWriter,
                val sessionID: Int,
                propagateExceptions: Boolean = false) extends SparkIMain(initialSettings, interpreterWriter, propagateExceptions){
 
-  private val _compiler: Global = getAndSetCompiler()
+  setupCompiler()
   stopClassServer()
   setupClassNames()
 
-  @DeveloperApi
-  override def initializeSynchronous(): Unit = {
-    val _initializedCompleteField = this.getClass.getSuperclass.getDeclaredField("_initializeComplete")
-    _initializedCompleteField.setAccessible(true)
-    if (!_initializedCompleteField.get(this).asInstanceOf[Boolean]) {
-      _initialize()
-      assert(global != null, global)
-    }
-  }
-
-  private def _initialize() ={
-    try {
-      // todo. if this crashes, REPL will hang
-      new _compiler.Run().compileSources(_initSources)
-      val _initializedCompleteField = this.getClass.getSuperclass.getDeclaredField("_initializeComplete")
-      _initializedCompleteField.setAccessible(true)
-      _initializedCompleteField.set(this,true)
-      true
-    }
-    catch AbstractOrMissingHandler()
-
-  }
-
-  private def _initSources = List(new BatchSourceFile("<init>", "package intp_id_" + sessionID + " \n class $repl_$init { }"))
-
   /**
-    * Stop class server started in SparkIMain constructor because we have already one running and need to use
-    * that server
+    * Stop class server started in SparkIMain constructor because we have to use our class server which is already
+    * running
     */
-  private def stopClassServer(): Unit ={
-    val fieldClassServer =  this.getClass.getSuperclass.getDeclaredField("classServer")
+  private def stopClassServer() = {
+    val fieldClassServer = this.getClass.getSuperclass.getDeclaredField("classServer")
     fieldClassServer.setAccessible(true)
     val classServer = fieldClassServer.get(this).asInstanceOf[HttpServer]
     classServer.stop()
   }
 
-  private def getAndSetCompiler(): Global = {
-    // need to override virtualDirectory so it uses our directory
+  /**
+    * Create a new instance of compiler with the desired output directory
+    */
+  private def setupCompiler() = {
+    // set virtualDirectory to our shared directory for all repl instances
     val fieldVirtualDirectory = this.getClass.getSuperclass.getDeclaredField("org$apache$spark$repl$SparkIMain$$virtualDirectory")
     fieldVirtualDirectory.setAccessible(true)
     fieldVirtualDirectory.set(this,new PlainFile(H2OInterpreter.classOutputDir))
 
-    // need to initialize the compiler again so it uses new virtualDirectory
+    // initialize the compiler again with new virtualDirectory set
     val fieldCompiler = this.getClass.getSuperclass.getDeclaredField("_compiler")
     fieldCompiler.setAccessible(true)
     fieldCompiler.set(this,newCompiler(settings,reporter))
-    fieldCompiler.get(this).asInstanceOf[Global]
   }
 
   /**
-    * Ensures that before each class is added special prefix identifying the interpreter
-    * where this class was declared
+    * Ensure that each class defined in repl is in a package containing number of repl session
     */
-  private def setupClassNames(): Unit ={
-    val ru = scala.reflect.runtime.universe
-    val mirror = ru.runtimeMirror(getClass.getClassLoader)
-
-    val fixedSessionNamesSymbol = ru.typeOf[FixedSessionNames.type].termSymbol.asModule
-
-    val moduleMirror = mirror.reflect(this).reflectModule(fixedSessionNamesSymbol)
-    val instanceMirror = mirror.reflect(moduleMirror.instance)
-
-    val lineNameTerm = ru.typeOf[FixedSessionNames.type].declaration(ru.newTermName("lineName")).asTerm.accessed.asTerm
-    val fieldMirror = instanceMirror.reflectField(lineNameTerm)
-
-    val previousValue = fieldMirror.get.asInstanceOf[String]
-    fieldMirror.set("intp_id_" + sessionID + "." + previousValue)
+  private def setupClassNames() = {
+    import naming._
+    // sessionNames is lazy val and needs to be accessed first in order to be then set again to our desired value
+    naming.sessionNames.line
+    val fieldSessionNames = naming.getClass.getDeclaredField("sessionNames")
+    fieldSessionNames.setAccessible(true)
+    fieldSessionNames.set(naming, new SessionNames {
+      override def line  = "intp_id_" + sessionID + "." + propOr("line")
+    })
   }
 
-  override private[repl] def initialize(postInitSignal: => Unit): Unit = {
-    val _isInitializedField = this.getClass.getSuperclass.getDeclaredField("_isInitialized")
-    _isInitializedField.setAccessible(true)
-    synchronized {
-      if (_isInitializedField.get(this) == null) {
-        _isInitializedField.set(this, io.spawn {
-          try _initialize()
-          finally postInitSignal
-        })
-      }
-    }
-  }
 }
 
 object H2OIMain {
+
   val existingInterpreters = mutable.HashMap.empty[Int, H2OIMain]
   private var interpreterClassloader: InterpreterClassLoader = _
   private var _initialized = false
@@ -135,8 +92,8 @@ object H2OIMain {
   }
 
   /**
-    * Add directory with classes defined in REPL to the classloader
-   which is used in the local mode. This classloader is obtained using reflections.
+    * Add directory with classes defined in repl to the classloader
+    * which is used in the local mode. This classloader is obtained using reflections.
     */
   private def prepareLocalClassLoader() = {
     val f = SparkEnv.get.serializer.getClass.getSuperclass.getDeclaredField("defaultClassLoader")
@@ -155,7 +112,7 @@ object H2OIMain {
 
   private def initialize(sc: SparkContext): Unit = {
     if (sc.isLocal) {
-      // using master set to local or local[*]
+      // master set to local or local[*]
       prepareLocalClassLoader()
       interpreterClassloader = new InterpreterClassLoader()
     } else {


### PR DESCRIPTION
This PR cleans REPL a little bit.

The initialization piece of code does not have to have session id as part of it's name. It is just used to test wheter the compiler has been successfully initialised. We don't therefore have to change the initialization code and thus can remove it. ( the interpreter test runs anyway )

Also the code in `setupClassNames` was simplified. This change also allows us to use the same code in this method among all spark versions for scala 2.10 and 2.11. 

Also remove unnecessary setting of classpath since it's always overriden in `createInterpreter` method.