### PR TITLE
[BUILD] Fix in travis build file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,13 @@ cache:
 
 script: ./gradlew clean build -x integTest -x :sparkling-water-py:build -PsparklingTestEnv=local -PsparkHome=$SPARK_HOME
 
-# To solve BufferOverflow on OpenJDK7: see https://github.com/travis-ci/travis-ci/issues/5227
-before_install:
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*
+# To solve BufferOverflow on OpenJDK7 we setup short hostname (<64characters)
+# See:
+#   - ISSUE-5227: https://github.com/travis-ci/travis-ci/issues/5227
+#   - https://docs.travis-ci.com/user/hostname
+#   - https://github.com/mockito/mockito/blob/master/.travis.yml
+addons:
+    hosts:
+        - sw-test-host
+    hostname: sw-test-host
+


### PR DESCRIPTION
This solve travis issue-5227 - bufferflow in getHostname by
seting short hostname (<64characters).
See:
  - ISSUE-5227: https://github.com/travis-ci/travis-ci/issues/5227
  - https://docs.travis-ci.com/user/hostname