### PR TITLE
[SWPRIVATE-18] Progress bar update for SVM

### DIFF
--- a/ml/src/main/scala/org/apache/spark/ml/spark/ProgressListener.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/spark/ProgressListener.scala
@@ -16,25 +16,81 @@
  */
 package org.apache.spark.ml.spark
 
+import org.apache.spark.SparkContext
 import org.apache.spark.scheduler._
 import org.apache.spark.storage.RDDInfo
 import water.Job
+
+import scala.collection.mutable
 
 /**
   * One progress listener for each instance of model creation. Each listener gets all events so this particular one
   * will respond only to the ones corresponding to a given RDD used for training (which should not be shared) and
   * to a particular job type (depending on the algorithm).
   *
-  * It might not be 100% accurate
+  * It might not be 100% accurate depending on how many "non primary" jobs will be run.
+  *
+  * @param job Job which progress is to be updated
+  * @param rddInfo events triggered for this RDD (or its children) trigger progress change
+  * @param stageNames which stages are supposed to change the progress bar %
   */
-class ProgressListener(val job: Job[_], val rddInfo: RDDInfo, val stageNames: Iterable[String]) extends SparkListener {
+class ProgressListener(val sc: SparkContext,
+                       val job: Job[_],
+                       val rddInfo: RDDInfo,
+                       val stageNames: Iterable[String]) extends SparkListener {
+
+  var currentJobs: scala.collection.mutable.Map[Int, Int] = mutable.HashMap()
+
+  private def matchingRDD(stageInfo: StageInfo): Boolean = stageInfo.rddInfos.map(_.id).contains(rddInfo.id)
+  private def matchingRDD(stageInfos: Seq[StageInfo]): Boolean = stageInfos.exists(matchingRDD)
 
   override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
-    if(jobStart.stageInfos.exists{ stage =>
-      stageNames.exists( name => stage.name.contains(name) ) && stage.rddInfos.map(_.id).contains(rddInfo.id)
-    }) {
-      job.update(1)
+    if (matchingRDD(jobStart.stageInfos)) {
+      job.update(0, s"Staring Spark job with ID [${jobStart.jobId}]")
+
+      if (jobStart.stageInfos.exists(stage => stageNames.exists(stage.name.contains))) {
+        currentJobs.put(jobStart.jobId, 1)
+      } else {
+        currentJobs.put(jobStart.jobId, 0)
+      }
     }
   }
+
+  override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+    if(currentJobs.contains(jobEnd.jobId)) {
+      job.update(currentJobs.get(jobEnd.jobId).get, s"Finished Spark job with ID [${jobEnd.jobId}]")
+      currentJobs.remove(jobEnd.jobId)
+    }
+  }
+
+  var currentStages: scala.collection.mutable.Map[Int, String] = mutable.HashMap()
+
+  override def onStageSubmitted(stageSubmitted: SparkListenerStageSubmitted): Unit = {
+    if(matchingRDD(stageSubmitted.stageInfo)) {
+      updateTaskStatus(stageSubmitted.stageInfo.stageId, 0)
+    }
+  }
+
+  override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
+    if(currentStages.contains(stageCompleted.stageInfo.stageId)) {
+      currentStages.remove(stageCompleted.stageInfo.stageId)
+      job.update(0, printStagesStatus())
+    }
+  }
+
+  override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = {
+    if(currentStages.contains(taskStart.stageId)) {
+      updateTaskStatus(taskStart.stageId, taskStart.taskInfo.index + 1)
+    }
+  }
+
+  private def updateTaskStatus(stageId: Int, taskIdx: Int): Unit = {
+    val status = s"Stage [$stageId] status [$taskIdx/${sc.jobProgressListener.stageIdToInfo.get(stageId).get.numTasks}]."
+    currentStages.put(stageId, status)
+    job.update(0, printStagesStatus())
+  }
+
+  private def printStagesStatus(): String = currentStages.map{ case (id, status) => status}.mkString("\n")
+
 
 }

--- a/ml/src/main/scala/org/apache/spark/ml/spark/ProgressListener.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/spark/ProgressListener.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ml.spark
+
+import org.apache.spark.scheduler._
+import org.apache.spark.storage.RDDInfo
+import water.Job
+
+/**
+  * One progress listener for each instance of model creation. Each listener gets all events so this particular one
+  * will respond only to the ones corresponding to a given RDD used for training (which should not be shared) and
+  * to a particular job type (depending on the algorithm).
+  *
+  * It might not be 100% accurate
+  */
+class ProgressListener(val job: Job[_], val rddInfo: RDDInfo, val stageNames: Iterable[String]) extends SparkListener {
+
+  override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+    if(jobStart.stageInfos.exists{ stage =>
+      stageNames.exists( name => stage.name.contains(name) ) && stage.rddInfos.map(_.id).contains(rddInfo.id)
+    }) {
+      job.update(1)
+    }
+  }
+
+}

