### PR TITLE
[SW-208] Generate all temporary and output artefacts into build dir

### DIFF
--- a/py/build.gradle
+++ b/py/build.gradle
@@ -18,7 +18,10 @@ dependencies {
 // Create a file with version for Python dist task
 //
 task createVersionFile << {
-    File version_file = new File(getProjectDir(), "version.txt")
+    if(!getBuildDir().exists()){
+        getBuildDir().mkdir()
+    }
+    File version_file = new File(getBuildDir(), "version.txt")
     def version_txt = version.replace("-SNAPSHOT","")
     version_file.write(version_txt)
 }
@@ -76,14 +79,14 @@ or
 def copyH2OFromH2OHome(String H2O_HOME){
         copy {
             from "${H2O_HOME}/h2o-py/h2o"
-            into 'h2o'
+            into getBuildDir().absolutePath + File.separator + "h2o"
         }
 }
 
 def copyH2OFromH2OWheel(String H2O_PYTHON_WHEEL){
         copy {
             from zipTree(H2O_PYTHON_WHEEL)
-            into '.'
+            into getBuildDir().absolutePath
             include 'h2o/**'
         }
 }
@@ -106,14 +109,15 @@ task distPython(type: Exec, dependsOn: checkPythonEnv) {
             copyH2OFromH2OWheel(H2O_PYTHON_WHEEL)
         }
 
+
         copy {
             from "${configurations.compile.join(',')}"
-            into 'sparkling_water'
+            into  getBuildDir().absolutePath + File.separator + 'sparkling_water'
             rename ".*", "sparkling_water_assembly.jar"
         }
-        (new File('py/sparkling_water/__init__.py')).write("#Sparkling-water JAR holder for pySparkling module.")
+        (new File(getBuildDir(), "sparkling_water" + File.separator + "__init__.py")).write("#Sparkling-water JAR holder for pySparkling module.")
     }
-    commandLine getOsSpecificCommandLine(["python", "setup.py", "bdist_egg"])
+    commandLine getOsSpecificCommandLine(["python", "setup.py", "egg_info", "--egg-base=${getBuildDir().absolutePath}", "bdist_egg",  "--dist-dir=${getBuildDir().absolutePath+File.separator}dist", ])
 }
 
 configurations{
@@ -185,12 +189,7 @@ check.dependsOn integTestPython
 // Cleanup
 //
 task cleanPython(type: Delete) {
-    delete file("dist/"),
-            file("h2o_pysparkling_${version.substring(0, version.lastIndexOf('.'))}.egg-info/"),
-            fileTree(dir: projectDir, include: '**/*.pyc'),
-            file("version.txt"),
-            file("h2o/"),
-            file("sparkling_water/")
+    delete getBuildDir()
 }
 
 //

--- a/py/setup.py
+++ b/py/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 # Get the version from the relevant file
-with open(path.join(here, 'version.txt'), encoding='utf-8') as f:
+with open(path.join(here, 'build', 'version.txt'), encoding='utf-8') as f:
     version = f.read()
 
 


### PR DESCRIPTION
This PR does exactly what it says. All temporary artefacts created during assembling python package and the output artefacts are put inside `build` directory. 