### PR TITLE
[SW-178] Implement external backend

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -226,6 +226,7 @@ The following configuration properties can be passed to Spark to configure Spark
 | Property name | Default value | Description |
 |---------------|---------------|-------------|
 | **Generic parameters** |||
+|`spark.ext.h2o.backend.cluster.mode`|`internal`|This option can be set either to "internal" or "external". When set to "external" H2O Context is created by connecting to existing H2O cluster, otherwise it creates H2O cluster living in Spark - that means that each Spark executor will have one h2o instance running in it. The internal is not recommended for big clusters and clusters where Spark executors are not stable.|
 |`spark.ext.h2o.cloud.name`| `sparkling-water-` | Name of H2O cloud.|
 |`spark.ext.h2o.nthreads`|`-1`|Limit for number of threads used by H2O, default `-1` means unlimited.|
 |`spark.ext.h2o.disable.ga`|`false`|Disable Google Analytics tracking for embedded H2O.|
@@ -252,6 +253,7 @@ The following configuration properties can be passed to Spark to configure Spark
 |`spark.ext.h2o.client.network.mask`|--|Subnet selector for H2O client, this disables using IP reported by Spark but tries to find IP based on the specifed mask.|
 ---
 
+
 ####Internal backend configuration properties
 | Property name | Default value | Description |
 |---------------|---------------|-------------|
@@ -269,6 +271,13 @@ The following configuration properties can be passed to Spark to configure Spark
 |`spark.ext.h2o.node.network.mask`|--|Subnet selector for H2O running inside Spark executors, this disables using IP reported by Spark but tries to find IP based on the specified mask.|
 |`spark.ext.h2o.node.log.level`| `INFO`| H2O internal log level used for launched H2O nodes.|
 |`spark.ext.h2o.node.log.dir`| ` System.getProperty("user.dir") + File.separator + "h2ologs"` or YARN container dir| Location of h2o logs on executor machine.|
+---
+
+####External backend configuration properties
+| Property name | Default value | Description |
+|---------------|---------------|-------------|
+|`spark.ext.h2o.cloud.representative`| `null`| ip:port of arbitrary h2o node to identify external h2o cluster|
+|`spark.ext.h2o.external.cluster.num.h2o.nodes`| `null`| Number of nodes to wait for when connecting to external H2O cluster. |
 ---
 
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,26 @@ There are several ways of using Sparkling Water:
 
 ---
 
-H2O cloud is created automatically during the call of `H2OContext.getOrCreate`. Since it's not
+## Sparkling Water cluster backends
+
+Sparkling water supports two backend/deployment modes. We call them internal and external back-ends.
+Sparkling Water applications are independent on selected backend, the before `H2OContext` is created
+we need to tell it which backend used.
+
+### Internal backend
+In internal backend, H2O cloud is created automatically during the call of `H2OContext.getOrCreate`. Since it's not
 technically possible to get number of executors in Spark, we try to discover all executors at the initiation of `H2OContext`
 and we start H2O instance inside of each discovered executor. This solution is easiest to deploy; however when Spark
 or YARN kills the executor - which is not an unusual case - the whole H2O cluster goes down since h2o doesn't support high 
 availability. 
 
 
-Here we show a few examples how H2OContext can be started.
+Internal backend is default for behaviour for Sparkling Water. It can be changed via spark configuration property
+`spark.ext.h2o.backend.cluster.mode` to `external` or `internal`. Another way how to change type of backend is by calling
+ `setExternalClusterMode()` or `setInternalClusterMode()` method on `H2OConf` class. `H2OConf` is simple wrapper 
+around `SparkConf` and inherits all properties in spark configuration.
+
+Here we show a few examples how H2OContext can be started with internal backend.
 
 Explicitly specify internal backend on `H2OConf`
 ```
@@ -140,6 +152,40 @@ val conf = new H2OConf(sc)
 val h2oContext = H2OContext.getOrCreate(sc, conf)
 ```
 
