### PR TITLE
[MINOR] Adds the services file in ml module for RestAPI interface

### DIFF
--- a/ml/src/main/resources/META-INF/services/water.api.RestApi
+++ b/ml/src/main/resources/META-INF/services/water.api.RestApi
@@ -1,0 +1,1 @@
+hex.Register


### PR DESCRIPTION
Without this the `hex.Register` class won't be found by `ServiceLocator`