### PR TITLE
Improve shell scripts

### DIFF
--- a/bin/pysparkling
+++ b/bin/pysparkling
@@ -10,5 +10,5 @@ checkSparkVersion
 
 
 PYTHONPATH=$PY_EGG_FILE:$PYTHONPATH \
-$SPARK_HOME/bin/pyspark --py-files $PY_EGG_FILE "$@"
+pyspark --py-files $PY_EGG_FILE "$@"
 

--- a/bin/run-example.sh
+++ b/bin/run-example.sh
@@ -35,27 +35,29 @@ export SPARK_PRINT_LAUNCH_COMMAND=1
 VERBOSE= #--verbose
 
 # Derive actual spark.driver.extraJavaOptions value
-EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+if [ -f "$SPARK_HOME/conf/spark-defaults.conf" ]; then
+    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+fi
 
 if [ "$EXAMPLE_MASTER" == "yarn-client" ] || [ "$EXAMPLE_MASTER" == "yarn-cluster" ]; then
 #EXAMPLE_DEPLOY_MODE does not have to be set when executing on yarn
 (
  cd $TOPDIR
- $SPARK_HOME/bin/spark-submit \
+ spark-submit \
  --class $EXAMPLE \
  --master $EXAMPLE_MASTER \
  --driver-memory $EXAMPLE_DRIVER_MEMORY \
  --driver-java-options "$EXAMPLE_H2O_SYS_OPS" \
  --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" \
  $VERBOSE \
- $TOPDIR/assembly/build/libs/$FAT_JAR \
+ $FAT_JAR_FILE \
  "$@"
 )
 else
 VERBOSE=
 (
  cd $TOPDIR
- $SPARK_HOME/bin/spark-submit \
+ spark-submit \
  --class $EXAMPLE \
  --master $EXAMPLE_MASTER \
  --driver-memory $EXAMPLE_DRIVER_MEMORY \
@@ -63,7 +65,7 @@ VERBOSE=
  --deploy-mode $EXAMPLE_DEPLOY_MODE \
  --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" \
  $VERBOSE \
- $TOPDIR/assembly/build/libs/$FAT_JAR \
+ $FAT_JAR_FILE \
  "$@"
 )
 fi

--- a/bin/run-example.sh
+++ b/bin/run-example.sh
@@ -41,8 +41,6 @@ fi
 
 if [ "$EXAMPLE_MASTER" == "yarn-client" ] || [ "$EXAMPLE_MASTER" == "yarn-cluster" ]; then
 #EXAMPLE_DEPLOY_MODE does not have to be set when executing on yarn