+
+ 
+### External backend
+In external cluster mode we expected that H2O cluster is already running and we connect to it from Spark driver (actually
+H2O node in special client mode running in spark driver). 
+
+Few examples how to Sparkling Water in external backend mode.
+
+This piece of code tries to connect to existing h2o cloud with name "h2o-cloud". The H2O cloud is located using multicast
+and is assumed that all h2o nodes were started without `-flatfile` option and with `-md5skip` option.
+For example like:
+```
+java -jar h2o.jar -name h2o-cloud -md5skip
+```
+
+The following code will not work since specifying flatfile on h2o nodes and not in the H2O configuration ends up with spark not being 
+able to connect to the rest of the cloud.
+```
+java -jar h2o.jar -name h2o-cloud -md5skip -flatfile path_to_flat_file
+```
+
+
+Since multicast communication is often limited in the network, this code connects to H2O cluster "h2o-cluster" using 
+direct communication with arbitrary h2o node. Method `setH2OCluster` automatically sets external backend mode. It is internally 
+using [H2O's flatfile configuration property](https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/howto/H2O-DevCmdLine.md#flatfile).
+
+This is also why all H2O nodes has to be started with `-flatfile` option and at least one node has to have ip and port of h2o
+client in it's flatfile. We can also specify the IP address of h2o client using method `setClientIP` and then use the provided
+ip address in the flatfile mentioned earlier.
+
+```
+val conf = new H2OConf(sc).setH2OCluster(host, port).setClientIp(ip).setCloudName("h2o-cloud")
+val h2oContext = H2OContext.getOrCreate(sc, conf)
+```
 
 
 <a name="SparkShell"></a>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,10 +57,13 @@ dependencies {
 // Setup test environment for Spark
 test {
     // Test environment
+    systemProperty "spark.ext.h2o.backend.cluster.mode", detectClusterMode()
     systemProperty "spark.testing", "true"
     systemProperty "spark.ext.h2o.node.log.dir", new File(project.getBuildDir(), "h2ologs-test/nodes")
     systemProperty "spark.ext.h2o.client.log.dir", new File(project.getBuildDir(), "h2ologs-test/client")
 
+    // Pass list of jars required for testing
+    systemProperty "sparkling.assembly.jar", "${project(":sparkling-water-assembly").configurations.shadow.artifacts.file.join(',')}"
     // Run with assertions ON
     enableAssertions = true
 
@@ -90,6 +93,7 @@ processResources.dependsOn createSparkVersionFile
 
 integTest {
     // Pass references to libraries to test launcher
+    systemProperty "spark.ext.h2o.backend.cluster.mode", detectClusterMode()
     systemProperty "spark.testing",   "true"
     systemProperty "spark.test.home", "${sparkHome}"
     systemProperty "sparkling.test.hdp.version", "${hdpVersion}"

--- a/core/src/integTest/scala/water/sparkling/itest/local/H2OContextLocalClusterSuite.scala
+++ b/core/src/integTest/scala/water/sparkling/itest/local/H2OContextLocalClusterSuite.scala
@@ -37,9 +37,20 @@ class H2OContextLocalClusterSuite extends FunSuite
     // For distributed testing we need to pass around jar containing all implementation classes plus test classes
     val conf = defaultSparkConf.setJars(swassembly :: Nil)
     sc = new SparkContext("local-cluster[3,2,2048]", "test-local-cluster", conf)
-    hc = H2OContext.getOrCreate(sc, new H2OConf(sc))
+
+    // start h2o cloud in case of external cluster mode
+    if(testsInExternalMode(sc.getConf)){
+      startCloud(3, sc.getConf)
+    }
+
+    hc = H2OContext.getOrCreate(sc, new H2OConf(sc).setNumOfExternalH2ONodes(3))
 
     assert(water.H2O.CLOUD.members().length == 3, "H2O cloud should have 3 members")
+
+    // stop h2o cloud in case of external cluster mode
+    if(testsInExternalMode(sc.getConf)){
+      stopCloud()
+    }
     // Does not reset
     resetContext()
   }
@@ -48,8 +59,18 @@ class H2OContextLocalClusterSuite extends FunSuite
   ignore("2nd run to verify that test does not overlap") {
     val conf = defaultSparkConf.setJars(swassembly :: Nil)
     sc = new SparkContext("local-cluster[3,2,721]", "test-local-cluster", conf)
+
+    // start h2o cloud in case of external cluster mode
+    if(testsInExternalMode(sc.getConf)){
+      startCloud(2, sc.getConf)
+    }
+
     hc = H2OContext.getOrCreate(sc)
 
+    // stop h2o cloud in case of external cluster mode
+    if(testsInExternalMode(sc.getConf)){
+      stopCloud()
+    }
     resetContext()
   }
 }

--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -17,15 +17,18 @@
 
 package org.apache.spark.h2o
 
+import java.util.concurrent.atomic.AtomicReference
+
 import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.h2o.backends.external.ExternalBackendConf
 import org.apache.spark.h2o.backends.internal.InternalBackendConf
-import org.apache.spark.{Logging, SparkContext}
+import org.apache.spark.{Logging, SparkContext, SparkEnv}
 
 /**
   * Configuration holder which is representing
   * properties passed from user to Sparkling Water.
   */
-class H2OConf(@transient val sc: SparkContext) extends Logging with InternalBackendConf {
+class H2OConf(@transient val sc: SparkContext) extends Logging with ExternalBackendConf with InternalBackendConf {
 
   /** Support for creating H2OConf in Java environments */
   def this(jsc: JavaSparkContext) = this(jsc.sc)
@@ -84,9 +87,12 @@ class H2OConf(@transient val sc: SparkContext) extends Logging with InternalBack
   /** Get a parameter as a boolean, falling back to a default if not set */
   def getBoolean(key: String, defaultValue: Boolean): Boolean = sparkConf.getBoolean(key, defaultValue)
 
-  override def toString: String = internalConfString
-}
 
-object H2OConf {
-  def apply(sc: SparkContext) = new H2OConf(sc)
+  override def toString: String = {
+    if(runsInExternalClusterMode){
+      externalConfString
+    }else{
+      internalConfString
+    }
+  }
 }

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContextImplicits.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContextImplicits.scala
@@ -56,6 +56,13 @@ abstract class H2OContextImplicits {
   /** Implicit conversion from Spark DataFrame to H2OFrame key */
   implicit def toH2OFrameKeyFromDataFrame(rdd : DataFrame) : Key[Frame] = _h2oContext.toH2OFrameKey(rdd, None)
 
+  /** Implicit conversion from Spark Dataset to H2OFrame */
+  implicit def asH2OFrameFromDataset[T<: Product : TypeTag](ds: Dataset[T]) : H2OFrame = _h2oContext.asH2OFrame(ds, None)
+
+  /** Implicit conversion from Spark Dataset to H2OFrame key */
+  implicit def toH2OFrameKeyFromDataset[T<: Product : TypeTag](ds: Dataset[T]) : Key[Frame] = _h2oContext.toH2OFrameKey(ds, None)
+
+
   /** Implicit conversion from Frame(H2O) to H2OFrame */
   implicit def asH2OFrameFromFrame(fr: Frame) : H2OFrame = new H2OFrame(fr)
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedH2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedH2OConf.scala
@@ -68,10 +68,7 @@ trait SharedH2OConf {
     self
   }
 
-  def setInternalClusterMode(): H2OConf = {
-    setBackendClusterMode("internal")
-    self
-  }
+  def setInternalClusterMode(): H2OConf = setBackendClusterMode("internal")
 
   def setReplDisabled(): H2OConf = {
     sparkConf.set(PROP_REPL_ENABLED._1, false.toString)
@@ -82,10 +79,7 @@ trait SharedH2OConf {
     self
   }
 
-  def setExternalClusterMode(): H2OConf = {
-    setBackendClusterMode("external")
-    self
-  }
+  def setExternalClusterMode(): H2OConf = setBackendClusterMode("external")
 
   def setClientIp(ip: String): H2OConf = {
     sparkConf.set(PROP_CLIENT_IP._1, ip)
@@ -94,6 +88,11 @@ trait SharedH2OConf {
 
   def setH2OClientLogLevel(level: String): H2OConf = {
     sparkConf.set(PROP_CLIENT_LOG_LEVEL._1, level)
+    self
+  }
+
+  def setClientNetworkMask(mask: String): H2OConf = {
+    sparkConf.set(PROP_CLIENT_NETWORK_MASK._1, mask)
     self
   }
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ConnectionToH2OHelper.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ConnectionToH2OHelper.scala
@@ -1,0 +1,114 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.backends.external
+
+import java.net.InetSocketAddress
+import java.nio.{ByteOrder, ByteBuffer}
+import java.nio.channels.SocketChannel
+
+import org.apache.spark.h2o.utils.NodeDesc
+import water.AutoBufferUtils
+
+import scala.collection.mutable
+
+/**
+  * Helper containing connections to H2O
+  */
+object ConnectionToH2OHelper {
+
+  // since one executor can work on multiple tasks at the same time it can also happen that it needs
+  // to communicate with the same node using 2 or more connections at the given time. For this we use
+  // this helper which internally stores connections to one node and remember which ones are being used and which
+  // ones are free. Programmer then can get connection using getAvailableConnection. This method creates a new connection
+  // if all connections are currently used or reuse the existing free one. Programmer needs to put the connection back to the
+  // pool of available connections using the method putAvailableConnection
+  private class PerOneNodeConnection(val nodeDesc: NodeDesc) {
+
+    private def getConnection(nodeDesc: NodeDesc): SocketChannel = {
+      val sock = SocketChannel.open()
+      sock.socket().setSendBufferSize(AutoBufferUtils.BBP_BIG_SIZE)
+      val isa = new InetSocketAddress(nodeDesc.hostname, nodeDesc.port + 1) // +1 to connect to internal comm port
+      val res = sock.connect(isa) // Can toss IOEx, esp if other node is still booting up
+      assert(res)
+      sock.configureBlocking(true)
+      assert(!sock.isConnectionPending && sock.isBlocking && sock.isConnected && sock.isOpen)
+      sock.socket().setTcpNoDelay(true)
+      val bb = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder())
+      bb.put(3.asInstanceOf[Byte]).putChar(sock.socket().getLocalPort.asInstanceOf[Char]).put(0xef.asInstanceOf[Byte]).flip()
+      while (bb.hasRemaining) {
+        // Write out magic startup sequence
+        sock.write(bb)
+      }
+      sock
+    }
+
+    // ordered list of connections where the available connections are at the start of the list and the used at the end.
+    private val availableConnections = new mutable.SynchronizedQueue[(SocketChannel, Long)]()
+    def getAvailableConnection(): SocketChannel = {
+      if(availableConnections.isEmpty){
+        getConnection(nodeDesc)
+      }else{
+        val socketChannel = availableConnections.dequeue()._1
+        if(!socketChannel.isOpen || !socketChannel.isConnected){
+          // connection closed, open a new one to replace it
+          getConnection(nodeDesc)
+        }else{
+          socketChannel
+        }
+      }
+    }
+
+    def putAvailableConnection(sock: SocketChannel): Unit = {
+      availableConnections += ((sock, System.currentTimeMillis()))
+
+      // after each put start this cleaning thread
+      val waitTime = 1000 // 1 second
+      new Thread(){
+        override def run(): Unit = {
+          Thread.sleep(waitTime)
+          availableConnections.filter{
+          case (socket, lastTimeUsed) =>  if (System.currentTimeMillis() - lastTimeUsed > waitTime) {
+            socket.close()
+            false
+          }else{
+            true
+          }
+        }
+        }
+      }.start()
+    }
+  }
+
+  // this map is created in each executor so we don't have to specify executor Id
+  private[this] val connectionMap = mutable.HashMap.empty[NodeDesc, PerOneNodeConnection]
+
+  def getOrCreateConnection(nodeDesc: NodeDesc): SocketChannel = connectionMap.synchronized{
+    if(!connectionMap.contains(nodeDesc)){
+      connectionMap += nodeDesc -> new PerOneNodeConnection(nodeDesc)
+    }
+    connectionMap(nodeDesc).getAvailableConnection()
+  }
+
+  def putAvailableConnection(nodeDesc: NodeDesc, sock: SocketChannel): Unit = connectionMap.synchronized{
+    if(!connectionMap.contains(nodeDesc)){
+      connectionMap += nodeDesc -> new PerOneNodeConnection(nodeDesc)
+    }
+    connectionMap(nodeDesc).putAvailableConnection(sock)
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -1,0 +1,87 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.backends.external
+
+import org.apache.spark.h2o.H2OConf
+import org.apache.spark.h2o.backends.SharedH2OConf
+
+/**
+  * External backend configuration
+  */
+trait ExternalBackendConf extends SharedH2OConf {
+  self: H2OConf =>
+
+  import ExternalBackendConf._
+  def h2oCluster = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
+
+  def h2oClusterHost = {
+    val value = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
+    if (value.isDefined){
+      Option(value.get.split(":")(0))
+    }else{
+      None
+    }
+  }
+
+  def h2oClusterPort = {
+    val value = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
+    if (value.isDefined){
+      Option(value.get.split(":")(1))
+    }else{
+      None
+    }
+  }
+
+  def numOfExternalH2ONodes = sparkConf.getOption(PROP_EXTERNAL_H2O_NODES._1)
+
+  /**
+    * Sets node and port representing H2O Cluster to which should H2O connect when started in external mode.
+    * This method automatically sets external cluster mode
+    *
+    * @param host host representing the cluster
+    * @param port port representing the cluster
+    * @return H2O Configuration
+    */
+  def setH2OCluster(host: String, port: Int): H2OConf = {
+    setExternalClusterMode()
+    sparkConf.set(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, host + ":" + port)
+    self
+  }
+
+  def setNumOfExternalH2ONodes(numOfExternalH2ONodes: Int): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_H2O_NODES._1, numOfExternalH2ONodes.toString)
+    self
+  }
+
+  def externalConfString: String =
+    s"""Sparkling Water configuration:
+        |  backend cluster mode : ${backendClusterMode}
+        |  cloudName            : ${cloudName.getOrElse("Not set yet")}
+        |  cloud representative : ${h2oCluster.getOrElse("Not set, using cloud name only")}
+        |  clientBasePort       : ${clientBasePort}
+        |  h2oClientLog         : ${h2oClientLogLevel}
+        |  nthreads             : ${nthreads}""".stripMargin
+}
+
+object ExternalBackendConf {
+  /** ip:port of arbitrary h2o node to identify external h2o cluster */
+  val PROP_EXTERNAL_CLUSTER_REPRESENTATIVE = ("spark.ext.h2o.cloud.representative",null.asInstanceOf[String])
+
+  /** Number of nodes to wait for when connecting to external H2O cluster */
+  val PROP_EXTERNAL_H2O_NODES = ("spark.ext.h2o.external.cluster.num.h2o.nodes", null.asInstanceOf[String])
+}

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -27,27 +27,15 @@ trait ExternalBackendConf extends SharedH2OConf {
   self: H2OConf =>
 
   import ExternalBackendConf._
+
   def h2oCluster = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
-
-  def h2oClusterHost = {
-    val value = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
-    if (value.isDefined){
-      Option(value.get.split(":")(0))
-    }else{
-      None
-    }
-  }
-
-  def h2oClusterPort = {
-    val value = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
-    if (value.isDefined){
-      Option(value.get.split(":")(1))
-    }else{
-      None
-    }
-  }
-
+  def YARNQueue = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_YARN_QUEUE._1)
+  def driverPath = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_H2O_DRIVER._1)
   def numOfExternalH2ONodes = sparkConf.getOption(PROP_EXTERNAL_H2O_NODES._1)
+  def hadoopLocation = sparkConf.get(PROP_EXTERNAL_HADOOP_LOCATION._1, PROP_EXTERNAL_HADOOP_LOCATION._2)
+  def HDFSOutputDir = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_HDFS_DIR._1)
+  def memoryForHadoopInstance = sparkConf.get(PROP_EXTERNAL_H2O_MEMORY._1, PROP_EXTERNAL_H2O_MEMORY._2)
+
 
   /**
     * Sets node and port representing H2O Cluster to which should H2O connect when started in external mode.
@@ -63,10 +51,56 @@ trait ExternalBackendConf extends SharedH2OConf {
     self
   }
 
+  def h2oClusterHost = {
+    val value = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
+    if (value.isDefined) {
+      Option(value.get.split(":")(0))
+    } else {
+      None
+    }
+  }
+
+  def h2oClusterPort = {
+    val value = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
+    if (value.isDefined) {
+      Option(value.get.split(":")(1))
+    } else {
+      None
+    }
+  }
+
+
+  def setYARNQueue(queueName: String) = {
+    sparkConf.set(PROP_EXTERNAL_CLUSTER_YARN_QUEUE._1, queueName)
+    self
+  }
+
+  def setDriverPath(path: String): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_CLUSTER_H2O_DRIVER._1, path)
+    self
+  }
+
   def setNumOfExternalH2ONodes(numOfExternalH2ONodes: Int): H2OConf = {
     sparkConf.set(PROP_EXTERNAL_H2O_NODES._1, numOfExternalH2ONodes.toString)
     self
   }
+
+  def setHadoopLocation(hadoopLocation: String): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_HADOOP_LOCATION._1, hadoopLocation)
+    self
+  }
+
+  def setHDFSOutputDir(dir: String): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_CLUSTER_HDFS_DIR._1, dir)
+    self
+  }
+
+
+  def setMemoryForHadoopInstance(mem: String): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_H2O_MEMORY._1, mem)
+    self
+  }
+
 
   def externalConfString: String =
     s"""Sparkling Water configuration:
@@ -79,9 +113,26 @@ trait ExternalBackendConf extends SharedH2OConf {
 }
 
 object ExternalBackendConf {
+
+  val PROP_EXTERNAL_H2O_MEMORY = ("spark.ext.h2o.hadoop.memory", "6g")
+  
+  val PROP_EXTERNAL_HADOOP_LOCATION = ("spark.ext.h2o.hadoop.location", "hadoop")
+
+  val PROP_EXTERNAL_CLUSTER_HDFS_DIR = ("spark.ext.h2o.external.hdfs.dir", null.asInstanceOf[String])
+
+  /**
+    * If this option is set then h2o external cluster will be automatically started using the provided
+    * h2o driver on yarn
+    */
+  val PROP_EXTERNAL_CLUSTER_H2O_DRIVER = ("spark.ext.h2o.external.h2o.driver", null.asInstanceOf[String])
+
+  /** Yarn queue on which external cluster should be started */
+  val PROP_EXTERNAL_CLUSTER_YARN_QUEUE = ("spark.ext.h2o.external.yarn.queue", null.asInstanceOf[String])
+
   /** ip:port of arbitrary h2o node to identify external h2o cluster */
-  val PROP_EXTERNAL_CLUSTER_REPRESENTATIVE = ("spark.ext.h2o.cloud.representative",null.asInstanceOf[String])
+  val PROP_EXTERNAL_CLUSTER_REPRESENTATIVE = ("spark.ext.h2o.cloud.representative", null.asInstanceOf[String])
 
   /** Number of nodes to wait for when connecting to external H2O cluster */
   val PROP_EXTERNAL_H2O_NODES = ("spark.ext.h2o.external.cluster.num.h2o.nodes", null.asInstanceOf[String])
+
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendUtils.scala
@@ -1,0 +1,49 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.backends.external
+
+import org.apache.spark.h2o.H2OConf
+import org.apache.spark.h2o.backends.SharedBackendUtils
+import org.apache.spark.h2o.utils.NodeDesc
+import water.H2O
+
+/**
+  * Various helper methods used in the external backend
+  */
+private[external] trait ExternalBackendUtils extends SharedBackendUtils{
+
+  /**
+    * Get arguments for H2O client
+    *
+    * @return array of H2O client arguments.
+    */
+  override def getH2OClientArgs(conf: H2OConf): Array[String] = {
+    Array("-md5skip")++getH2OClientConnectionArgs(conf)++super.getH2OClientArgs(conf)
+  }
+
+  def cloudMembers = H2O.CLOUD.members().map(NodeDesc(_))
+
+  private[this] def getH2OClientConnectionArgs(conf: H2OConf): Array[String] = {
+    if (conf.h2oCluster.isDefined) {
+      Array("-flatfile", saveAsFile(conf.h2oCluster.get).getAbsolutePath)
+    }else{
+      Array()
+    }
+  }
+}
+private[external] object ExternalBackendUtils extends ExternalBackendUtils

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -24,12 +24,40 @@ import org.apache.spark.h2o.utils.NodeDesc
 import water.api.RestAPIManager
 import water.{H2O, H2OStarter}
 
+import scala.util.Random
 import scala.util.control.NoStackTrace
 
 
-class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with ExternalBackendUtils with Logging{
+class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with ExternalBackendUtils with Logging {
+
+  def launchH2OOnYarn(conf: H2OConf): Unit = {
+    val cmdToLaunch = Seq[String](
+      conf.hadoopLocation,
+      "jar",
+      conf.driverPath.get,
+      "-nodes", conf.numOfExternalH2ONodes.get,
+      "-J", "-md5skip",
+      "-mapperXmx", conf.memoryForHadoopInstance,
+      "-output", conf.HDFSOutputDir.get,
+      conf.YARNQueue.map("-Dmapred.job.queue.name=" + _).getOrElse("")
+    )
+
+    logDebug("Command used to start H2O on yarn: " + cmdToLaunch.mkString)
+    import scala.sys.process._
+    val startOnYarnBuffer = new StringBuffer()
+
+    val proc = cmdToLaunch.mkString(" ").!(ProcessLogger(startOnYarnBuffer.append(_)))
+    logDebug(startOnYarnBuffer.toString)
+    assert(proc == 0, s"Process finished in wrong way! response=$proc from \n${cmdToLaunch mkString " "}")
+  }
 
   override def init(): Array[NodeDesc] = {
+
+    if (hc.getConf.driverPath.isDefined) {
+      // start h2o instances on yarn
+      logInfo("Starting H2O cluster on YARN")
+      launchH2OOnYarn(hc.getConf)
+    }
     // Start H2O in client mode and connect to existing H2O Cluster
     logTrace("Starting H2O on client mode and connecting it to existing h2o cluster")
     val h2oClientArgs = getH2OClientArgs(hc.getConf)
@@ -40,24 +68,33 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
     RestAPIManager(hc).registerAll()
     H2O.finalizeRegistration()
 
-    if(hc.getConf.numOfExternalH2ONodes.isDefined){
+    if (hc.getConf.numOfExternalH2ONodes.isDefined) {
       H2O.waitForCloudSize(hc.getConf.numOfExternalH2ONodes.get.toInt, hc.getConf.cloudTimeout)
     }
 
-    if(cloudMembers.length==0){
-      throw new H2OClusterNotRunning(
-        s"""
-          |
+    if (cloudMembers.length == 0) {
+      if (hc.getConf.driverPath.isEmpty) {
+        throw new H2OClusterNotRunning(
+          s"""
+           |
           |H2O Cluster is not running or couldn't be connected to. Provided configuration:
-          |   cloud name            : ${hc.getConf.cloudName.get}
-          |   cloud representative  : ${hc.getConf.h2oCluster.getOrElse("Not set, connecting to cluster in multicast mode")}
-          |
-          | It is possible that in case you provided only cloud name h2o is not able to cloud up because multicast
-          | communication is limited in your network. In that case please consider setting "${ExternalBackendConf.PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1}"
-          | property and starting nodes in h2o cluster with -flatfile option describing the cluster.
-        """.stripMargin)
-    }
+           |   cloud name            : ${hc.getConf.cloudName.get}
 
+           |   cloud representative  : ${hc.getConf.h2oCluster.getOrElse(
+            "Not set, connecting to cluster in multicast mode")}
+
+           |
+          | It is possible that in case you provided only cloud name h2o is not able to cloud up because multicast
+           | communication is limited in your network. In that case please consider setting "${ExternalBackendConf.
+            PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1}
+"
+           | property and starting nodes in h2o cluster with -flatfile option describing the cluster.
+        """.stripMargin)
+        }else{
+        throw new H2OClusterNotRunning("Problem during connection to h2o cluster started on yarn. Please check the logs")
+      }
+    }
+    
     cloudMembers
   }
 
@@ -70,11 +107,25 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
   override def checkAndUpdateConf(conf: H2OConf): H2OConf = {
     super.checkAndUpdateConf(conf)
 
-    if(conf.cloudName.isEmpty){
-      throw new IllegalArgumentException(
-        """Cloud name has to be specified when using external backend cluster mode. It can be set either using H2OConf
-          |instance or via 'spark.ext.h2o.cloud.name' spark configuration property""".stripMargin)
+    if (conf.driverPath.isDefined) {
+      if (conf.cloudName.isEmpty) {
+        conf.setCloudName("sparkling-water-" + System.getProperty("user.name", "cluster") + "_" + Random.nextInt())
+      }
 
+      if (conf.numOfExternalH2ONodes.isEmpty) {
+        throw new IllegalArgumentException("Number of h2o nodes has to be specified in external auto start backend mode.")
+      }
+
+      if (conf.HDFSOutputDir.isEmpty) {
+        conf.setHDFSOutputDir(conf.cloudName.get)
+      }
+
+    } else {
+      if (conf.cloudName.isEmpty) {
+        throw new IllegalArgumentException(
+          """Cloud name has to be specified when using external backend cluster mode in manual start mode. It can be set either using H2OConf
+            |instance or via 'spark.ext.h2o.cloud.name' spark configuration property""".stripMargin)
+      }
     }
     conf
   }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -1,0 +1,83 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.backends.external
+
+import org.apache.spark.Logging
+import org.apache.spark.h2o.{H2OConf, H2OContext}
+import org.apache.spark.h2o.backends.SparklingBackend
+import org.apache.spark.h2o.utils.NodeDesc
+import water.api.RestAPIManager
+import water.{H2O, H2OStarter}
+
+import scala.util.control.NoStackTrace
+
+
+class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with ExternalBackendUtils with Logging{
+
+  override def init(): Array[NodeDesc] = {
+    // Start H2O in client mode and connect to existing H2O Cluster
+    logTrace("Starting H2O on client mode and connecting it to existing h2o cluster")
+    val h2oClientArgs = getH2OClientArgs(hc.getConf)
+    logDebug(s"Arguments used for launching h2o client node: ${h2oClientArgs.mkString(" ")}")
+    H2OStarter.start(h2oClientArgs, false)
+
+    // Register web API for client
+    RestAPIManager(hc).registerAll()
+    H2O.finalizeRegistration()
+
+    if(hc.getConf.numOfExternalH2ONodes.isDefined){
+      H2O.waitForCloudSize(hc.getConf.numOfExternalH2ONodes.get.toInt, hc.getConf.cloudTimeout)
+    }
+
+    if(cloudMembers.length==0){
+      throw new H2OClusterNotRunning(
+        s"""
+          |
+          |H2O Cluster is not running or couldn't be connected to. Provided configuration:
+          |   cloud name            : ${hc.getConf.cloudName.get}
+          |   cloud representative  : ${hc.getConf.h2oCluster.getOrElse("Not set, connecting to cluster in multicast mode")}
+          |
+          | It is possible that in case you provided only cloud name h2o is not able to cloud up because multicast
+          | communication is limited in your network. In that case please consider setting "${ExternalBackendConf.PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1}"
+          | property and starting nodes in h2o cluster with -flatfile option describing the cluster.
+        """.stripMargin)
+    }
+
+    cloudMembers
+  }
+
+  override def stop(stopSparkContext: Boolean): Unit = {
+    if (stopSparkContext) hc.sparkContext.stop()
+    H2O.orderlyShutdown(1000)
+    H2O.exit(0)
+  }
+
+  override def checkAndUpdateConf(conf: H2OConf): H2OConf = {
+    super.checkAndUpdateConf(conf)
+
+    if(conf.cloudName.isEmpty){
+      throw new IllegalArgumentException(
+        """Cloud name has to be specified when using external backend cluster mode. It can be set either using H2OConf
+          |instance or via 'spark.ext.h2o.cloud.name' spark configuration property""".stripMargin)
+
+    }
+    conf
+  }
+}
+
+class H2OClusterNotRunning(msg: String) extends Exception(msg) with NoStackTrace

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalReadConverterContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalReadConverterContext.scala
@@ -1,0 +1,84 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.backends.external
+
+import org.apache.spark.h2o.converters.ReadConverterContext
+import org.apache.spark.h2o.utils.NodeDesc
+import water.AutoBufferUtils._
+import water.{AutoBuffer, AutoBufferUtils, ExternalFrameHandler}
+/**
+  *
+  * @param keyName key name of frame to query data from
+  * @param chunkIdx chunk index
+  * @param nodeDesc the h2o node which has data for chunk with the chunkIdx
+  */
+class ExternalReadConverterContext(override val keyName: String, override val chunkIdx: Int,
+                                    val nodeDesc: NodeDesc, expectedTypes: Array[Byte], selectedColumnIndices: Array[Int])
+  extends ExternalBackendUtils with ReadConverterContext {
+
+  private val socketChannel = ConnectionToH2OHelper.getOrCreateConnection(nodeDesc)
+  private val inputAb = createInputAutoBuffer()
+  private val numOfRows: Int =  AutoBufferUtils.getInt(inputAb)
+  private def createInputAutoBuffer(): AutoBuffer = {
+    val ab = new AutoBuffer()
+    ab.put1(ExternalFrameHandler.INIT_BYTE)
+    ab.putInt(ExternalFrameHandler.DOWNLOAD_FRAME)
+    ab.putStr(keyName)
+    ab.putA1(expectedTypes)
+    ab.putInt(chunkIdx)
+    ab.putA4(selectedColumnIndices)
+    writeToChannel(ab, socketChannel)
+    val inAb = AutoBufferUtils.create(socketChannel)
+    inAb
+  }
+
+  override def numRows: Int = numOfRows
+
+  private def get[T](columnNum: Int, read: AutoBuffer => T): Option[T] =
+    if (isNA(columnNum)) {
+      None
+    } else {
+      Option(read(inputAb))
+    }
+
+  /**
+    * method isNA has to be called before any other method which gets data:
+    * getDouble, getLong, getString, getShort, getByte, getFloat, getUTF8String, getBoolean, getTimestamp
+    *
+    * It should be always called like : isNA(..);get..(..); isNA(..);get..(..);....
+    */
+  override def isNA(columnNum: Int): Boolean = AutoBufferUtils.getInt(inputAb) == ExternalFrameHandler.IS_NA
+
+  override def getDouble(columnNum: Int): Option[Double] = get(columnNum, _.get8d())
+
+  override def getLong(columnNum: Int): Option[Long] = get(columnNum, _.get8())
+
+  override def getString(columnNum: Int): Option[String] = get(columnNum, _.getStr())
+
+  override def hasNext: Boolean = {
+    val isNext = super.hasNext
+    if(!isNext){
+      // confirm that all has been done before proceeding with the computation
+      assert(AutoBufferUtils.getInt(inputAb)==ExternalFrameHandler.CONFIRM_READING_DONE)
+
+      // put back socket channel to pool of opened connections after we get the last element
+      ConnectionToH2OHelper.putAvailableConnection(nodeDesc, socketChannel)
+    }
+    isNext
+  }
+}

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalWriteConverterContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalWriteConverterContext.scala
@@ -1,0 +1,133 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.backends.external
+
+import org.apache.spark.h2o._
+import org.apache.spark.h2o.converters.WriteConverterContext
+import org.apache.spark.h2o.utils.NodeDesc
+import water.AutoBufferUtils._
+import water.{AutoBuffer, AutoBufferUtils, ExternalFrameHandler}
+
+class ExternalWriteConverterContext(nodeDesc: NodeDesc) extends ExternalBackendUtils with WriteConverterContext {
+
+  val socketChannel = ConnectionToH2OHelper.getOrCreateConnection(nodeDesc)
+  var rowCounter: Long = 0
+  private val ab = new AutoBuffer().flipForReading() // using default constructor AutoBuffer is created with
+  // private property _read set to false, in order to satisfy call clearForWriting it has to be set to true
+  // which does the call of flipForReading method
+
+  override def numOfRows(): Long = rowCounter
+  /**
+    * This method closes the communication after the chunks have been closed
+    */
+  override def closeChunks(): Unit = {
+    AutoBufferUtils.clearForWriting(ab)
+    ab.putInt(ExternalFrameHandler.CLOSE_NEW_CHUNK)
+    writeToChannel(ab, socketChannel)
+    val confirmAb = AutoBufferUtils.create(socketChannel)
+    // this needs to be here because confirmAb forces this code to wait
+    // for all the work to be done on the recipient side. The assert is just additional, not so important check
+    assert(AutoBufferUtils.getInt(confirmAb)==ExternalFrameHandler.CONFIRM_WRITING_DONE)
+    ConnectionToH2OHelper.putAvailableConnection(nodeDesc, socketChannel)
+  }
+
+  /**
+    * Initialize the communication before the chunks are created
+    */
+  override def createChunks(keystr: String, vecTypes: Array[Byte], chunkId: Int): Unit = {
+    AutoBufferUtils.clearForWriting(ab)
+    ab.put1(ExternalFrameHandler.INIT_BYTE)
+    ab.putInt(ExternalFrameHandler.CREATE_FRAME)
+    ab.putInt(ExternalFrameHandler.CREATE_NEW_CHUNK)
+    ab.putStr(keystr)
+    ab.putA1(vecTypes)
+    ab.putInt(chunkId)
+    writeToChannel(ab, socketChannel)
+  }
+
+
+  override def put(columnNum: Int, n: Number) = {
+    AutoBufferUtils.clearForWriting(ab)
+    ab.putInt(ExternalFrameHandler.ADD_TO_CHUNK)
+    ab.putInt(ExternalFrameHandler.TYPE_NUM)
+    ab.putInt(columnNum)
+    ab.put8d(n.doubleValue())
+    writeToChannel(ab, socketChannel)
+  }
+
+
+  override def put(columnNum: Int, n: Boolean) = {
+    AutoBufferUtils.clearForWriting(ab)
+    ab.putInt(ExternalFrameHandler.ADD_TO_CHUNK)
+    ab.putInt(ExternalFrameHandler.TYPE_NUM)
+    ab.putInt(columnNum)
+    ab.put8d(if (n) 1 else 0)
+    writeToChannel(ab, socketChannel)
+  }
+
+  override def put(columnNum: Int, n: java.sql.Timestamp) = {
+    AutoBufferUtils.clearForWriting(ab)
+    ab.putInt(ExternalFrameHandler.ADD_TO_CHUNK)
+    ab.putInt(ExternalFrameHandler.TYPE_NUM)
+    ab.putInt(columnNum)
+    ab.put8d(n.getTime())
+    writeToChannel(ab, socketChannel)
+  }
+
+  override def put(columnNum: Int, n: String) = {
+    AutoBufferUtils.clearForWriting(ab)
+    ab.putInt(ExternalFrameHandler.ADD_TO_CHUNK)
+    ab.putInt(ExternalFrameHandler.TYPE_STR)
+    ab.putInt(columnNum)
+    ab.putStr(n)
+    writeToChannel(ab, socketChannel)
+  }
+
+  override def putNA(columnNum: Int) = {
+    AutoBufferUtils.clearForWriting(ab)
+    ab.putInt(ExternalFrameHandler.ADD_TO_CHUNK)
+    ab.putInt(ExternalFrameHandler.TYPE_NA)
+    ab.putInt(columnNum)
+    writeToChannel(ab, socketChannel)
+  }
+
+  override def increaseRowCounter(): Unit = rowCounter = rowCounter + 1
+}
+
+
+object ExternalWriteConverterContext extends ExternalBackendUtils{
+
+  def scheduleUpload[T](rdd: RDD[T]): (RDD[T], Map[Int, NodeDesc]) = {
+    val nodes = cloudMembers
+    val preparedRDD =  if (rdd.getNumPartitions < nodes.length) {
+      // repartition to get same amount of partitions as is number of h2o nodes
+      rdd.repartition(nodes.length)
+    } else{
+      // in case number of partitions is equal or higher than number of H2O nodes return original rdd
+      // We are not repartitioning when number of partitions is bigger than number of h2o nodes since the data
+      // in one partition could then become too big for one h2o node, we rather create multiple chunks at one h2o node
+      rdd
+    }
+
+    // numPartitions is always >= than nodes.length at this step
+    val partitionIdxs = 0 until preparedRDD.getNumPartitions
+    val uploadPlan = partitionIdxs.zip(Stream.continually(nodes).flatten).toMap
+
+    (preparedRDD, uploadPlan)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendConf.scala
@@ -44,7 +44,7 @@ trait InternalBackendConf extends SharedH2OConf {
     s"""Sparkling Water configuration:
         |  backend cluster mode : ${backendClusterMode}
         |  workers              : ${numH2OWorkers}
-        |  cloudName            : ${cloudName.get}
+        |  cloudName            : ${cloudName.getOrElse("Not set yet. It will be set automatically when starting H2OContext when not set")}
         |  flatfile             : ${useFlatFile}
         |  clientBasePort       : ${clientBasePort}
         |  nodeBasePort         : ${nodeBasePort}

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -21,7 +21,7 @@ import org.apache.spark.Logging
 import org.apache.spark.h2o.backends.SparklingBackend
 import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OConf, H2OContext}
-import org.apache.spark.listeners.{ExecutorAddNotSupportedListener}
+import org.apache.spark.listeners.ExecutorAddNotSupportedListener
 import water.api.RestAPIManager
 import water.{H2O, H2OStarter}
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/DatasetConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/DatasetConverter.scala
@@ -1,0 +1,64 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.converters
+
+import org.apache.spark.Logging
+import org.apache.spark.h2o._
+
+import scala.language.{implicitConversions, postfixOps}
+import scala.reflect.runtime.universe._
+
+
+trait DatasetConverter extends Logging with ConverterUtils{
+
+  /** Transform Spark's Dataset into H2O Frame */
+  def toH2OFrame[T <: Product](hc: H2OContext, ds: Dataset[T], frameKeyName: Option[String])(implicit ttag:TypeTag[T]) = {
+    val tpe = ttag.tpe
+    val constructorSymbol = tpe.declaration(nme.CONSTRUCTOR)
+    val defaultConstructor =
+      if (constructorSymbol.isMethod) constructorSymbol.asMethod
+      else {
+        val ctors = constructorSymbol.asTerm.alternatives
+        ctors.map { _.asMethod }.find { _.isPrimaryConstructor }.get
+      }
+
+    val params: List[(String, Type)] = defaultConstructor.paramss.flatten map {
+      sym => sym.name.toString -> tpe.member(sym.name).asMethod.returnType
+    }
+
+    val rdd: RDD[Product] = try {
+      ds.rdd.asInstanceOf[RDD[Product]]
+    } catch {
+      case oops: Exception =>
+        oops.printStackTrace()
+        throw oops
+    }
+    val res = try {
+
+      val prototype = H2OFrameFromRDDProductBuilder(hc, rdd, frameKeyName)
+      prototype.withFields(params)
+    } catch {
+      case oops: Exception =>
+        oops.printStackTrace()
+        throw oops
+    }
+    res
+  }
+}
+
+object DatasetConverter extends DatasetConverter

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2OFrameFromRDDProductBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2OFrameFromRDDProductBuilder.scala
@@ -1,0 +1,140 @@
+package org.apache.spark.h2o.converters
+
+import org.apache.spark.TaskContext
+import org.apache.spark.h2o.utils.NodeDesc
+import org.apache.spark.h2o.{H2OContext, _}
+import water.Key
+
+import scala.collection.immutable
+import scala.reflect.runtime.universe._
+
+case class MetaInfo(names:Array[String], vecTypes: Array[Byte])  {
+  require(names.length > 0, "Empty meta info does not make sense")
+  require(names.length == vecTypes.length, s"Different lengths: ${names.length} names, ${vecTypes.length} types")
+}
+
+case class H2OFrameFromRDDProductBuilder(hc: H2OContext, rdd: RDD[Product], frameKeyName: Option[String]) extends ConverterUtils {
+
+
+  private[this] val defaultFieldNames = (i: Int) => "f" + i
+
+
+  def withDefaultFieldNames() = {
+    withFieldNames(defaultFieldNames)
+  }
+
+  def withFieldNames(fieldNames: Int => String): H2OFrame = {
+    if(rdd.isEmpty()){
+      // transform empty Seq in order to create empty H2OFrame
+      hc.asH2OFrame(hc.sparkContext.parallelize(Seq.empty[Int]), frameKeyName)
+    }else {
+      val meta = metaInfo(fieldNames)
+      withMeta(meta)
+    }
+  }
+
+  def withFields(fields: List[(String, Type)]): H2OFrame = {
+    if(rdd.isEmpty()){
+      // transform empty Seq in order to create empty H2OFrame
+      hc.asH2OFrame(hc.sparkContext.parallelize(Seq.empty[Int]), frameKeyName)
+    }else{
+      val meta = metaInfo(fields)
+      withMeta(meta)
+    }
+  }
+
+  private[this] def keyName(rdd: RDD[_], frameKeyName: Option[String]) = frameKeyName.getOrElse("frame_rdd_" + rdd.id + Key.rand())
+
+  private[this] def withMeta(meta: MetaInfo): H2OFrame = {
+    val kn: String = keyName(rdd, frameKeyName)
+    convert[Product](hc, rdd, kn, meta.names, meta.vecTypes, H2OFrameFromRDDProductBuilder.perTypedDataPartition())
+  }
+
+  import org.apache.spark.h2o.utils.H2OTypeUtils._
+
+  def metaInfo(fieldNames: Int => String): MetaInfo = {
+    //TODO: what if there is no first element
+    val first = rdd.first()
+    val fnames: Array[String] = (0 until first.productArity map fieldNames).toArray[String]
+
+    val ftypes = first.productIterator map H2OFrameFromRDDProductBuilder.inferFieldType
+
+    // Collect H2O vector types for all input types
+    val vecTypes:Array[Byte] = ftypes map dataTypeToVecType toArray
+
+    MetaInfo(fnames, vecTypes)
+  }
+
+  def metaInfo(tuples: List[(String, Type)]): MetaInfo = {
+    val names = tuples map (_._1) toArray
+    val vecTypes = tuples map (nt => dataTypeToVecType(nt._2)) toArray
+
+    MetaInfo(names, vecTypes)
+  }
+
+}
+
+object H2OFrameFromRDDProductBuilder{
+
+  /**
+    * Infers the type from Any, used for determining the types in Product RDD
+    *
+    * @param value the value the type of which we are trying to check, via reflection
+    * @return
+    */
+  private[converters] def inferFieldType(value : Any): Class[_] ={
+    value match {
+      case n: Byte  => classOf[java.lang.Byte]
+      case n: Short => classOf[java.lang.Short]
+      case n: Int => classOf[java.lang.Integer]
+      case n: Long => classOf[java.lang.Long]
+      case n: Float => classOf[java.lang.Float]
+      case n: Double => classOf[java.lang.Double]
+      case n: Boolean => classOf[java.lang.Boolean]
+      case n: String => classOf[java.lang.String]
+      case n: java.sql.Timestamp => classOf[java.sql.Timestamp]
+      case q => throw new IllegalArgumentException(s"Do not understand type $q")
+    }
+  }
+
+
+  /**
+    *
+    * @param keyName key of the frame
+    * @param vecTypes h2o vec types
+    * @param uploadPlan plan which assigns each partition h2o node where the data from that partition will be uploaded
+    * @param context spark task context
+    * @param it iterator over data in the partition
+    * @tparam T type of data inside the RDD
+    * @return pair (partition ID, number of rows in this partition)
+    */
+  private[converters] def perTypedDataPartition[T<:Product]()
+                                                           (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[immutable.Map[Int, NodeDesc]])
+                                                           (context: TaskContext, it: Iterator[T]): (Int, Long) = {
+    // An array of H2O NewChunks; A place to record all the data in this partition
+    val con = ConverterUtils.getWriteConverterContext(uploadPlan, context.partitionId())
+    con.createChunks(keyName,vecTypes,context.partitionId())
+
+    it.foreach(prod => { // For all rows which are subtype of Product
+      for( i <- 0 until prod.productArity ) { // For all fields...
+      val fld = prod.productElement(i)
+        val x = fld match {
+          case Some(n) => n
+          case _ => fld
+        }
+        x match {
+          case n: Number  => con.put(i, n.doubleValue())
+          case n: Boolean => con.put(i, if (n) 1 else 0)
+          case n: String  => con.put(i, n)
+          case n : java.sql.Timestamp => con.put(i, n)
+          case _ => con.putNA(i)
+        }
+      }
+    })
+    //Compress & write data in partitions to H2O Chunks
+    con.closeChunks()
+
+    // Return Partition number and number of rows in this partition
+    (context.partitionId, con.numOfRows)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/h2o/converters/LabeledPointConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/LabeledPointConverter.scala
@@ -46,7 +46,7 @@ private[converters] object LabeledPointConverter extends Logging with ConverterU
       // Features vectors of different sizes, filling missing with n/a
       logWarning("WARNING: Converting RDD[LabeledPoint] to H2OFrame where features vectors have different size, filling missing with n/a")
     }
-    val fnames = (Seq[String]("label") ++ 0.until(maxNumFeatures).map(num => "feature" + num).toSeq).toArray[String]
+    val fnames = (Seq[String]("label") ++ 0.until(maxNumFeatures).map(num => "feature" + num)).toArray[String]
     val ftypes = 0.until(maxNumFeatures + 1).map(_ => typ(typeOf[Double]))
     val vecTypes = ftypes.indices.map(idx => dataTypeToVecType(ftypes(idx))).toArray
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/ProductRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/ProductRDDConverter.scala
@@ -17,46 +17,29 @@
 
 package org.apache.spark.h2o.converters
 
+import org.apache.spark.Logging
 import org.apache.spark.h2o._
-import org.apache.spark.h2o.utils.H2OTypeUtils._
-import org.apache.spark.h2o.utils.{H2OTypeUtils, NodeDesc, ReflectionUtils}
-import org.apache.spark.{Logging, TaskContext}
+import org.apache.spark.h2o.utils.{H2OTypeUtils, ReflectionUtils}
 import water.Key
 
-import scala.collection.immutable
-import scala.collection.mutable.ListBuffer
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
-private[h2o] object ProductRDDConverter extends Logging with ConverterUtils{
+private[h2o] object ProductRDDConverter extends Logging with ConverterUtils {
 
   /** Transform H2OFrame to Product RDD */
-  def toRDD[A <: Product: TypeTag: ClassTag, T <: Frame](hc: H2OContext, fr: T): H2ORDD[A, T] = {
-    new H2ORDD[A, T](fr)(hc.sparkContext)
+  def toRDD[A <: Product : TypeTag : ClassTag, T <: Frame](hc: H2OContext, fr: T): H2ORDD[A, T] = {
+    new H2ORDD[A, T](fr)(hc)
   }
 
   /** Transform RDD to H2OFrame. This method expects RDD of type Product without TypeTag */
   def toH2OFrame(hc: H2OContext, rdd: RDD[Product], frameKeyName: Option[String]): H2OFrame = {
-
-    val keyName = frameKeyName.getOrElse("frame_rdd_" + rdd.id + Key.rand()) // There are uniq IDs for RDD
-
-    // infer the type
-    val first = rdd.first()
-    val fnames = 0.until(first.productArity).map(idx => "f" + idx).toArray[String]
-    val ftypes = new ListBuffer[Class[_]]()
-    val it = first.productIterator
-    while(it.hasNext){
-      ftypes+=inferFieldType(it.next())
-    }
-    // Collect H2O vector types for all input types
-    val vecTypes = ftypes.toArray[Class[_]].indices.map(idx => dataTypeToVecType(ftypes(idx))).toArray
-
-    convert[Product](hc, rdd, keyName, fnames, vecTypes, perTypedRDDPartition())
+    H2OFrameFromRDDProductBuilder(hc,rdd, frameKeyName).withDefaultFieldNames()
   }
 
   /** Transform typed RDD into H2O Frame */
-  def toH2OFrame[T <: Product : TypeTag](hc: H2OContext, rdd: RDD[T], frameKeyName: Option[String]) : H2OFrame = {
+  def toH2OFrame[T <: Product : TypeTag](hc: H2OContext, rdd: RDD[T], frameKeyName: Option[String]): H2OFrame = {
     import H2OTypeUtils._
     import ReflectionUtils._
 
@@ -64,74 +47,14 @@ private[h2o] object ProductRDDConverter extends Logging with ConverterUtils{
 
     val fnames = names[T]
     val ftypes = types[T](fnames)
+
     // Collect H2O vector types for all input types
     val vecTypes = ftypes.indices.map(idx => dataTypeToVecType(ftypes(idx))).toArray
 
-    convert[T](hc, rdd, keyName, fnames, vecTypes, perTypedRDDPartition())
-  }
+    convert[T](hc, rdd, keyName, fnames, vecTypes, H2OFrameFromRDDProductBuilder.perTypedDataPartition())
 
-  /**
-    *
-    * @param keyName key of the frame
-    * @param vecTypes h2o vec types
-    * @param uploadPlan plan which assigns each partition h2o node where the data from that partition will be uploaded
-    * @param context spark task context
-    * @param it iterator over data in the partition
-    * @tparam T type of data inside the RDD
-    * @return pair (partition ID, number of rows in this partition)
-    */
-  private[this]
-  def perTypedRDDPartition[T<:Product]()
-                                      (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[immutable.Map[Int, NodeDesc]])
-                                      ( context: TaskContext, it: Iterator[T] ): (Int,Long) = {
-    val con = ConverterUtils.getWriteConverterContext(uploadPlan, context.partitionId())
-    // Creates array of H2O NewChunks; A place to record all the data in this partition
-    con.createChunks(keyName, vecTypes, context.partitionId())
-
-    it.foreach(prod => { // For all rows which are subtype of Product
-      for( i <- 0 until prod.productArity ) { // For all fields...
-      val fld = prod.productElement(i)
-        // TODO(vlad): deal properly with Option
-        val x = fld match {
-          case Some(n) => n
-          case _ => fld
-        }
-        x match {
-          case n: Number  => con.put(i, n)
-          case n: Boolean => con.put(i, n)
-          case n: String  => con.put(i, n)
-          case n : java.sql.Timestamp => con.put(i, n)
-          case _ => con.putNA(i)
-        }
-      }
-      con.increaseRowCounter()
-    })
-
-    //Compress & write data in partitions to H2O Chunks
-    con.closeChunks()
-
-    // Return Partition number and number of rows in this partition
-    (context.partitionId, con.numOfRows)
-  }
-
-  /**
-    * Infers the type from Any, used for determining the types in Product RDD
-    *
-    * @param value the value the type of which we are trying to check, via reflection
-    * @return
-    */
-  private[this] def inferFieldType(value : Any): Class[_] ={
-    value match {
-      case n: Byte  => classOf[java.lang.Byte]
-      case n: Short => classOf[java.lang.Short]
-      case n: Int => classOf[java.lang.Integer]
-      case n: Long => classOf[java.lang.Long]
-      case n: Float => classOf[java.lang.Float]
-      case n: Double => classOf[java.lang.Double]
-      case n: Boolean => classOf[java.lang.Boolean]
-      case n: String => classOf[java.lang.String]
-      case n: java.sql.Timestamp => classOf[java.sql.Timestamp]
-      case q => throw new IllegalArgumentException(s"Do not understand type $q")
-    }
   }
 }
+
+
+

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -41,7 +41,7 @@ trait SparkDataFrameConverter extends Logging with ConverterUtils {
 
   def toDataFrame[T <: Frame](hc: H2OContext, fr: T, copyMetadata: Boolean)(implicit sqlContext: SQLContext): DataFrame = {
     // Relation referencing H2OFrame
-    val relation = new H2OFrameRelation(fr, copyMetadata)(sqlContext)
+    val relation = H2OFrameRelation(fr, copyMetadata)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SupportedRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SupportedRDDConverter.scala
@@ -26,7 +26,7 @@ import scala.reflect.runtime.universe._
 
 
 /**
-  * This converter just wraps the existing RDD converters and hides the internal RDD covnerters
+  * This converter just wraps the existing RDD converters and hides the internal RDD converters
   */
 
 trait SupportedRDDConverter{

--- a/core/src/main/scala/org/apache/spark/util/h2o/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/h2o/Utils.scala
@@ -1,0 +1,9 @@
+package org.apache.spark.util.h2o
+
+/**
+  * Expose some utilities method already defined in Spark
+  */
+object Utils {
+
+  def createTempDir() = org.apache.spark.util.Utils.createTempDir()
+}

--- a/core/src/main/scala/water/AutoBufferUtils.scala
+++ b/core/src/main/scala/water/AutoBufferUtils.scala
@@ -1,0 +1,39 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package water
+
+import java.nio.channels.SocketChannel
+
+
+object AutoBufferUtils {
+
+  def getInt(ab: AutoBuffer): Int = ab.getInt
+
+  def create(socketChannel: SocketChannel) = new AutoBuffer(socketChannel, false)
+
+  def writeToChannel(ab: AutoBuffer, channel: SocketChannel): Unit = {
+    ab.flipForReading()
+    while (ab._bb.hasRemaining){
+      channel.write(ab._bb)
+    }
+  }
+
+  def clearForWriting(ab: AutoBuffer): Unit = ab.clearForWriting(H2O.MAX_PRIORITY)
+
+  val BBP_BIG_SIZE = AutoBuffer.BBP_BIG._size
+}

--- a/core/src/main/scala/water/api/RDDs/RDDsHandler.scala
+++ b/core/src/main/scala/water/api/RDDs/RDDsHandler.scala
@@ -17,7 +17,7 @@
 package water.api.RDDs
 
 import org.apache.spark.SparkContext
-import org.apache.spark.h2o.converters.SupportedDataset.ProductFrameBuilder
+import org.apache.spark.h2o.converters.{DatasetConverter, H2OFrameFromRDDProductBuilder}
 import org.apache.spark.h2o.{H2OContext, H2OFrame}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
@@ -28,7 +28,7 @@ import water.exceptions.H2ONotFoundArgumentException
 /**
  * Handler for all RDD related queries
  */
-class RDDsHandler(val sc: SparkContext, val h2oContext: H2OContext) extends Handler {
+class RDDsHandler(val sc: SparkContext, val h2oContext: H2OContext) extends Handler with DatasetConverter {
 
   def list(version: Int, s: RDDsV3): RDDsV3 = {
     val r = s.createAndFillImpl()
@@ -44,7 +44,7 @@ class RDDsHandler(val sc: SparkContext, val h2oContext: H2OContext) extends Hand
     if (sc.getPersistentRDDs.get(s.rdd_id).isEmpty) {
       throw new H2ONotFoundArgumentException(s"RDD with ID '${s.rdd_id}' does not exist!")
     }
-    val rdd = sc.getPersistentRDDs.get(s.rdd_id).get
+    val rdd = sc.getPersistentRDDs(s.rdd_id)
     s.name = Option(rdd.name).getOrElse(rdd.id.toString)
     s.partitions = rdd.partitions.length
     s
@@ -64,7 +64,7 @@ class RDDsHandler(val sc: SparkContext, val h2oContext: H2OContext) extends Hand
         case t if t.isInstanceOf[Float] => h2oContext.asH2OFrame(rdd.asInstanceOf[RDD[Float]], name)
         case t if t.isInstanceOf[Long] => h2oContext.asH2OFrame(rdd.asInstanceOf[RDD[Long]], name)
         case t if t.isInstanceOf[java.sql.Timestamp] => h2oContext.asH2OFrame(rdd.asInstanceOf[RDD[java.sql.Timestamp]], name)
-        case t if t.isInstanceOf[Product] => ProductFrameBuilder(sc, rdd.asInstanceOf[RDD[Product]], name).withDefaultFieldNames()
+        case t if t.isInstanceOf[Product] => H2OFrameFromRDDProductBuilder(h2oContext, rdd.asInstanceOf[RDD[Product]], name).withDefaultFieldNames()
         case t => throw new IllegalArgumentException(s"Do not understand type $t")
       }
     }
@@ -75,7 +75,7 @@ class RDDsHandler(val sc: SparkContext, val h2oContext: H2OContext) extends Hand
       throw new H2ONotFoundArgumentException(s"RDD with ID '${s.rdd_id}' does not exist, can not proceed with the transformation!")
     }
     // TODO(vlad): take care of the cases when the data are missing
-    val rdd = sc.getPersistentRDDs.get(s.rdd_id).get
+    val rdd = sc.getPersistentRDDs(s.rdd_id)
     val h2oFrame = if(s.h2oframe_id == null) convertToH2OFrame(rdd, None) else convertToH2OFrame(rdd,Some(s.h2oframe_id.toLowerCase))
     s.h2oframe_id = h2oFrame._key.toString
     s

--- a/core/src/test/scala/org/apache/spark/h2o/utils/ExternalClusterModeTestHelper.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/ExternalClusterModeTestHelper.scala
@@ -1,0 +1,84 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.utils
+
+import org.apache.spark.SparkConf
+import org.apache.spark.h2o.backends.SharedH2OConf._
+import org.scalatest.Suite
+
+import scala.sys.process.Process
+import scala.util.Random
+
+/**
+  * Used to start H2O nodes from scala code
+  */
+trait ExternalClusterModeTestHelper {
+  self: Suite =>
+
+  @transient var nodeProcesses: Seq[Process] = _
+
+  lazy val swJar = sys.props.getOrElse("sparkling.assembly.jar", if(sys.env.get("sparkling.assembly.jar").isDefined){
+    sys.env("sparkling.assembly.jar")
+  } else{
+    fail("sparkling.assembly.jar environment variable is not set! It should point to the location of sparkling-water" +
+      " assembly JAR")
+  })
+
+  lazy val h2oJar = sys.props.getOrElse("H2O_JAR", if (sys.env.get("H2O_JAR").isDefined) {
+    sys.env("H2O_JAR")
+  } else {
+    fail("H2O_JAR environment variable is not set! It should point to the location of H2O assembly jar file")
+  })
+
+  def uniqueCloudName(customPart: String) = s"sparkling-water-$customPart-${Random.nextInt()}"
+
+  private def launchSingle(cloudName: String, ip: String): Process = {
+    val cmdToLaunch = Seq[String]("java", "-jar", h2oJar, "-md5skip", "-name", cloudName, "-ip", ip)
+    import scala.sys.process._
+    Process(cmdToLaunch).run()
+  }
+
+  def startCloud(cloudSize: Int, cloudName: String, ip: String): Unit = {
+    nodeProcesses = (1 to cloudSize).map { _ => launchSingle(cloudName, ip) }
+    // Wait 2 seconds to ensure that h2o nodes are created earlier than h2o client
+    Thread.sleep(2000)
+  }
+
+  def startCloud(cloudSize: Int, sparkConf: SparkConf): Unit = {
+    startCloud(cloudSize, sparkConf.get(PROP_CLOUD_NAME._1), sparkConf.get(PROP_CLIENT_IP._1))
+  }
+
+  def testsInExternalMode(conf: Option[SparkConf] = None): Boolean = {
+    if(conf.isDefined){
+      conf.get.getOption(PROP_BACKEND_CLUSTER_MODE._1).getOrElse(PROP_BACKEND_CLUSTER_MODE._2) == "external"
+    }else{
+      sys.props.getOrElse(PROP_BACKEND_CLUSTER_MODE._1, PROP_BACKEND_CLUSTER_MODE._2) == "external"
+    }
+  }
+
+  def testsInExternalMode(conf: SparkConf): Boolean = {
+    testsInExternalMode(Option(conf))
+  }
+
+  def stopCloud(): Unit = {
+    if (nodeProcesses != null) {
+      nodeProcesses.foreach(_.destroy())
+      nodeProcesses = null
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/h2o/utils/PerTestSparkTestContext.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/PerTestSparkTestContext.scala
@@ -33,10 +33,17 @@ trait PerTestSparkTestContext extends SparkTestContext { self: Suite =>
     super.beforeEach()
     sc = createSparkContext
     sqlc = SQLContext.getOrCreate(sc)
-    hc = createH2OContext(sc, new H2OConf(sc))
+
+    if(testsInExternalMode(sc.getConf)){
+      startCloud(2, sc.getConf)
+    }
+    hc = createH2OContext(sc, new H2OConf(sc).setNumOfExternalH2ONodes(2))
   }
 
   override protected def afterEach(): Unit = {
+    if(testsInExternalMode(sc.getConf)){
+      stopCloud()
+    }
     resetContext()
     super.afterEach()
   }

--- a/core/src/test/scala/org/apache/spark/h2o/utils/SharedSparkTestContext.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/SharedSparkTestContext.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
   * Helper trait to simplify initialization and termination of Spark/H2O contexts.
   *
   */
-trait SharedSparkTestContext extends SparkTestContext { self: Suite =>
+trait SharedSparkTestContext extends SparkTestContext with ExternalClusterModeTestHelper { self: Suite =>
 
   def createSparkContext:SparkContext
 
@@ -43,10 +43,17 @@ trait SharedSparkTestContext extends SparkTestContext { self: Suite =>
     super.beforeAll()
     sc = createSparkContext
     sqlc = SQLContext.getOrCreate(sc)
-    hc = createH2OContext(sc, new H2OConf(sc))
+    if(testsInExternalMode(sc.getConf)){
+      startCloud(2, sc.getConf)
+    }
+    hc = createH2OContext(sc, new H2OConf(sc).setNumOfExternalH2ONodes(2))
   }
 
+
   override def afterAll(): Unit = {
+    if(testsInExternalMode(sc.getConf)){
+      stopCloud()
+    }
     resetContext()
     super.afterAll()
   }

--- a/core/src/test/scala/org/apache/spark/h2o/utils/SparkTestContext.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/SparkTestContext.scala
@@ -27,7 +27,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
   * Helper trait to simplify initialization and termination of Spark/H2O contexts.
   *
   */
-trait SparkTestContext extends BeforeAndAfterEach with BeforeAndAfterAll { self: Suite =>
+trait SparkTestContext extends BeforeAndAfterEach with BeforeAndAfterAll with ExternalClusterModeTestHelper{ self: Suite =>
 
   @transient var sc: SparkContext = _
   @transient var hc: H2OContext = _
@@ -58,6 +58,7 @@ trait SparkTestContext extends BeforeAndAfterEach with BeforeAndAfterAll { self:
     sys.props.get("spark.ext.h2o.client.ip").map(value => sc.set("spark.ext.h2o.client.ip", value))
     sc
   }
+
 }
 
 object SparkTestContext {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 }
 
 integTest {
+  systemProperty "spark.ext.h2o.backend.cluster.mode", detectClusterMode()
   systemProperty "spark.testing",   "true"
   systemProperty "spark.test.home", "${sparkHome}"
   systemProperty "sparkling.test.hdp.version", "${hdpVersion}"
@@ -72,6 +73,7 @@ integTest {
 
 // Setup test environment for scripts test
 scriptsTest {
+  systemProperty "spark.ext.h2o.backend.cluster.mode", detectClusterMode()
   systemProperty "spark.testing",   "true"
   systemProperty "spark.test.home", "${sparkHome}"
   systemProperty "sparkling.test.log.dir", new File(project.getBuildDir(), "h2ologs-test")

--- a/gradle/scala.gradle
+++ b/gradle/scala.gradle
@@ -43,6 +43,32 @@ test {
     maxParallelForks = 1
 }
 
+//
+// Initial task checking setup of all properties required
+// by scala tests
+//
+task checkScalaTestEnv << {
+
+    // if the spark.ext.h2o.backend.cluster.mode is set to external, then
+    // we need to have also H2O_JAR property set in order to be able to perform
+    // tests
+    if( detectClusterMode()=="external" && System.getenv("H2O_JAR")==null){
+
+        throw new InvalidUserDataException("""When running tests on external H2O Cluster, H2O_JAR property is required.
+
+Please set it, for example:
+
+mkdir -p \$(pwd)/private/
+curl -s ${h2oJarLocation()} > \$(pwd)/private/h2o.zip
+unzip h2o.zip
+export H2O_JAR=\$(pwd)/private/h2o/h2o.jar
+                                  """)
+    }
+}
+
+
+check.dependsOn(checkScalaTestEnv)
+
 // Enable scalastyle
 apply from: "$rootDir/gradle/scalastyle.gradle"
 

--- a/gradle/utils.gradle
+++ b/gradle/utils.gradle
@@ -9,8 +9,28 @@ def isWindowsBased(){
     return Os.isFamily(Os.FAMILY_WINDOWS)
 }
 
+def detectClusterMode(defaultClusterMode = "internal") {
+    String mode = [ project.hasProperty("clusterMode") ? project["clusterMode"] : null,
+                    System.properties["clusterMode"],
+                    defaultClusterMode
+    ].find { h -> h!=null } // first match
+    // Return env
+
+    logger.info("* Test will be running in '$mode' cluster mode (configure via property 'clusterMode')")
+    return mode
+}
+
+//
+// Represents location of H2O jar
+//
+def h2oJarLocation() {
+   return "http://h2o-release.s3.amazonaws.com/h2o/${h2oMajorName != "master" ? "rel-${h2oMajorName}" : "master"}/${h2oBuild}/h2o-${h2oMajorVersion}.${h2oBuild}.zip"
+}
+
 // Export methods by turning them into closures
 ext{
     getOsSpecificCommandLine = this.&getOsSpecificCommandLine
     isWindowsBased = this.&isWindowsBased
+    detectClusterMode = this.&detectClusterMode
+    h2oJarLocation = this.&h2oJarLocation
 }

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -49,6 +49,7 @@ task checkPythonEnv << {
     def SPARK_HOME = sparkHome
     def H2O_HOME = System.getenv("H2O_HOME")
     def H2O_PYTHON_WHEEL = System.getenv("H2O_PYTHON_WHEEL")
+    def H2O_JAR = System.getenv("H2O_JAR")
 
     if (SPARK_HOME == null) throw new InvalidUserDataException("SPARK_HOME needs to be defined!")
 
@@ -67,6 +68,22 @@ or
     export H2O_PYTHON_WHEEL=\$(pwd)/private/h2o.whl
 """)
     }
+
+    // if the spark.ext.h2o.backend.cluster.mode is set to external, then
+    // we need to have also H2O_JAR property set in order to be able to perform
+    // tests
+    if( detectClusterMode()=="external" && System.getenv("H2O_JAR")==null){
+        throw new InvalidUserDataException("""When running tests on external H2O Cluster, H2O_JAR property is required.
+
+Please set it, for example:
+
+mkdir -p \$(pwd)/private/
+curl -s ${h2oJarLocation()} > \$(pwd)/private/h2o.zip
+unzip h2o.zip
+export H2O_JAR=\$(pwd)/private/h2o/h2o.jar
+                                  """)
+    }
+
 
     if(H2O_HOME != null && H2O_PYTHON_WHEEL !=null){
         logger.info("Both \"H2O_HOME\" and \"H2O_PYTHON_WHEEL\" properties are set. Using \"H2O_HOME\"!")
@@ -130,6 +147,10 @@ artifacts {
 task testPython(type: Exec, dependsOn: [configurations.compile, distPython] ) {
     preparePythonEnv(environment)
     // add PySparkling egg on PYTHONPATH so unittests can see all the modules within this egg file
+    environment['spark.ext.h2o.backend.cluster.mode'] = detectClusterMode()
+
+    // sparkling assembly jar is here because of external h2o tests
+    environment["sparkling.assembly.jar"] = configurations.compile.join(',')
     environment['PYTHONPATH'] = configurations.eggs.artifacts.file.join(File.separator) +  File.pathSeparator + environment['PYTHONPATH']
     environment['SPARK_WORKER_DIR'] = file('build/h2ologs-pyunit/nodes')
     environment['SPARK_CONF_DIR'] = file("tests/conf/pyunit")
@@ -144,6 +165,9 @@ task integTestPython(type: Exec, dependsOn: [configurations.compile, distPython]
     def testEnv = detectEnvironment()
 
     // Pass references to libraries to test launcher
+    environment['spark.ext.h2o.backend.cluster.mode'] = detectClusterMode()
+    // sparkling assembly jar is here because of external h2o tests
+    environment["sparkling.assembly.jar"] = configurations.compile.join(',')
     environment["sparkling.pysparkling.egg"] = configurations.eggs.artifacts.file.join(File.separator)
     environment["spark.testing"] = "true"
     environment["spark.test.home"] = "${sparkHome}"

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -31,22 +31,56 @@ class H2OConf(object):
         else:
             return None
 
+
+    def runs_in_external_cluster_mode(self):
+        return self._jconf.runsInExternalClusterMode()
+
+    def runs_in_internal_cluster_mode(self):
+        return self._jconf.runsInInternalClusterMode()
+
     # setters for most common properties
     def set_cloud_name(self, cloud_name):
         self._jconf.setCloudName(cloud_name)
+        return self
+
+    def set_num_of_external_h2o_nodes(self, num_of_external_h2o_nodes):
+        self._jconf.setNumOfExternalH2ONodes(num_of_external_h2o_nodes)
+        return self
+
+    def set_internal_cluster_mode(self):
+        self._jconf.setInternalClusterMode()
+        return self
+
+    def set_external_cluster_mode(self):
+        self._jconf.setExternalClusterMode()
         return self
 
     def set_client_ip(self, ip):
         self._jconf.setClientIP(ip)
         return self
 
+    def set_client_network_mask(self, mask):
+        self._jconf.setClientNetworkMask(mask)
+        return self
+
     def set_flatfile_path(self, flatfile_path):
         self._jconf.setFlatFilePath(flatfile_path)
         return self
 
+    def set_h2o_cloud(self, ip, port):
+        self._jconf.setH2OCluster(ip, port)
+        return self
+    
     # getters
     def cloud_name(self):
         return self._get_option(self._jconf.cloudName())
+
+
+    def num_of_external_h2o_nodes(self):
+        return self._get_option(self._jconf.numOfExternalH2ONodes())
+
+    def flatfile_path(self):
+        return self._get_option(self._jconf.flatFilePath())
 
     def num_H2O_Workers(self):
         return self._get_option(self._jconf.numH2OWorkers())
@@ -81,6 +115,9 @@ class H2OConf(object):
     def subseq_tries(self):
         return self._jconf.subseqTries()
 
+
+    def backend_cluster_mode(self):
+        return self._jconf.backendClusterMode()
 
     def client_ip(self):
         return self._get_option(self._jconf.clientIp())
@@ -190,7 +227,14 @@ class H2OConf(object):
         """
         for conf in list_of_configurations:
             self._jconf.set(conf[0], conf[1])
-        self
+        return self
 
     def __str__(self):
         return self._jconf.toString()
+
+    def __repr__(self):
+        self.show()
+        return ""
+
+    def show(self):
+        print self

--- a/py/tests/external_cluster_test_utils.py
+++ b/py/tests/external_cluster_test_utils.py
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Helper class for running tests in external h2o cluster
+"""
+
+from random import randrange
+import subprocess
+import time
+import test_utils
+import socket
+
+class ExternalClusterTestHelper:
+    def __init__(self):
+        self.sw_jar = test_utils.get_env_org_fail("sparkling.assembly.jar",
+                                                                   "sparkling.assembly.jar environment variable is not set! It should " +
+                                                                   "point to the location of sparkling-water assembly JAR")
+        self.h2o_jar = test_utils.get_env_org_fail("H2O_JAR",
+                                              "H2O_JAR environment variable is not set! It should point to the " +
+                                              "location of H2O assembly jar file")
+        self.node_processes = []
+
+
+    @staticmethod
+    def unique_cloud_name(custom_part):
+        return "sparkling-water-"+custom_part+str(randrange(65536))
+
+    @staticmethod
+    def local_ip():
+        return socket.gethostbyname(socket.gethostname())
+
+    def _launch_single(self, cloud_name, ip):
+        cmd_line = ["java", "-cp", ":".join([self.sw_jar, self.h2o_jar]), "water.H2OApp", "-md5skip", "-name", cloud_name, "-ip", ip]
+        return subprocess.Popen(cmd_line)
+
+    def start_cloud(self, cloud_size, cloud_name, ip):
+        self.node_processes = [ self._launch_single(cloud_name, ip) for i in range(1, cloud_size+1)]
+        # Wait 2 seconds to ensure that h2o nodes are created earlier than h2o client
+        time.sleep(2)
+
+    def stop_cloud(self):
+        for p in self.node_processes:
+            p.terminate()
+
+    @staticmethod
+    def tests_in_external_mode(spark_conf = None):
+        if spark_conf is not None:
+            return spark_conf.get("spark.ext.h2o.backend.cluster.mode", "internal") == "external"
+        else:
+            cluster_mode = test_utils.get_env_org_fail("spark.ext.h2o.backend.cluster.mode",
+                                                        "The variable 'spark.ext.h2o.backend.cluster.mode' has to be set")
+        return cluster_mode == "external"
+
+

--- a/py/tests/tests_unit.py
+++ b/py/tests/tests_unit.py
@@ -35,7 +35,7 @@ class FrameTransformationsTest(unittest.TestCase):
     def setUpClass(cls):
         cls._sc = SparkContext(conf = test_utils.get_default_spark_conf())
         test_utils.set_up_class(cls)
-        cls._hc = H2OContext.getOrCreate(cls._sc, H2OConf(cls._sc))
+        cls._hc = H2OContext.getOrCreate(cls._sc, H2OConf(cls._sc).set_num_of_external_h2o_nodes(2))
 
     @classmethod
     def tearDownClass(cls):
@@ -132,7 +132,7 @@ class H2OConfTest(unittest.TestCase):
     def setUpClass(cls):
         cls._sc = SparkContext(conf = test_utils.get_default_spark_conf().set("spark.ext.h2o.cloud.name", "test-cloud"))
         test_utils.set_up_class(cls)
-        h2o_conf = H2OConf(cls._sc)
+        h2o_conf = H2OConf(cls._sc).set_num_of_external_h2o_nodes(2)
         cls._hc = H2OContext.getOrCreate(cls._sc, h2o_conf)
 
     @classmethod


### PR DESCRIPTION
This architectural change allows to connect to existing h2o cluster from sparkling water. This has a benefit that we are no longer affected by Spark killing it's executors thus we should have more stable solution in environment with lots of h2o/spark node.

This change depends on JH_SW_connection branch in h2o project. Before integrating this change, the change on h2o side has to be integrated first.