### PR TITLE
[SWPRIVATE-16] NA handling for Spark algorithms

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,7 @@
 description = "Sparkling Water Core"
 
 apply from: "$rootDir/gradle/utils.gradle"
+apply from: "$rootDir/gradle/sparkTest.gradle"
 
 dependencies {
   // Required for h2o-app (we need UI)
@@ -52,30 +53,6 @@ dependencies {
 
   // Put Spark Assembly on runtime path
   integTestRuntime fileTree(dir: new File((String) sparkHome, "lib/"), include: '*.jar' )
-}
-
-// Setup test environment for Spark
-test {
-    // Test environment
-    systemProperty "spark.testing", "true"
-    systemProperty "spark.ext.h2o.node.log.dir", new File(project.getBuildDir(), "h2ologs-test/nodes")
-    systemProperty "spark.ext.h2o.client.log.dir", new File(project.getBuildDir(), "h2ologs-test/client")
-
-    // Run with assertions ON
-    enableAssertions = true
-
-    // For a new JVM for each test class
-    forkEvery = 1
-
-    // Increase heap size
-    maxHeapSize = "4g"
-
-    // Increase PermGen
-    jvmArgs '-XX:MaxPermSize=384m'
-
-    // Working dir will be root project
-    workingDir = rootDir
-//    testLogging.showStandardStreams = true
 }
 
 task createSparkVersionFile << {

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -543,21 +543,6 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     h2oFrameEnum.delete()
   }
 
-  def makeH2OFrame[T: ClassTag](fname: String, colNames: Array[String], chunkLayout: Array[Long],
-                                 data: Array[Array[T]], h2oType: Byte, colDomains: Array[Array[String]] = null): H2OFrame = {
-    var f: Frame = new Frame(Key.make(fname))
-    FrameUtils.preparePartialFrame(f,colNames)
-    f.update()
-
-    for( i <- chunkLayout.indices) { buildChunks(fname, data(i), i, Array(h2oType)) }
-
-    f = DKV.get(fname).get()
-
-    FrameUtils.finalizePartialFrame(f, chunkLayout, colDomains, Array(h2oType))
-
-    new H2OFrame(f)
-  }
-
   def fp(it:Iterator[Row]):Unit = {
     println(it.size)
   }

--- a/core/src/test/scala/org/apache/spark/h2o/utils/SharedSparkTestContext.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/SharedSparkTestContext.scala
@@ -21,9 +21,9 @@ import java.util.concurrent.ConcurrentHashMap
 
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.{H2OConf, H2OContext, Holder}
-import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.scalatest.Suite
-import water.fvec.{Chunk, FrameUtils, NewChunk, Vec}
+import water.fvec._
+import water.{DKV, Key}
 import water.parser.BufferedString
 
 import scala.reflect.ClassTag
@@ -32,9 +32,10 @@ import scala.reflect.ClassTag
   * Helper trait to simplify initialization and termination of Spark/H2O contexts.
   *
   */
-trait SharedSparkTestContext extends SparkTestContext { self: Suite =>
+trait SharedSparkTestContext extends SparkTestContext {
+  self: Suite =>
 
-  def createSparkContext:SparkContext
+  def createSparkContext: SparkContext
 
   def createH2OContext(sc: SparkContext, conf: H2OConf): H2OContext = {
     H2OContext.getOrCreate(sc, conf)
@@ -51,26 +52,51 @@ trait SharedSparkTestContext extends SparkTestContext { self: Suite =>
     super.afterAll()
   }
 
-  def buildChunks[T: ClassTag](fname: String, data: Array[T], cidx: Integer, h2oType: Array[Byte]): Chunk = {
+  def makeH2OFrame[T: ClassTag](fname: String, colNames: Array[String], chunkLayout: Array[Long],
+                                data: Array[Array[T]], h2oType: Byte, colDomains: Array[Array[String]] = null): H2OFrame = {
+    makeH2OFrame2(fname, colNames, chunkLayout, data.map(_.map(value => Array(value))), Array(h2oType), colDomains)
+  }
+
+  def makeH2OFrame2[T: ClassTag](fname: String, colNames: Array[String], chunkLayout: Array[Long],
+                                 data: Array[Array[Array[T]]], h2oTypes: Array[Byte], colDomains: Array[Array[String]] = null): H2OFrame = {
+    var f: Frame = new Frame(Key.make(fname))
+    FrameUtils.preparePartialFrame(f, colNames)
+    f.update()
+
+    for (i <- chunkLayout.indices) {
+      buildChunks(fname, data(i), i, h2oTypes)
+    }
+
+    f = DKV.get(fname).get()
+
+    FrameUtils.finalizePartialFrame(f, chunkLayout, colDomains, h2oTypes)
+
+    new H2OFrame(f)
+  }
+
+  def buildChunks[T: ClassTag](fname: String, data: Array[Array[T]], cidx: Integer, h2oType: Array[Byte]): Array[_ <: Chunk] = {
     val nchunks: Array[NewChunk] = FrameUtils.createNewChunks(fname, h2oType, cidx)
 
-    val chunk: NewChunk = nchunks(0)
-    data.foreach {
-      case u: UUID               => chunk.addUUID(
-        u.getLeastSignificantBits,
-        u.getMostSignificantBits)
-      case s: String             => chunk.addStr(new BufferedString(s))
-      case b: Byte               => chunk.addNum(b)
-      case s: Short              => chunk.addNum(s)
-      case c: Integer if h2oType(0) == Vec.T_CAT => chunk.addCategorical(c)
-      case i: Integer if h2oType(0) != Vec.T_CAT => chunk.addNum(i.toDouble)
-      case l: Long               => chunk.addNum(l)
-      case d: Double             => chunk.addNum(d)
-      case x                     =>
-        throw new IllegalArgumentException(s"Failed to figure out what is it: $x")
+    data.foreach { values =>
+      values.indices.foreach { idx =>
+        val chunk: NewChunk = nchunks(idx)
+        values(idx) match {
+          case null                                  => chunk.addNA()
+          case u: UUID                               => chunk.addUUID(u.getLeastSignificantBits, u.getMostSignificantBits)
+          case s: String                             => chunk.addStr(new BufferedString(s))
+          case b: Byte                               => chunk.addNum(b)
+          case s: Short                              => chunk.addNum(s)
+          case c: Integer if h2oType(0) == Vec.T_CAT => chunk.addCategorical(c)
+          case i: Integer if h2oType(0) != Vec.T_CAT => chunk.addNum(i.toDouble)
+          case l: Long                               => chunk.addNum(l)
+          case d: Double                             => chunk.addNum(d)
+          case x =>
+            throw new IllegalArgumentException(s"Failed to figure out what is it: $x")
+        }
+      }
     }
     FrameUtils.closeNewChunks(nchunks)
-    chunk
+    nchunks
   }
 }
 

--- a/gradle/sparkTest.gradle
+++ b/gradle/sparkTest.gradle
@@ -1,0 +1,23 @@
+// Setup test environment for Spark
+test {
+    // Test environment
+    systemProperty "spark.testing", "true"
+    systemProperty "spark.ext.h2o.node.log.dir", new File(project.getBuildDir(), "h2ologs-test/nodes")
+    systemProperty "spark.ext.h2o.client.log.dir", new File(project.getBuildDir(), "h2ologs-test/client")
+
+    // Run with assertions ON
+    enableAssertions = true
+
+    // For a new JVM for each test class
+    forkEvery = 1
+
+    // Increase heap size
+    maxHeapSize = "4g"
+
+    // Increase PermGen
+    jvmArgs '-XX:MaxPermSize=384m'
+
+    // Working dir will be root project
+    workingDir = rootDir
+//    testLogging.showStandardStreams = true
+}

--- a/ml/build.gradle
+++ b/ml/build.gradle
@@ -1,3 +1,5 @@
+apply from: "$rootDir/gradle/sparkTest.gradle"
+
 description = "Sparkling Water ML Pipelines"
 
 dependencies {
@@ -37,3 +39,4 @@ sourceSets {
     }
   }
 }
+

--- a/ml/src/main/java/hex/schemas/SVMV3.java
+++ b/ml/src/main/java/hex/schemas/SVMV3.java
@@ -17,6 +17,7 @@
 
 package hex.schemas;
 
+import org.apache.spark.ml.spark.models.MissingValuesHandling;
 import org.apache.spark.ml.spark.models.svm.*;
 import water.DKV;
 import water.Key;
@@ -51,7 +52,8 @@ public class SVMV3 extends ModelBuilderSchema<SVM, SVMV3, SVMV3.SVMParametersV3>
                 "gradient",
 
                 "ignored_columns",
-                "ignore_const_cols"
+                "ignore_const_cols",
+                "missing_values_handling"
         };
 
         @API(help="Initial model weights.", direction=API.Direction.INOUT, gridable = true)
@@ -81,6 +83,11 @@ public class SVMV3 extends ModelBuilderSchema<SVM, SVMV3, SVMV3.SVMParametersV3>
 
         @API(help="Set the gradient computation type for SGD.", direction=API.Direction.INPUT, values = {"Hinge", "LeastSquares", "Logistic"}, required = true, gridable = true, level = API.Level.expert)
         public Gradient gradient = Gradient.Hinge;
+
+        @API(level = API.Level.expert, direction = API.Direction.INOUT, gridable = true,
+                values = {"NotAllowed", "Skip", "MeanImputation"},
+                help = "Handling of missing values. Either NotAllowed, Skip or MeanImputation.")
+        public MissingValuesHandling missing_values_handling;
 
         @Override
         public SVMParametersV3 fillFromImpl(SVMParameters impl) {

--- a/ml/src/main/java/org/apache/spark/ml/spark/models/svm/SVM.java
+++ b/ml/src/main/java/org/apache/spark/ml/spark/models/svm/SVM.java
@@ -18,25 +18,24 @@ package org.apache.spark.ml.spark.models.svm;
 
 import hex.*;
 
-import org.apache.spark.api.java.function.Function;
 import org.apache.spark.SparkContext;
 import org.apache.spark.h2o.H2OContext;
 import org.apache.spark.ml.spark.ProgressListener;
+import org.apache.spark.ml.FrameMLUtils;
+import org.apache.spark.ml.spark.models.MissingValuesHandling;
 import org.apache.spark.ml.spark.models.svm.SVMModel.SVMOutput;
 import org.apache.spark.mllib.classification.SVMWithSGD;
 import org.apache.spark.mllib.linalg.Vector;
 import org.apache.spark.mllib.linalg.Vectors;
 import org.apache.spark.mllib.regression.LabeledPoint;
 import org.apache.spark.rdd.RDD;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.StructField;
 import org.apache.spark.storage.RDDInfo;
 
+import scala.Tuple2;
 import water.DKV;
+import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.Frame;
-import water.fvec.H2OFrame;
 import water.fvec.Vec;
 import water.util.Log;
 
@@ -100,11 +99,13 @@ public class SVM extends ModelBuilder<SVMModel, SVMParameters, SVMOutput> {
             }
         }
 
-        for (int i = 0; i < _train.numCols(); i++) {
-            Vec vec = _train.vec(i);
-            String vecName = _train.name(i);
-            if (vec.naCnt() > 0 && (null == _parms._ignored_columns || Arrays.binarySearch(_parms._ignored_columns, vecName) < 0)) {
-                error("_train", "Training frame cannot contain any missing values [" + vecName + "].");
+        if(MissingValuesHandling.NotAllowed == _parms._missing_values_handling) {
+            for (int i = 0; i < _train.numCols(); i++) {
+                Vec vec = _train.vec(i);
+                String vecName = _train.name(i);
+                if (vec.naCnt() > 0 && (null == _parms._ignored_columns || Arrays.binarySearch(_parms._ignored_columns, vecName) < 0)) {
+                    error("_train", "Training frame cannot contain any missing values [" + vecName + "].");
+                }
             }
         }
 
@@ -114,7 +115,7 @@ public class SVM extends ModelBuilder<SVMModel, SVMParameters, SVMOutput> {
         for (int i = 0; i < _train.vecs().length; i++) {
             Vec vec = _train.vec(i);
             if (!ignoredCols.contains(_train.name(i)) && !(vec.isNumeric() || vec.isCategorical())) {
-                error("_train", "SVM supports only frames with numeric values (except for result column). But a " + vec.get_type_str() + " was found.");
+                error("_train", "SVM supports only frames with numeric/categorical values (except for result column). But a " + vec.get_type_str() + " was found.");
             }
         }
 
@@ -175,18 +176,26 @@ public class SVM extends ModelBuilder<SVMModel, SVMParameters, SVMOutput> {
             try {
                 model.delete_and_lock(_job);
 
-                RDD<LabeledPoint> training = getTrainingData(
+                Tuple2<RDD<LabeledPoint>, double[]> points = FrameMLUtils.toLabeledPoints(
                         _train,
                         _parms._response_column,
-                        model._output.nfeatures()
+                        model._output.nfeatures(),
+                        _parms._missing_values_handling,
+                        h2oContext,
+                        sqlContext
                 );
+                RDD<LabeledPoint> training = points._1();
                 training.cache();
+
+                if(training.count() == 0 &&
+                        MissingValuesHandling.Skip == _parms._missing_values_handling) {
+                    throw new H2OIllegalArgumentException("No rows left in the dataset after filtering out rows with missing values. Ignore columns with many NAs or set missing_values_handling to 'MeanImputation'.");
+                }
+
 
                 SVMWithSGD svm = new SVMWithSGD();
                 svm.setIntercept(_parms._add_intercept);
-
                 svm.optimizer().setNumIterations(_parms._max_iterations);
-
                 svm.optimizer().setStepSize(_parms._step_size);
                 svm.optimizer().setRegParam(_parms._reg_param);
                 svm.optimizer().setMiniBatchFraction(_parms._mini_batch_fraction);
@@ -207,12 +216,13 @@ public class SVM extends ModelBuilder<SVMModel, SVMParameters, SVMOutput> {
                                 svm.run(training, vec2vec(_parms.initialWeights().vecs()));
                 training.unpersist(false);
 
-
                 sc.listenerBus().listeners().remove(progressBar);
 
                 model._output.weights_$eq(trainedModel.weights().toArray());
                 model._output.iterations_$eq(_parms._max_iterations);
                 model._output.interceptor_$eq(trainedModel.intercept());
+
+                model._output.numMeans_$eq(points._2());
 
                 Frame train = DKV.<Frame>getGet(_parms._train);
                 model.score(train).delete();
@@ -243,61 +253,5 @@ public class SVM extends ModelBuilder<SVMModel, SVMParameters, SVMOutput> {
             }
             return Vectors.dense(dense);
         }
-
-        private RDD<LabeledPoint> getTrainingData(Frame parms, String _response_column, int nfeatures) {
-            return h2oContext.asDataFrame(new H2OFrame(parms), true, sqlContext)
-                    .javaRDD()
-                    .map(new RowToLabeledPoint(nfeatures, _response_column, parms.domains())).rdd();
-        }
     }
 }
-
-class RowToLabeledPoint implements Function<Row, LabeledPoint> {
-    private final int nfeatures;
-    private final String _response_column;
-    private final String[][] domains;
-
-    RowToLabeledPoint(int nfeatures, String response_column, String[][] domains) {
-        this.nfeatures = nfeatures;
-        this._response_column = response_column;
-        this.domains = domains;
-    }
-
-    @Override
-    public LabeledPoint call(Row row) throws Exception {
-        StructField[] fields = row.schema().fields();
-        double[] features = new double[nfeatures];
-        for (int i = 0; i < nfeatures; i++) {
-            features[i] = toDouble(row.get(i), fields[i], domains[i]);
-        }
-
-        return new LabeledPoint(
-                toDouble(row.<String>getAs(_response_column), fields[fields.length - 1], domains[domains.length - 1]),
-                Vectors.dense(features));
-    }
-
-    private double toDouble(Object value, StructField fieldStruct, String[] domain) {
-        if (fieldStruct.dataType().sameType(DataTypes.ByteType)) {
-            return ((Byte) value).doubleValue();
-        }
-
-        if (fieldStruct.dataType().sameType(DataTypes.ShortType)) {
-            return ((Short) value).doubleValue();
-        }
-
-        if (fieldStruct.dataType().sameType(DataTypes.IntegerType)) {
-            return ((Integer) value).doubleValue();
-        }
-
-        if (fieldStruct.dataType().sameType(DataTypes.DoubleType)) {
-            return (Double) value;
-        }
-
-        if (fieldStruct.dataType().sameType(DataTypes.StringType)) {
-            return Arrays.binarySearch(domain, value);
-        }
-
-        throw new IllegalArgumentException("Target column has to be an enum or a number. " + fieldStruct.toString());
-    }
-}
-

--- a/ml/src/main/java/org/apache/spark/ml/spark/models/svm/SVMParameters.java
+++ b/ml/src/main/java/org/apache/spark/ml/spark/models/svm/SVMParameters.java
@@ -1,6 +1,7 @@
 package org.apache.spark.ml.spark.models.svm;
 
 import hex.Model;
+import org.apache.spark.ml.spark.models.MissingValuesHandling;
 import water.Key;
 import water.fvec.Frame;
 
@@ -35,6 +36,7 @@ public class SVMParameters extends Model.Parameters {
     public Updater _updater = Updater.L2;
     public Gradient _gradient = Gradient.Hinge;
     public Key<Frame> _initial_weights = null;
+    public MissingValuesHandling _missing_values_handling = MissingValuesHandling.MeanImputation;
 
     public void validate(SVM svm) {
         if (_max_iterations < 0 || _max_iterations > 1e6) {

--- a/ml/src/main/scala/org/apache/spark/ml/FrameMLUtils.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/FrameMLUtils.scala
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ml
+
+import org.apache.spark.h2o.H2OContext
+import org.apache.spark.ml.spark.models.MissingValuesHandling
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{Row, SQLContext}
+import org.apache.spark.sql.types.{DataTypes, StructField}
+import water.fvec.{Frame, H2OFrame}
+
+object FrameMLUtils {
+  /** 
+    * Converts a H2O Frame into an RDD[LabeledPoint]. Assumes that the last column is the response column which will be used 
+    * as the label. All other columns will be mapped to a vector and used as features. Categorical columns will be mapped to their 
+    * numerical values. 
+    * 
+    * @param frame Input frame to be converted 
+    * @param reponseColumn Column which contains the labels 
+    * @param nfeatures Number of features we want to use 
+    * @param missingHandler Missing values strategy 
+    * @param h2oContext Current H2OContext 
+    * @param sqlContext Current SQLContext 
+    * @return Returns an equivalent RDD[LabeledPoint] and means for each column 
+    */
+  def toLabeledPoints(frame: Frame,
+                      reponseColumn: String,
+                      nfeatures: Int,
+                      missingHandler: MissingValuesHandling,
+                      h2oContext: H2OContext,
+                      sqlContext: SQLContext): (RDD[LabeledPoint], Array[Double]) = {
+    var means: Array[Double] = new Array[Double](nfeatures)
+    val domains = frame.domains()
+
+    val trainingDF = h2oContext.asDataFrame(new H2OFrame(frame))(sqlContext)
+    val fields: Array[StructField] = trainingDF.schema.fields
+    var trainingRDD = trainingDF.rdd
+
+    if (MissingValuesHandling.Skip.eq(missingHandler)) {
+      trainingRDD = trainingRDD.filter(!_.anyNull)
+    } else if (MissingValuesHandling.MeanImputation.eq(missingHandler)) {
+      // Computing the means by hand and not using frame.means() as it does not compute the mean for enum columns
+      means = movingAverage(trainingRDD, fields, domains)
+    }
+
+    (trainingRDD.map(row => {
+      val features = (0 until nfeatures).map{ i =>
+        if (row.isNullAt(i)) means(i)
+        else toDouble(row.get(i), fields(i), domains(i))
+      }.toArray[Double]
+
+      new LabeledPoint(
+        toDouble(row.getAs[String](reponseColumn), fields(fields.length - 1), domains(domains.length - 1)),
+        Vectors.dense(features)
+      )
+    }), means)
+  }
+
+  // Running average so we don't get overflows
+  private[ml] def movingAverage(trainingRDD: RDD[Row],
+                                fields: Array[StructField],
+                                domains: Array[Array[String]]): Array[Double] = {
+    val means = new Array[Double](fields.length)
+    val counts = new Array[Int](means.length)
+    trainingRDD.aggregate(means.zip(counts))(
+      // Compute the average within a RDD partition
+      (agg, row) => {
+        agg.indices.foreach(i => {
+          if (!row.isNullAt(i)) {
+            val value = toDouble(row.get(i), fields(i), domains(i))
+            val delta = value - agg(i)._1
+            val n = agg(i)._2 + 1
+            agg(i) = (agg(i)._1 + delta / n, n)
+          }
+        })
+        agg
+      },
+      // Merge all RDD partition stats
+      (agg1, agg2) => {
+        merge(agg1, agg2)
+      }
+    ).map(_._1)
+  }
+
+  def merge(agg1: Array[(Double, Int)], agg2: Array[(Double, Int)]): Array[(Double, Int)] = {
+    agg1.indices.foreach { idx =>
+      if (agg1(idx)._2 == 0) {
+        agg1(idx) = agg2(idx)
+      } else {
+        val otherMu: Double = agg2(idx)._1
+        val mu: Double = agg1(idx)._1
+        val n = agg1(idx)._2
+        val otherN = agg2(idx)._2
+        val delta = otherMu - mu
+
+        if (otherN * 10 < n) {
+          agg1(idx) = (mu + (delta * otherN) / (n + otherN), n + otherN)
+        } else if (n * 10 < otherN) {
+          agg1(idx) = (otherMu - (delta * n) / (n + otherN), n + otherN)
+        } else {
+          agg1(idx) = ((mu * n + otherMu * otherN) / (n + otherN), n + otherN)
+        }
+      }
+    }
+    agg1
+  }
+
+  private[ml] def toDouble(value: Any, fieldStruct: StructField, domain: Array[String]): Double = {
+    value match {
+      case b: Byte if fieldStruct.dataType == DataTypes.ByteType => b.doubleValue
+      case s: Short if fieldStruct.dataType == DataTypes.ShortType => s.doubleValue
+      case i: Int if fieldStruct.dataType == DataTypes.IntegerType => i.doubleValue
+      case d: Double if fieldStruct.dataType == DataTypes.DoubleType => d
+      case string: String if fieldStruct.dataType == DataTypes.StringType => domain.indexOf(string)
+      case _ => throw new IllegalArgumentException("Target column has to be an enum or a number. " + fieldStruct)
+    }
+  }
+}

--- a/ml/src/main/scala/org/apache/spark/ml/spark/models/MissingValuesHandling.java
+++ b/ml/src/main/scala/org/apache/spark/ml/spark/models/MissingValuesHandling.java
@@ -1,0 +1,5 @@
+package org.apache.spark.ml.spark.models;
+
+public enum MissingValuesHandling {
+    NotAllowed, Skip, MeanImputation
+}

--- a/ml/src/test/scala/org/apache/spark/ml/FrameMLUtilsTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/FrameMLUtilsTest.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ml
+
+import org.apache.spark.SparkContext
+import org.apache.spark.h2o.utils.SharedSparkTestContext
+import org.apache.spark.ml.spark.models.MissingValuesHandling
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{DataTypes, StructField}
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import water.fvec.Vec
+
+@RunWith(classOf[JUnitRunner])
+class FrameMLUtilsTest extends FunSuite with SharedSparkTestContext {
+
+  override def createSparkContext: SparkContext = new SparkContext("local[*]", "test-local", conf = defaultSparkConf)
+
+  test("Should compute the running average.") {
+    val trainRDD = sc.parallelize(Array(Row(1, 2, 3, 2.0, 1), Row(2, 3, 4, 2.5, 2), Row(3, 4, 5, 3.0, null)))
+
+    val means = FrameMLUtils.movingAverage(
+      trainRDD,
+      Array(
+        StructField("F1", DataTypes.IntegerType),
+        StructField("F2", DataTypes.IntegerType),
+        StructField("F3", DataTypes.IntegerType),
+        StructField("F4", DataTypes.DoubleType),
+        StructField("F4", DataTypes.IntegerType)
+      ),
+      new Array(5)
+    )
+
+    assertResult(2)(means(0))
+    assertResult(3)(means(1))
+    assertResult(4)(means(2))
+    assertResult(2.5)(means(3))
+    assertResult(1.5)(means(4))
+
+  }
+
+  test("Should properly cast to double") {
+    assertResult(15.0)(FrameMLUtils.toDouble(15.asInstanceOf[Byte], StructField("F1", DataTypes.ByteType), Array()))
+    assertResult(15.0)(FrameMLUtils.toDouble(15.asInstanceOf[Short], StructField("F1", DataTypes.ShortType), Array()))
+    assertResult(15.0)(FrameMLUtils.toDouble(15.asInstanceOf[Integer], StructField("F1", DataTypes.IntegerType), Array()))
+    assertResult(15.0)(FrameMLUtils.toDouble(15.asInstanceOf[Double], StructField("F1", DataTypes.DoubleType), Array()))
+    assertResult(2.0)(FrameMLUtils.toDouble("15", StructField("F1", DataTypes.StringType), Array("5", "10", "15")))
+    val errField: StructField = StructField("F1", DataTypes.BooleanType)
+    val errMsg = intercept[IllegalArgumentException] {
+      FrameMLUtils.toDouble(true, errField, Array("5", "10", "15"))
+    }
+    assertResult(s"Target column has to be an enum or a number. ${errField.toString}")(errMsg.getMessage)
+  }
+
+  test("Should skip rows with missing values") {
+    val h2oFrame = prepareFrameWithNAs
+
+    val labelPoints = FrameMLUtils.toLabeledPoints(
+      h2oFrame,
+      "C3",
+      3,
+      MissingValuesHandling.Skip,
+      hc,
+      sqlContext
+    )._1.collect()
+
+    assertResult(17)(labelPoints.length)
+    labelPoints.foreach(entry => assertResult(3)(entry.features.numActives))
+
+    //     Clean up
+    h2oFrame.delete()
+  }
+
+  test("Should imput missing values with averages") {
+    val h2oFrame = prepareFrameWithNAs
+
+    val labelPoints = FrameMLUtils.toLabeledPoints(
+      h2oFrame,
+      "C3",
+      3,
+      MissingValuesHandling.MeanImputation,
+      hc,
+      sqlContext
+    )._1.collect()
+
+    assertResult(50)(labelPoints.length)
+    labelPoints.foreach(entry => {
+      assertResult(3)(entry.features.numActives)
+      if(entry.label % 3 == 0) {
+        assertResult(25.5)(entry.features(0))
+      } else if(entry.label % 3 == 1) {
+        assertResult(25.757575757575758)(entry.features(1))
+        assertResult(0.48484848484848486)(entry.features(2))
+      } else {
+        assertResult(entry.label)(entry.features(0))
+        assertResult(entry.label)(entry.features(1))
+      }
+    })
+
+    //     Clean up
+    h2oFrame.delete()
+  }
+
+  private def prepareFrameWithNAs = {
+    val fname: String = "testMetadata.hex"
+    val colNames: Array[String] = Array("C0", "C1", "C2", "C3")
+    val chunkLayout: Array[Long] = Array(50L)
+    val data = Array(
+      (1L to 50L).map(i => Array[Any](i, i, 0, i)).map(arr => {
+        val i = arr(0).asInstanceOf[Long]
+        if (i % 3 == 0) Array[Any](null, i, 1, i)
+        else if (i % 3 == 1) Array[Any](i, null, null, i)
+        else arr
+      }).toArray
+    )
+    makeH2OFrame2(fname, colNames, chunkLayout, data, Array(Vec.T_NUM, Vec.T_NUM, Vec.T_CAT, Vec.T_NUM), Array(null, null, Array("NO", "YES"), null))
+  }
+}

--- a/ml/src/test/scala/org/apache/spark/ml/spark/models/svm/SVMModelTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/spark/models/svm/SVMModelTest.scala
@@ -45,7 +45,7 @@ class SVMModelTest extends FunSuite with SharedSparkTestContext {
     }).cache()
     val trainDF = trainRDD.toDF("Label", "Vector")
 
-    val trainFrame = hc.asH2OFrame(trainDF, "bubbles")
+    val trainFrame = h2oContext.asH2OFrame(trainDF, "bubbles")
     trainFrame.replace(0, trainFrame.vec(0).toCategoricalVec).remove()
 
     val initialWeights = Vectors.dense(1, 1, 1, 1, 1)


### PR DESCRIPTION
- added NA value handling for SVM: mean imputation, skip, not allowed (old variant with an error message)
- means are calculated via RDD as H2OFrame.means() doesn't support enum columns
- changed the SVM model scoring/pojo generation to include column means when running in MeanImputation mode
- refactored tests a bit (frame creation now supports multi column frames)
