### PR TITLE
[SW-176] Adds a missing method from the CDH SparkListener trait.

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -21,7 +21,7 @@ import org.apache.spark.Logging
 import org.apache.spark.h2o.backends.SparklingBackend
 import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OConf, H2OContext}
-import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorAdded}
+import org.apache.spark.listeners.{ExecutorAddNotSupportedListener}
 import water.api.RestAPIManager
 import water.{H2O, H2OStarter}
 
@@ -70,11 +70,7 @@ class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend
     if(hc.getConf.isClusterTopologyListenerEnabled){
       // Attach listener which kills H2O cluster when new Spark executor has been launched ( which means
       // that this executors hasn't been discovered during the spreadRDD phase)
-      hc.sparkContext.addSparkListener(new SparkListener(){
-        override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = {
-          throw new IllegalArgumentException("Executor without H2O instance discovered, killing the cloud!")
-        }
-      })
+      hc.sparkContext.addSparkListener(new ExecutorAddNotSupportedListener())
     }
 
     // Start H2O nodes

--- a/core/src/main/scala/org/apache/spark/listeners/H2OSparkListener.scala
+++ b/core/src/main/scala/org/apache/spark/listeners/H2OSparkListener.scala
@@ -1,0 +1,34 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.spark.listeners
+
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerExecutorAdded}
+
+trait H2OSparkListener extends SparkListener {
+
+  // Fix for CDH 5.7 spark version which already implements some Spark 2.0 features
+  def onOtherEvent(event: SparkListenerEvent) { }
+
+}
+
+class ExecutorAddNotSupportedListener extends H2OSparkListener {
+
+  override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = {
+    throw new IllegalArgumentException("Executor without H2O instance discovered, killing the cloud!")
+  }
+
+}


### PR DESCRIPTION
**Why the fix:**

CDH added a new method to `SparkListener` (which was added in Spark2.0) https://github.com/cloudera/spark/blob/cdh5.7.1-release/core/src/main/scala/org/apache/spark/scheduler/SparkListener.scala#L245 We're getting an `AbstractMethodError` when running on CDH5.7.1 since the trait against which we're compiling (Spark 1.6) doesn't have `onExecutorAdded`.

Adding the `onExecutorAdded` has to be done in a separate trait/class, adding it on the anonymous class won't work due to how Scala compiles it. 

**How this was tested:**

Manually ran `./sparkling-shell --num-executors 2 --executor-memory 6g --driver-memory 6g --master yarn-client --conf spark.dynamicAllocation.enabled=false`:

```
import org.apache.spark.h2o._
val hc = H2OContext.getOrCreate(sc)
sc.parallelize(Array(1,1)).toDF.count()
```

on `mr-0xd6-precise1` with `SPARK_HOME=/opt/cloudera/parcels/CDH-5.7.1-1.cdh5.7.1.p0.11/lib/spark/` (previously, with SW1.6.5 would fail with the aforementioned error).

