### PR TITLE
[SW-169] Fix deprecation warnings

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -25,8 +25,10 @@ import org.apache.spark.h2o.backends.internal.InternalH2OBackend
 import org.apache.spark.h2o.converters._
 import org.apache.spark.h2o.utils.{H2OContextUtils, LogUtil, NodeDesc}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.{DataFrame, SQLContext, SparkSession}
 import water._
+
+import scala.annotation.meta.{field, param}
 import scala.collection.mutable
 import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.ClassTag
@@ -56,11 +58,12 @@ import scala.util.control.NoStackTrace
   * @param sparkContext Spark Context
   * @param conf H2O configuration
   */
-class H2OContext private (@transient val sparkContext: SparkContext, @transient conf: H2OConf) extends Logging
+class H2OContext private (@(transient @param @field) val sparkContext: SparkContext, @(transient @param @field) conf: H2OConf) extends Logging
   with Serializable with SparkDataFrameConverter with SupportedRDDConverter with DatasetConverter
   with H2OContextUtils { self =>
 
-  @transient val sqlc: SQLContext = SQLContext.getOrCreate(sparkContext)
+
+  @transient val sqlc: SQLContext = SparkSession.builder().getOrCreate().sqlContext
 
   /** IP of H2O client */
   private var localClientIp: String = _

--- a/core/src/main/scala/org/apache/spark/h2o/converters/DatasetConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/DatasetConverter.scala
@@ -19,6 +19,7 @@ package org.apache.spark.h2o.converters
 
 
 import org.apache.spark.h2o._
+import org.apache.spark.h2o.utils.CrossScalaUtils
 import org.apache.spark.internal.Logging
 
 import scala.language.{implicitConversions, postfixOps}
@@ -30,7 +31,7 @@ trait DatasetConverter extends Logging with ConverterUtils{
   /** Transform Spark's Dataset into H2O Frame */
   def toH2OFrame[T <: Product](hc: H2OContext, ds: Dataset[T], frameKeyName: Option[String])(implicit ttag:TypeTag[T]) = {
     val tpe = ttag.tpe
-    val constructorSymbol = tpe.declaration(nme.CONSTRUCTOR)
+    val constructorSymbol = CrossScalaUtils.getConstructorSymbol(tpe)
     val defaultConstructor =
       if (constructorSymbol.isMethod) constructorSymbol.asMethod
       else {
@@ -38,7 +39,7 @@ trait DatasetConverter extends Logging with ConverterUtils{
         ctors.map { _.asMethod }.find { _.isPrimaryConstructor }.get
       }
 
-    val params: List[(String, Type)] = defaultConstructor.paramss.flatten map {
+    val params: List[(String, Type)] = CrossScalaUtils.getParams(defaultConstructor).flatten map {
       sym => sym.name.toString -> tpe.member(sym.name).asMethod.returnType
     }
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDDLike.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDDLike.scala
@@ -20,12 +20,14 @@ package org.apache.spark.h2o.converters
 import org.apache.spark.Partition
 import water.fvec.{Frame, FrameUtils}
 
+import scala.annotation.meta.{field, getter}
+
 /**
  * Contains functions that are shared between all H2ORDD types (i.e., Scala, Java)
  */
 private[converters] trait H2ORDDLike[T <: Frame] {
   /** Underlying DataFrame */
-  @transient val frame: T
+  @(transient @field @getter) val frame: T
 
   /** Is the external backend in use */
   val isExternalBackend: Boolean

--- a/core/src/main/scala/org/apache/spark/h2o/utils/CrossScalaShared.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/CrossScalaShared.scala
@@ -14,29 +14,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package water.support
 
-import org.apache.spark.SparkContext
-import org.apache.spark.h2o._
-import org.apache.spark.sql.SQLContext
+package org.apache.spark.h2o.utils
 
-import scala.annotation.meta.{field, getter}
+import scala.language.{implicitConversions, postfixOps}
+import scala.reflect.runtime.universe._
 
 /**
- * A simple application trait to define Sparkling Water applications.
- */
-trait SparklingWaterApp {
+  * Trait specifying which methods should each implementation have
+  */
+trait CrossScalaShared {
+  def getConstructorSymbol(tpe: Type): Symbol
 
-  @(transient @field @getter) val sc: SparkContext
-  @(transient @field @getter) val sqlContext: SQLContext
-  @(transient @field @getter) val h2oContext: H2OContext
-
-  def loadH2OFrame(datafile: String) = new H2OFrame(new java.net.URI(datafile))
-
-  def shutdown(): Unit = {
-    // Shutdown Spark
-    sc.stop()
-    // Shutdown H2O explicitly (at least the driver)
-    h2oContext.stop()
-  }
+  def getParams(methodSymbol: MethodSymbol): List[List[Symbol]]
 }

--- a/core/src/main/scala_2.10/org/apache/spark/h2o/utils/CrossScalaUtils.scala
+++ b/core/src/main/scala_2.10/org/apache/spark/h2o/utils/CrossScalaUtils.scala
@@ -14,29 +14,22 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package water.support
 
-import org.apache.spark.SparkContext
-import org.apache.spark.h2o._
-import org.apache.spark.sql.SQLContext
+package org.apache.spark.h2o.utils
 
-import scala.annotation.meta.{field, getter}
+import scala.language.{implicitConversions, postfixOps}
+import scala.reflect.runtime.universe._
 
 /**
- * A simple application trait to define Sparkling Water applications.
- */
-trait SparklingWaterApp {
+  * Utils object which is in both scala 2.10 and scala 2.11 and contains same methods but with implementation tailored
+  * to specific scala version
+  */
+object CrossScalaUtils extends CrossScalaShared {
+  override def getConstructorSymbol(tpe: _root_.scala.reflect.runtime.universe.Type): _root_.scala.reflect.runtime.universe.Symbol = {
+    tpe.declaration(nme.CONSTRUCTOR)
+  }
 
-  @(transient @field @getter) val sc: SparkContext
-  @(transient @field @getter) val sqlContext: SQLContext
-  @(transient @field @getter) val h2oContext: H2OContext
-
-  def loadH2OFrame(datafile: String) = new H2OFrame(new java.net.URI(datafile))
-
-  def shutdown(): Unit = {
-    // Shutdown Spark
-    sc.stop()
-    // Shutdown H2O explicitly (at least the driver)
-    h2oContext.stop()
+  override def getParams(methodSymbol: _root_.scala.reflect.runtime.universe.MethodSymbol): List[List[_root_.scala.reflect.runtime.universe.Symbol]] = {
+    methodSymbol.paramss
   }
 }

--- a/core/src/main/scala_2.11/org/apache/spark/h2o/utils/CrossScalaUtils.scala
+++ b/core/src/main/scala_2.11/org/apache/spark/h2o/utils/CrossScalaUtils.scala
@@ -14,29 +14,22 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package water.support
 
-import org.apache.spark.SparkContext
-import org.apache.spark.h2o._
-import org.apache.spark.sql.SQLContext
+package org.apache.spark.h2o.utils
 
-import scala.annotation.meta.{field, getter}
+import scala.language.{implicitConversions, postfixOps}
+import scala.reflect.runtime.universe._
 
 /**
- * A simple application trait to define Sparkling Water applications.
- */
-trait SparklingWaterApp {
+  * Utils object which is in both scala 2.10 and scala 2.11 and contains same methods but with implementation tailored
+  * to specific scala version
+  */
+object CrossScalaUtils extends CrossScalaShared {
+  override def getConstructorSymbol(tpe: _root_.scala.reflect.runtime.universe.Type): _root_.scala.reflect.runtime.universe.Symbol = {
+    tpe.decl(termNames.CONSTRUCTOR)
+  }
 
-  @(transient @field @getter) val sc: SparkContext
-  @(transient @field @getter) val sqlContext: SQLContext
-  @(transient @field @getter) val h2oContext: H2OContext
-
-  def loadH2OFrame(datafile: String) = new H2OFrame(new java.net.URI(datafile))
-
-  def shutdown(): Unit = {
-    // Shutdown Spark
-    sc.stop()
-    // Shutdown H2O explicitly (at least the driver)
-    h2oContext.stop()
+  override def getParams(methodSymbol: _root_.scala.reflect.runtime.universe.MethodSymbol): List[List[_root_.scala.reflect.runtime.universe.Symbol]] = {
+    methodSymbol.paramLists
   }
 }


### PR DESCRIPTION
This PR fixes deprecation warnings by introducing desired meta-annotaions.

This PR also introduces new trait and object. New trait `CrossScalaShared` is used to specify methods which each scala-version specific implementation should have and `CrossScalaUtils` is object implemented for each scala version with implementation tailored for specific scala.

This way we can utilities functions which will work on both scala versions and won't produce deprecations warnings/other problems in both cases.

