### PR TITLE
[SW-196] Fix wrong output of __str__ on H2OContext

### DIFF
--- a/py/pysparkling/context.py
+++ b/py/pysparkling/context.py
@@ -85,10 +85,11 @@ class H2OContext(object):
         self._ss = SparkSession.builder.getOrCreate()
         self._sql_context = SQLContext(spark_context, self._ss)
         self._jsql_context = self._ss._jwrapped
-
         self._jsc = self._sc._jsc
         self._jvm = self._sc._jvm
         self._gw = self._sc._gateway
+
+        self.is_initialized = False
 
     @staticmethod
     def getOrCreate(spark_context, conf = None):
@@ -118,7 +119,7 @@ class H2OContext(object):
         h2o_context._client_port = jhc.h2oLocalClientPort()
         # Create H2O REST API client
         h2o.init(ip=h2o_context._client_ip, port=h2o_context._client_port, start_h2o=False, strict_version_check=False)
-        h2o.is_initialized = True
+        h2o_context.is_initialized = True
         return h2o_context
 
     def stop(self):
@@ -126,10 +127,10 @@ class H2OContext(object):
         #self._jhc.stop(False)
 
     def __str__(self):
-        if hasattr(self, 'is_initialized'):
+        if self.is_initialized:
           return "H2OContext: ip={}, port={} (open UI at http://{}:{} )".format(self._client_ip, self._client_port, self._client_ip, self._client_port)
         else:
-          return "H2OContext: --not initialized (call getOrCreate())"
+          return "H2OContext: not initialized, call H2OContext.getOrCreate(sc) or H2OContext.getOrCreate(sc, conf)"
 
     def __repr__(self):
         self.show()


### PR DESCRIPTION
This PR fixes the problem of getting wrong output from `__str__` method on h2o context. 

The check for `has_attr` always returned false since it was called on `self` and field `is_initialized` was set on h2o, so the field weren't available in all cases.
This fixes the problem by setting the` is_initialized` attribute on `h2o_context` instance