-(
- cd $TOPDIR
  spark-submit \
  --class $EXAMPLE \
  --master $EXAMPLE_MASTER \
@@ -55,8 +53,6 @@ if [ "$EXAMPLE_MASTER" == "yarn-client" ] || [ "$EXAMPLE_MASTER" == "yarn-cluste
 )
 else
 VERBOSE=
-(
- cd $TOPDIR
  spark-submit \
  --class $EXAMPLE \
  --master $EXAMPLE_MASTER \
@@ -67,5 +63,4 @@ VERBOSE=
  $VERBOSE \
  $FAT_JAR_FILE \
  "$@"
-)
 fi

--- a/bin/run-python-script.sh
+++ b/bin/run-python-script.sh
@@ -35,8 +35,6 @@ VERBOSE=--verbose
 if [ "$EXAMPLE_MASTER" == "yarn-client" ] || [ "$EXAMPLE_MASTER" == "yarn-cluster" ]; then
 #EXAMPLE_DEPLOY_MODE does not have to be set when executing on yarn
 VERBOSE=
-(
- cd $TOPDIR
  spark-submit \
  --master $SCRIPT_MASTER \
  --driver-memory $SCRIPT_DRIVER_MEMORY \
@@ -49,8 +47,6 @@ VERBOSE=
 )
 else
 VERBOSE=
-(
- cd $TOPDIR
  spark-submit \
  --master $SCRIPT_MASTER \
  --driver-memory $SCRIPT_DRIVER_MEMORY \
@@ -61,5 +57,4 @@ VERBOSE=
  $VERBOSE \
  $SCRIPT \
  "$@"
-)
 fi

--- a/bin/run-python-script.sh
+++ b/bin/run-python-script.sh
@@ -37,7 +37,7 @@ if [ "$EXAMPLE_MASTER" == "yarn-client" ] || [ "$EXAMPLE_MASTER" == "yarn-cluste
 VERBOSE=
 (
  cd $TOPDIR
- $SPARK_HOME/bin/spark-submit \
+ spark-submit \
  --master $SCRIPT_MASTER \
  --driver-memory $SCRIPT_DRIVER_MEMORY \
  --driver-java-options "$SCRIPT_H2O_SYS_OPS" \
@@ -51,7 +51,7 @@ else
 VERBOSE=
 (
  cd $TOPDIR
- $SPARK_HOME/bin/spark-submit \
+ spark-submit \
  --master $SCRIPT_MASTER \
  --driver-memory $SCRIPT_DRIVER_MEMORY \
  --driver-java-options "$SCRIPT_H2O_SYS_OPS" \

--- a/bin/run-sparkling.sh
+++ b/bin/run-sparkling.sh
@@ -14,12 +14,15 @@ DRIVER_MEMORY=${DRIVER_MEMORY:-1G}
 MASTER=${MASTER:-"local-cluster[3,2,1024]"}
 VERBOSE=--verbose
 VERBOSE=
-EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+if [ -f $SPARK_HOME/conf/spark-defaults.conf ]; then
+    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+fi
 
 # Show banner
 banner 
 
 (
  cd $TOPDIR
- $SPARK_HOME/bin/spark-submit "$@" $VERBOSE --driver-memory $DRIVER_MEMORY --master $MASTER --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" --class "$DRIVER_CLASS" $FAT_JAR_FILE
+spark-submit "$@" $VERBOSE --driver-memory $DRIVER_MEMORY --master $MASTER --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" --class "$DRIVER_CLASS" $FAT_JAR_FILE
 )
+

--- a/bin/run-sparkling.sh
+++ b/bin/run-sparkling.sh
@@ -21,8 +21,5 @@ fi
 # Show banner
 banner 
 
-(
- cd $TOPDIR
 spark-submit "$@" $VERBOSE --driver-memory $DRIVER_MEMORY --master $MASTER --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" --class "$DRIVER_CLASS" $FAT_JAR_FILE
-)
 

--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -1,8 +1,12 @@
 function checkSparkHome() {
   # Example class prefix
   if [ ! -f "$SPARK_HOME/bin/spark-submit" ]; then
-    echo "Please setup SPARK_HOME variable to your Spark installation!"
-    exit -1
+    if [ -z "`which spark-submit`" ] ; then
+      echo "Please setup SPARK_HOME variable to your Spark installation!"
+      exit -1
+    fi
+  else
+      export PATH=$SPARK_HOME/bin:$PATH
   fi
 }
 
@@ -23,7 +27,7 @@ if [ -z $TOPDIR ]; then
 fi
 
 function checkSparkVersion() {
-  installed_spark_version=$($SPARK_HOME/bin/spark-submit --version 2>&1 | grep version | sed -e "s/.*version //" | sed -e "s/\([0-9][0-9]*.[0-9][0-9]*\).*/\1/")
+  installed_spark_version=$(spark-submit --version 2>&1 | grep version | sed -e "s/.*version //" | sed -e "s/\([0-9][0-9]*.[0-9][0-9]*\).*/\1/")
   if ! [[ "$SPARK_VERSION" =~ "$installed_spark_version".* ]]; then
     echo "You are trying to use Sparkling Water built for Spark ${SPARK_VERSION}, but your \$SPARK_HOME(=$SPARK_HOME) property points to Spark of version ${installed_spark_version}. Please ensure correct Spark is provided and re-run Sparkling Water."
     exit -1

--- a/bin/sparkling-shell
+++ b/bin/sparkling-shell
@@ -16,12 +16,14 @@ DRIVER_MEMORY=${DRIVER_MEMORY:-2G}
 USER_MASTER=${MASTER:-$(getMasterArg "$@")}
 USER_MASTER=${USER_MASTER:-"$DEFAULT_MASTER"}
 export MASTER="$USER_MASTER"
-EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+if [ -f "$SPARK_HOME/conf/spark-defaults.conf" ]; then
+    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+fi
 
 banner
 
 (
  cd $TOPDIR
  # If extra java properties are defined use them and append our property
- $SPARK_HOME/bin/spark-shell --jars $TOPDIR/assembly/build/libs/$FAT_JAR --driver-memory $DRIVER_MEMORY --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" "$@"
+ spark-shell --jars $FAT_JAR_FILE --driver-memory $DRIVER_MEMORY --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" "$@"
 )

--- a/bin/sparkling-shell
+++ b/bin/sparkling-shell
@@ -22,8 +22,5 @@ fi
 
 banner
 
-(
- cd $TOPDIR
  # If extra java properties are defined use them and append our property
  spark-shell --jars $FAT_JAR_FILE --driver-memory $DRIVER_MEMORY --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" "$@"
-)


### PR DESCRIPTION
This PR implements 2 things:

- Don't fail immediately if SPARK_HOME isn't set: Sometimes the Spark is installed via package manager, or some other means, like, Cloudera parcells.  In this case the `SPARK_HOME` isn't set explicitly, but `spark-shell` & `spark-submit` are available in the `PATH`.  This patch adds for this case, and fail only if both `SPARK_HOME` isn't set, and `spark-submit` isn't available in the `PATH`.  It also fixes explicit use of `FAT_JAR` variable instead of using `FAT_JAR_FILE` that points to the full path to `FAT_JAR`;
- Don't change current directory in scripts: Sometimes you need to run the `spark-shell` or other command from some directory with data, etc., but all scripts right now change directory to the `TOP_DIR`.
