### PR TITLE
[SW-192] Add org.apache.spark.sql._ to packages imported by default in REPL

### DIFF
--- a/core/src/test/scala/water/api/ScalaCodeHandlerSuite.scala
+++ b/core/src/test/scala/water/api/ScalaCodeHandlerSuite.scala
@@ -124,7 +124,7 @@ class ScalaCodeHandlerSuite extends FunSuite with SharedSparkTestContext with Be
 
     assert(result.output.equals(""), "Printed output should be empty")
     assert(result.status.equals("Error"), "Status should be Error")
-    assert(result.response.equals("<console>:33: error: not found: value foo\n              foo\n              ^\n"), "Response should not be empty")
+    assert(result.response.contains(" error: not found: value foo\n              foo\n              ^\n"), "Response should not be empty")
   }
 
   test("ScalaCodeHandler.interpret() method, using previously defined class"){

--- a/repl/src/main/scala/org/apache/spark/repl/h2o/H2OInterpreter.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/h2o/H2OInterpreter.scala
@@ -126,6 +126,7 @@ class H2OInterpreter(val sparkContext: SparkContext, var sessionId: Int) extends
           "org.apache.spark.sql.{DataFrame, Row, SQLContext}",
           "sqlContext.implicits._",
           "sqlContext.sql",
+          "org.apache.spark.sql._",
           "org.apache.spark.sql.functions._",
           "org.apache.spark.h2o._",
           "org.apache.spark._")


### PR DESCRIPTION
Right now this package is not imported and for example when specifying saving mode in datasource api using`SaveMode.Append `
it doesn't know the class SaveMode.
It's more convenient for the user not having to import this package.