--- a/ml/src/main/scala/org/apache/spark/ml/spark/models/svm/SVM.java
+++ b/ml/src/main/scala/org/apache/spark/ml/spark/models/svm/SVM.java
@@ -192,7 +192,7 @@ public class SVM extends ModelBuilder<SVMModel, SVMParameters, SVMOutput> {
             svm.optimizer().setGradient(_parms._gradient.get());
             svm.optimizer().setUpdater(_parms._updater.get());
 
-            ProgressListener progressBar = new ProgressListener(_job, RDDInfo.fromRdd(training), asScalaIterable(Arrays.<String>asList("treeAggregate")));
+            ProgressListener progressBar = new ProgressListener(sc, _job, RDDInfo.fromRdd(training), asScalaIterable(Arrays.<String>asList("treeAggregate")));
             
             sc.addSparkListener(progressBar);
 

--- a/ml/src/main/scala/org/apache/spark/ml/spark/models/svm/SVM.java
+++ b/ml/src/main/scala/org/apache/spark/ml/spark/models/svm/SVM.java
@@ -27,6 +27,7 @@ import org.apache.spark.mllib.linalg.Vector;
 import org.apache.spark.mllib.linalg.Vectors;
 import org.apache.spark.mllib.regression.LabeledPoint;
 import org.apache.spark.rdd.RDD;
+import org.apache.spark.scheduler.*;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.types.DataTypes;
@@ -187,6 +188,95 @@ public class SVM extends ModelBuilder<SVMModel, SVMParameters, SVMOutput> {
             svm.optimizer().setConvergenceTol(_parms._convergence_tol);
             svm.optimizer().setGradient(_parms._gradient.get());
             svm.optimizer().setUpdater(_parms._updater.get());
+
+            SparkListener progressBar = new SparkListener() {
+                @Override
+                public void onApplicationStart(SparkListenerApplicationStart applicationStart) {
+                    super.onApplicationStart(applicationStart);
+                }
+
+                @Override
+                public void onJobStart(SparkListenerJobStart jobStart) {
+                    super.onJobStart(jobStart);
+                }
+
+                @Override
+                public void onBlockManagerRemoved(SparkListenerBlockManagerRemoved blockManagerRemoved) {
+                    super.onBlockManagerRemoved(blockManagerRemoved);
+                }
+
+                @Override
+                public void onExecutorRemoved(SparkListenerExecutorRemoved executorRemoved) {
+                    super.onExecutorRemoved(executorRemoved);
+                }
+
+                @Override
+                public void onUnpersistRDD(SparkListenerUnpersistRDD unpersistRDD) {
+                    super.onUnpersistRDD(unpersistRDD);
+                }
+
+                @Override
+                public void onTaskGettingResult(SparkListenerTaskGettingResult taskGettingResult) {
+                    super.onTaskGettingResult(taskGettingResult);
+                }
+
+                @Override
+                public void onExecutorAdded(SparkListenerExecutorAdded executorAdded) {
+                    super.onExecutorAdded(executorAdded);
+                }
+
+                @Override
+                public void onBlockUpdated(SparkListenerBlockUpdated blockUpdated) {
+                    super.onBlockUpdated(blockUpdated);
+                }
+
+                @Override
+                public void onEnvironmentUpdate(SparkListenerEnvironmentUpdate environmentUpdate) {
+                    super.onEnvironmentUpdate(environmentUpdate);
+                }
+
+                @Override
+                public void onTaskEnd(SparkListenerTaskEnd taskEnd) {
+                    super.onTaskEnd(taskEnd);
+                }
+
+                @Override
+                public void onBlockManagerAdded(SparkListenerBlockManagerAdded blockManagerAdded) {
+                    super.onBlockManagerAdded(blockManagerAdded);
+                }
+
+                @Override
+                public void onApplicationEnd(SparkListenerApplicationEnd applicationEnd) {
+                    super.onApplicationEnd(applicationEnd);
+                }
+
+                @Override
+                public void onStageCompleted(SparkListenerStageCompleted stageCompleted) {
+                    super.onStageCompleted(stageCompleted);
+                }
+
+                @Override
+                public void onTaskStart(SparkListenerTaskStart taskStart) {
+                    super.onTaskStart(taskStart);
+                }
+
+                @Override
+                public void onExecutorMetricsUpdate(SparkListenerExecutorMetricsUpdate executorMetricsUpdate) {
+                    super.onExecutorMetricsUpdate(executorMetricsUpdate);
+                }
+
+                @Override
+                public void onStageSubmitted(SparkListenerStageSubmitted stageSubmitted) {
+                    super.onStageSubmitted(stageSubmitted);
+                }
+
+                @Override
+                public void onJobEnd(SparkListenerJobEnd jobEnd) {
+                    super.onJobEnd(jobEnd);
+                }
+            };
+            
+            sc.addSparkListener();
 
             final org.apache.spark.mllib.classification.SVMModel trainedModel =
                     (null == _parms._initial_weights) ?


### PR DESCRIPTION
Not 100% but close. SVM has one main spark job that is ran in a for loop for the number of iterations specified by the user (default 100) - it's called `treeAggregate`. There are a few other jobs that run before (3-5) that's why it's not 100% accurate but I think it's close enough to leave it as it is - otherwise we'd have to find all the jobs spark uses for SVM and keep track of all the changes they do to them.

I'm using RDD info to update a job only when a job is submitted on the appropriate RDD (we can have multiple models being built at the same time).

Thoughts?