### PR TITLE
[SW-193] Add scala version to pysparkling package name

### DIFF
--- a/py/PUBLISHING_TO_PIPY.txt
+++ b/py/PUBLISHING_TO_PIPY.txt
@@ -36,5 +36,6 @@ python setup.py sdist upload -r pypi
 
 
 5 - Don't forget to do this for each pySparkling release ( for Spark 1.5, Spark 1.6 ... )
+    and for each spark release publish it for both scala versions 2.10 and 2.11
 
 6 - That's it!

--- a/py/README.rst
+++ b/py/README.rst
@@ -2,15 +2,15 @@ PySparkling and Spark Version
 =============================
 There exist multiple pySparkling packages, each is intended to be used with different Spark version.
 
- - h2o_pysparkling_1.6 - for Spark 1.6.x
- - h2o_pysparkling_1.5 - for Spark 1.5.x
- - h2o_pysparkling_1.4 - for Spark 1.4.x
+ - h2o_pysparkling_2_10_1.6 - for Spark 1.6.x
+ - h2o_pysparkling_2_10_1.5 - for Spark 1.5.x
+ - h2o_pysparkling_2_10_1.4 - for Spark 1.4.x
 
-So for example, to install pySparkling for Spark 1.6, the command would look like:
+So for example, to install pySparkling for Spark 1.6 build for Scala 2.11, the command would look like:
 
 .. code-block:: bash
 
-    pip install h2o_pysparkling_1.6
+    pip install h2o_pysparkling_2.11_1.6
 
 Setup and Installation
 ======================

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 task createVersionFile << {
     File version_file = new File(getProjectDir(), "version.txt")
     def version_txt = version.replace("-SNAPSHOT","")
-    version_file.write(version_txt)
+    version_file.write(version_txt+System.getProperty("line.separator")+scalaBaseVersion)
 }
 
 //

--- a/py/setup.py
+++ b/py/setup.py
@@ -9,13 +9,14 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-# Get the version from the relevant file
+# Get the version and scala version from the relevant file
 with open(path.join(here, 'version.txt'), encoding='utf-8') as f:
-    version = f.read()
+    version = f.readline()
+    scala_version = f.readline()
 
 
 setup(
-    name='h2o_pysparkling_'+version[:version.rindex(".")],
+    name='h2o_pysparkling_'+scala_version+"_"+version[:version.rindex(".")],
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see


### PR DESCRIPTION
We need to embed the scala version in the name since spark can be built with different scala versions. We need to have packages for all of them and we need to somehow distinguish them from each other.