### PR TITLE
[SW-185] Post-refactorization and post-integration fixes

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDDLike.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDDLike.scala
@@ -19,8 +19,6 @@ package org.apache.spark.h2o.converters
 
 import org.apache.spark.Partition
 import water.fvec.{Frame, FrameUtils}
-import water.{DKV, Key}
-import scala.reflect.runtime.universe._
 
 /**
  * Contains functions that are shared between all H2ORDD types (i.e., Scala, Java)
@@ -52,28 +50,15 @@ private[converters] trait H2ORDDLike[T <: Frame] {
 
     /* Key of pointing to underlying dataframe */
     val keyName: String
+
     /* Partition index */
     val partIndex: Int
-    /* Lazily fetched dataframe from K/V store */
-    lazy val fr: Frame = getFrame()
-    /* Number of columns in the full dataset */
-    lazy val ncols = fr.numCols()
-
-    /** Create new types list which describes expected types in a way external H2O backend can use it. This list
-      * contains types in a format same for H2ODataFrame and H2ORDD */
-    val expectedTypes: Option[Array[Byte]]
 
     /* Converter context */
-    lazy val converterCtx: ReadConverterContext =
-      ConverterUtils.getReadConverterContext(isExternalBackend,
-                                             keyName,
-                                             chksLocation,
-                                             expectedTypes,
-                                             partIndex)
+    val converterCtx: ReadConverterContext
 
     override def hasNext: Boolean = converterCtx.hasNext
 
-    private def getFrame() = DKV.get(Key.make(keyName)).get.asInstanceOf[Frame]
   }
 
 }


### PR DESCRIPTION
This PR fixed problem in H2ODataFrame where we are not allowed to use methods requiring H2O backend since in future external cluster mode, h2o is not running in a spark executor.

Tests are passing.

@mmalohlava Pls let me know if it looks good to you.