### PR TITLE
[SW-212] Fix deprecation warning in gradle build system

### DIFF
--- a/gradle/scala.gradle
+++ b/gradle/scala.gradle
@@ -3,8 +3,6 @@ apply from: "$rootDir/gradle/utils.gradle"
 
 // Activate Zinc compiler and configure scalac
 tasks.withType(ScalaCompile) {
-    scalaCompileOptions.useCompileDaemon = false
-    scalaCompileOptions.useAnt = false
     scalaCompileOptions.additionalParameters = ['-target:jvm-1.6']
 }
 


### PR DESCRIPTION
Gradle is deprecating use of ant-based compiler and options connected to it.
 `scalaCompileOptions.useCompileDaemon` is now set to false automatically and will be completely removed in Gradle 3.0

`scalaCompileOptions.useAnt` is also automatically set to false ( trying to assign it will trigger the deprecation warning ) and will also be removed in Gradle 3.0