### PR TITLE
[SW-207] Use correct spark conf in SpreadRDDBuilder

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -253,7 +253,7 @@ class H2OContext (@transient val sparkContext: SparkContext) extends {
     H2O.exit(0)
   }
 
-  private def createSpreadRDD() = new SpreadRDDBuilder(sparkContext,
+  private def createSpreadRDD() = new SpreadRDDBuilder(this,
                                                        H2OContextUtils.guessTotalExecutorSize(sparkContext)).build()
 
 

--- a/core/src/main/scala/org/apache/spark/h2o/SpreadRDDBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/SpreadRDDBuilder.scala
@@ -28,9 +28,10 @@ import scala.annotation.tailrec
   * An H2O specific builder for InvokeOnNodesRDD.
   */
 private[spark]
-class SpreadRDDBuilder(sc: SparkContext,
+class SpreadRDDBuilder(hc: H2OContext,
                        numExecutorHint: Option[Int] = None) extends {
-    val sparkConf = sc.getConf
+    val sparkConf = hc.sparkConf
+    val sc = hc.sparkContext
   } with H2OConf with org.apache.spark.Logging {
 
   val numExecutors = numH2OWorkers


### PR DESCRIPTION
Right now the wrong `SparkConf` was used in `SpreadRDDBuilder` in sparkling water for Spark 1.5.

This PR fixes this problem by passing the builder `sparkConf` from h2oContext instead of from sparkContext. It is because we set additional properties to `sparkConf` in h2o context and we need to have these fields available.