### PR TITLE
[SW-XXX] Start working on SW/Steam integration server

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,7 +43,9 @@ dependencies {
   compile "org.scala-lang:scala-library:${scalaVersion}"
 
   // Steam RPC
-  compile "com.github.briandilley.jsonrpc4j:jsonrpc4j:1.4.6"
+  compile("com.github.briandilley.jsonrpc4j:jsonrpc4j:1.4.6") {
+      exclude(group: "com.fasterxml.jackson.core")
+  }
   compile "javax.portlet:portlet-api:2.0"
 
   // And use scalatest for Scala testing

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -42,6 +42,10 @@ dependencies {
   // And Scala library
   compile "org.scala-lang:scala-library:${scalaVersion}"
 
+  // Steam RPC
+  compile "com.github.briandilley.jsonrpc4j:jsonrpc4j:1.4.6"
+  compile "javax.portlet:portlet-api:2.0"
+
   // And use scalatest for Scala testing
   testCompile "org.scalatest:scalatest_${scalaBaseVersion}:2.2.1"
   testCompile "junit:junit:4.11"

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -62,7 +62,6 @@ class H2OContext private (@(transient @param @field) val sparkContext: SparkCont
   with Serializable with SparkDataFrameConverter with SupportedRDDConverter with DatasetConverter
   with H2OContextUtils { self =>
 
-
   @transient val sqlc: SQLContext = SparkSession.builder().getOrCreate().sqlContext
 
   /** IP of H2O client */
@@ -108,6 +107,10 @@ class H2OContext private (@(transient @param @field) val sparkContext: SparkCont
     // Store this instance so it can be obtained using getOrCreate method
     H2OContext.setInstantiatedContext(this)
     this
+  }
+
+  def awaitStop(): Unit = {
+    backend.awaitStop()
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
@@ -84,7 +84,7 @@ private[backends] trait SharedBackendUtils extends Logging with Serializable {
       ("-nthreads", if (conf.nthreads > 0) conf.nthreads else null))
       .filter(x => x._2 != null)
       .flatMap(x => Seq(x._1, x._2.toString)) ++ // Append single boolean options
-      Seq(("-ga_opt_out", conf.disableGA))
+      Seq(("-ga_opt_out", conf.disableGA), ("-md5skip", conf.md5skip))
         .filter(_._2).map(x => x._1)
 
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedH2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedH2OConf.scala
@@ -49,6 +49,8 @@ trait SharedH2OConf {
   def loginConf     = sparkConf.getOption(PROP_LOGIN_CONF._1)
   def userName      = sparkConf.getOption(PROP_USER_NAME._1)
 
+  def md5skip       = sparkConf.getBoolean(PROP_MD5SKIP._1, PROP_MD5SKIP._2)
+
   def isFailOnUnsupportedSparkParamEnabled = sparkConf.getBoolean(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._2)
   def scalaIntDefaultNum = sparkConf.getInt(PROP_SCALA_INT_DEFAULT_NUM._1, PROP_SCALA_INT_DEFAULT_NUM._2)
   def isH2OReplEnabled = sparkConf.getBoolean(PROP_REPL_ENABLED._1, PROP_REPL_ENABLED._2)
@@ -170,6 +172,9 @@ object SharedH2OConf {
 
   /** Enable/Disable exit on unsupported Spark parameters. */
   val PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM = ("spark.ext.h2o.fail.on.unsupported.spark.param", true)
+
+  /** Skip md5 jar hash check. */
+  val PROP_MD5SKIP = ("spark.ext.h2o.md5skip", false)
 
   private[spark] def defaultLogDir: String = {
     System.getProperty("user.dir") + java.io.File.separator + "h2ologs"

--- a/core/src/main/scala/water/messaging/ExternalMessageChannel.java
+++ b/core/src/main/scala/water/messaging/ExternalMessageChannel.java
@@ -1,0 +1,89 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package water.messaging;
+
+import com.googlecode.jsonrpc4j.*;
+import org.eclipse.jetty.server.Server;
+import water.messaging.driver.DriverHandler;
+import water.messaging.driver.DriverService;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class ExternalMessageChannel implements Runnable {
+
+    // Address of the remote host
+    // TODO the h2o cluster manager needs an endpoint to change this
+    private String addrs;
+    private final DriverService driver;
+    private final String topic;
+
+    /**
+     * @param addrs Remote host address
+     * @param driver Implementation providing getter capabilities from the app layer
+     * @throws Exception
+     */
+    public ExternalMessageChannel(
+            String addrs,
+            DriverService driver,
+            String topic) throws Throwable {
+        this.addrs = addrs;
+        this.driver = driver;
+        this.topic = topic;
+    }
+
+    public void send(final Map<String, Object> payload) throws Throwable {
+        payload.put("Topic", topic);
+        Map<String, Object>[] body = new HashMap[1];
+        body[0] = payload;
+        call("Receive", body);
+    }
+
+    public void call(String method,
+                     Map<String, Object>[] payload) throws Throwable {
+        JsonRpcHttpClient client = new JsonRpcHttpClient(new URL("http://" + addrs + "/h2ocluster"));
+        client.invoke("Handler." + method, payload);
+        client.setContentType("application/json-rpc");
+    }
+
+    @Override
+    public void run() {
+        Server server = new Server(0);
+        server.setHandler(new DriverHandler(driver));
+
+        try {
+            server.start();
+
+            driver.setPort(server.getConnectors()[0].getLocalPort());
+
+            Map<String, Object> payload = new HashMap<>(2);
+
+            Map<String, Object> value = new HashMap<>(3);
+            value.putAll(driver.get(new String[] {"ip", "id", "messaging"}));
+
+            payload.put("Value", value);
+
+            send(payload);
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+    }
+
+}

--- a/core/src/main/scala/water/messaging/driver/Driver.java
+++ b/core/src/main/scala/water/messaging/driver/Driver.java
@@ -52,7 +52,6 @@ public class Driver {
                 .setConf("spark.yarn.submit.waitAppCompletion", "false")
                 // Necessary as we'll be packaging this in a driver jar
                 .setConf("spark.ext.h2o.md5skip", "true")
-                .setConf("spark.ext.h2o.client.ip", "localhost")
                 .setConf(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, extraJava.toString());
 
         for(int i = 0; i < params.size(); i += 2) {

--- a/core/src/main/scala/water/messaging/driver/Driver.java
+++ b/core/src/main/scala/water/messaging/driver/Driver.java
@@ -52,6 +52,7 @@ public class Driver {
                 .setConf("spark.yarn.submit.waitAppCompletion", "false")
                 // Necessary as we'll be packaging this in a driver jar
                 .setConf("spark.ext.h2o.md5skip", "true")
+                .setConf("spark.ext.h2o.client.ip", "localhost")
                 .setConf(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, extraJava.toString());
 
         for(int i = 0; i < params.size(); i += 2) {

--- a/core/src/main/scala/water/messaging/driver/Driver.java
+++ b/core/src/main/scala/water/messaging/driver/Driver.java
@@ -1,0 +1,71 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package water.messaging.driver;
+
+import org.apache.spark.launcher.SparkLauncher;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+public class Driver {
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        String appClass = "water.SparklingWater";
+        List<String> params = new LinkedList<>();
+        StringBuilder extraJava = new StringBuilder();
+        for(String arg : args) {
+            if(arg.contains("appClassName")) {
+                appClass = arg.split("=")[1];
+            } else if(!arg.startsWith("-D")){
+                params.add(arg);
+            } else {
+                extraJava.append(arg);
+                extraJava.append(" ");
+            }
+        }
+
+        SparkLauncher launcher = new SparkLauncher()
+                .setAppResource(Driver.class.getProtectionDomain()
+                        .getCodeSource()
+                        .getLocation()
+                        .getPath())
+                .setMainClass(appClass)
+                .setMaster("yarn")
+                // Important - we don't want it to run on the same node as Steam
+                .setDeployMode("cluster")
+                .setConf("spark.yarn.submit.waitAppCompletion", "false")
+                // Necessary as we'll be packaging this in a driver jar
+                .setConf("spark.ext.h2o.md5skip", "true")
+                .setConf(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, extraJava.toString());
+
+        for(int i = 0; i < params.size(); i += 2) {
+            if("-mem".equals(params.get(i))) {
+                launcher.setConf("spark.executor.memory", params.get(i+1));
+                launcher.setConf("spark.driver.memory", params.get(i+1));
+            } else if("-size".equals(params.get(i))) {
+                launcher.setConf("spark.executor.instances", params.get(i+1));
+            } else if(params.get(i).startsWith("spark.")) {
+                launcher.setConf(params.get(i), params.get(i+1));
+            }
+        }
+
+        launcher.launch().waitFor();
+    }
+
+}

--- a/core/src/main/scala/water/messaging/driver/DriverHandler.java
+++ b/core/src/main/scala/water/messaging/driver/DriverHandler.java
@@ -1,0 +1,44 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package water.messaging.driver;
+
+import com.googlecode.jsonrpc4j.JsonRpcServer;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class DriverHandler extends AbstractHandler {
+
+    private JsonRpcServer jsonRpcServer;
+
+    public DriverHandler(DriverService driver) {
+        this.jsonRpcServer = new JsonRpcServer(new DriverServiceImpl(driver));
+    }
+
+    @Override
+    public void handle(String target,
+                       Request baseRequest,
+                       HttpServletRequest request,
+                       HttpServletResponse response) throws IOException, ServletException {
+        jsonRpcServer.handle(request, response);
+    }
+}

--- a/core/src/main/scala/water/messaging/driver/DriverService.java
+++ b/core/src/main/scala/water/messaging/driver/DriverService.java
@@ -15,22 +15,15 @@
 * limitations under the License.
 */
 
-package org.apache.spark.h2o.backends
+package water.messaging.driver;
 
-import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.NodeDesc
+import com.googlecode.jsonrpc4j.JsonRpcParam;
+import java.util.Map;
 
-trait SparklingBackend {
-  def init(): Array[NodeDesc]
+public interface DriverService {
+    Map<String, Object> get(@JsonRpcParam(value = "name") String[] name);
 
-  def awaitStop(): Unit = {}
+    void stop();
 
-  /**
-    * Check Spark and H2O environment on particular backend, update it if necessary and and warn about possible problems
-    *
-    * @param conf H2O Configuration
-    */
-  def checkAndUpdateConf(conf: H2OConf): H2OConf
-
-  def stop(stopSparkContext: Boolean)
+    void setPort(int port);
 }

--- a/core/src/main/scala/water/messaging/driver/DriverServiceImpl.java
+++ b/core/src/main/scala/water/messaging/driver/DriverServiceImpl.java
@@ -15,22 +15,32 @@
 * limitations under the License.
 */
 
-package org.apache.spark.h2o.backends
+package water.messaging.driver;
 
-import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.NodeDesc
+import com.googlecode.jsonrpc4j.JsonRpcMethod;
 
-trait SparklingBackend {
-  def init(): Array[NodeDesc]
+import java.util.Map;
 
-  def awaitStop(): Unit = {}
+public class DriverServiceImpl implements DriverService {
 
-  /**
-    * Check Spark and H2O environment on particular backend, update it if necessary and and warn about possible problems
-    *
-    * @param conf H2O Configuration
-    */
-  def checkAndUpdateConf(conf: H2OConf): H2OConf
+    private DriverService driver;
 
-  def stop(stopSparkContext: Boolean)
+    public DriverServiceImpl(DriverService driver) {
+        this.driver = driver;
+    }
+
+    @Override
+    @JsonRpcMethod("Driver.Get")
+    public Map<String, Object> get(String[] name) {
+        return driver.get(name);
+    }
+
+    @Override
+    @JsonRpcMethod("Driver.Stop")
+    public void stop() {
+        driver.stop();
+    }
+
+    @Override
+    public void setPort(int port) {}
 }

--- a/core/src/main/scala/water/messaging/driver/SWDriverServiceImpl.scala
+++ b/core/src/main/scala/water/messaging/driver/SWDriverServiceImpl.scala
@@ -1,0 +1,60 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package water.messaging.driver
+
+import java.util
+import java.util.concurrent.CountDownLatch
+
+import org.apache.spark.h2o.H2OContext
+import water.H2O
+
+import scala.annotation.meta.{field, param}
+
+class SWDriverServiceImpl(@(transient @param @field) val hc: H2OContext,
+                          @(transient @param @field) var port: Int) extends DriverService {
+
+  final val stopLatch = new CountDownLatch(1)
+
+  def awaitStop(): Unit = {
+    stopLatch.await()
+  }
+
+  override def stop() = {
+    // DON'T use hc.stop or anything that calls System.exit() -> it will call the shutdown hook
+    // before YARN gets the exit status and will mark the YARN job as failed -> this might mean
+    // a restart of the whole job. Thank you.
+    hc.sparkContext.stop()
+    H2O.orderlyShutdown(1000)
+    stopLatch.countDown()
+  }
+
+  import scala.collection.JavaConverters._
+  override def get(names: Array[String]): util.Map[String, AnyRef] = names.map {
+    case "id" =>
+      ("id", hc.sparkContext.applicationId)
+    case "ip" =>
+      // TODO good ip? share port with the ExternalMessageChannel!
+      val ip: String = hc.h2oLocalClientIp + ":" + hc.h2oLocalClientPort
+      ("ip", ip)
+    case "messaging" =>
+      val ip: String = hc.h2oLocalClientIp + ":" + port
+      ("messaging", ip)
+  }.toMap[String, AnyRef].asJava
+
+  override def setPort(port: Int): Unit = this.port = port
+}

--- a/core/src/main/scala/water/messaging/driver/WithExternalDriver.scala
+++ b/core/src/main/scala/water/messaging/driver/WithExternalDriver.scala
@@ -15,22 +15,18 @@
 * limitations under the License.
 */
 
-package org.apache.spark.h2o.backends
+package water.messaging.driver
 
-import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.NodeDesc
+import org.apache.spark.h2o.H2OContext
 
-trait SparklingBackend {
-  def init(): Array[NodeDesc]
+trait WithExternalDriver {
+  def app(args: Array[String]): H2OContext
 
-  def awaitStop(): Unit = {}
+  def main(args: Array[String]) {
+    val hc = app(args)
 
-  /**
-    * Check Spark and H2O environment on particular backend, update it if necessary and and warn about possible problems
-    *
-    * @param conf H2O Configuration
-    */
-  def checkAndUpdateConf(conf: H2OConf): H2OConf
-
-  def stop(stopSparkContext: Boolean)
+    if(!hc.sparkContext.isStopped) {
+      hc.awaitStop()
+    }
+  }
 }


### PR DESCRIPTION
To run:

1) Steam:
- get this Steam branch https://github.com/h2oai/steam/tree/MD_sw_integration 
- in the etc/vagrant/HDPYarn do vagrant up and vagrant ssh
- do "go build"
- run with sudo `env PATH=$PATH:/usr/local/hadoop/bin YARN_CONF_DIR=/usr/local/hadoop/etc/hadoop SPARK_HOME=/usr/local/spark ./steamY serve master --superuser-name=vagrant --superuser-password=superuser`

! The Steam vagrant env is set up with Java7 so please build the below steps using Java7

2) Spark version:
- get this branch (`MD_steam_integration`)
- run `./gradlew clean install -x test -x integTest`

3) Sample engine application:
- get the droplet from https://github.com/h2oai/h2o-droplets/tree/MD_sw_steam_integ
- [optional] add code to `water.SparklingWater` class (_NOT_ `water.droplet.SparklingWaterDroplet`!)
- from sparkling-water-droplet run `./gradlew externalLauncher`
- zip the jar in `build/libs`
- upload the ZIP through Steam's UI _remember_ to choose Spark as engine
- fill out the other input fields and launch cluster

Possible problems: I think I have something wrong with my YARN/mac setup (network) so I had to add in Sparkling Water in the `water.messaging.driver.Driver` in the Spark Launcher this conf `.setConf("spark.ext.h2o.client.ip", "localhost")`
