### PR TITLE
[SW-201] Methods in water.support classes should be defined using new api

### DIFF
--- a/core/src/main/scala/water/support/DeepLearningSupport.scala
+++ b/core/src/main/scala/water/support/DeepLearningSupport.scala
@@ -23,7 +23,7 @@ import org.apache.spark.h2o._
 
 trait DeepLearningSupport {
 
-  def DLModel(train: H2OFrame, valid: H2OFrame, response: String,
+  def DLModel[T <: Frame](train: T, valid: T, response: String,
               modelId: String = "model",
               epochs: Int = 10, l1: Double = 0.0001, l2: Double = 0.0001,
               activation: Activation = Activation.RectifierWithDropout,

--- a/core/src/main/scala/water/support/GBMSupport.scala
+++ b/core/src/main/scala/water/support/GBMSupport.scala
@@ -22,7 +22,7 @@ import org.apache.spark.h2o._
 
 trait GBMSupport {
 
-  def GBMModel(train: H2OFrame, test: H2OFrame, response: String,
+  def GBMModel[T <: Frame](train: T, test: T, response: String,
                modelId: String = "model",
                ntrees: Int = 50, depth: Int = 6, family: Family = Family.AUTO): GBMModel = {
     import hex.tree.gbm.GBM


### PR DESCRIPTION
Methods in `water.support` classes should be defined as `def method[T <: Frame](fr: T)` instead of `def method(fr: H2OFrame)`