### PR TITLE
[SW-128] Move flows into core so they are shown in flowui

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -3,6 +3,24 @@ description = "Sparkling Water Examples"
 apply from: "$rootDir/gradle/utils.gradle"
 apply from: "$rootDir/gradle/scriptsTest.gradle"
 
+project.ext.exampleResources = project.file("flows")
+
+sourceSets {
+    main {
+        resources {
+            srcDir("flows")
+        }
+    }
+}
+
+jar {
+    eachFile { f ->
+        if(new File(exampleResources, f.file.name).exists()) {
+            f.path = "www/flow/packs/examples/$f.name"
+        }
+    }
+}
+
 dependencies {
   // Sparkling Water Core
   compile( project(":sparkling-water-core") ) {

--- a/examples/flows/index.list
+++ b/examples/flows/index.list
@@ -1,0 +1,17 @@
+2016_H2O_Tour_Chicago.flow
+Amazon_Fine_Food_Sentiment_Analysis.flow
+Lending_Club.flow
+Strata_SJ_2016.flow
+GBM_Example.flow
+DeepLearning_MNIST.flow
+GLM_Example.flow
+DRF_Example.flow
+K-Means_Example.flow
+Million_Songs.flow
+KDDCup2009_Churn.flow
+QuickStartVideos.flow
+Airlines_Delay.flow
+GBM_Airlines_Classification.flow
+GBM_GridSearch.flow
+RandomData_Benchmark_Small.flow
+GBM_TuningGuide.flow


### PR DESCRIPTION
Is this enough? The [Jira](https://0xdata.atlassian.net/browse/SW-128) mentioned something about integrating into github but they were already in github? 

The flows are now packaged with the core jar and show up in the FlowUI `Help > examples` together with core H2O examples when running SW.