### PR TITLE
[SW-230] Fix windows scripts

### DIFF
--- a/bin/sparkling-env.cmd
+++ b/bin/sparkling-env.cmd
@@ -5,13 +5,13 @@ if not defined TOPDIR (
     exit /b -1
 )
 
-rem Version of this distribution                             
-for /f "tokens=2 delims==" %%i in ('findstr /r "^version=.*$" %TOPDIR%\gradle.properties') do (@set VERSION=%%i)
-for /f "tokens=2 delims==" %%i in ('findstr /r "^h2oMajorVersion=.*$" %TOPDIR%\gradle.properties') do (@set H2O_VERSION=%%i)
-for /f "tokens=2 delims==" %%i in ('findstr /r "^h2oBuild=.*$" %TOPDIR%\gradle.properties') do (@set H2O_BUILD=%%i)
-for /f "tokens=2 delims==" %%i in ('findstr /r "^h2oMajorName=.*$" %TOPDIR%\gradle.properties') do (@set H2O_NAME=%%i)
-for /f "tokens=2 delims==" %%i in ('findstr /r "^sparkVersion=.*$" %TOPDIR%\gradle.properties') do (@set SPARK_VERSION=%%i)
-for /f "tokens=2 delims==" %%i in ('findstr /r "^sparkVersion=.*$" %TOPDIR%\gradle.properties') do (@set SCALA_PARSED_VERSION=%%i)
+rem Version of this distribution
+for /f "tokens=2 delims==" %%i in ('TYPE %TOPDIR%\gradle.properties ^| findstr /r "^version="') do (@set VERSION=%%i)
+for /f "tokens=2 delims==" %%i in ('TYPE %TOPDIR%\gradle.properties ^| findstr /r "^h2oMajorVersion="') do (@set H2O_VERSION=%%i)
+for /f "tokens=2 delims==" %%i in ('TYPE %TOPDIR%\gradle.properties ^| findstr /r "^h2oBuild="') do (@set H2O_BUILD=%%i)
+for /f "tokens=2 delims==" %%i in ('TYPE %TOPDIR%\gradle.properties ^| findstr /r "^h2oMajorName="') do (@set H2O_NAME=%%i)
+for /f "tokens=2 delims==" %%i in ('TYPE %TOPDIR%\gradle.properties ^| findstr /r "^sparkVersion="') do (@set SPARK_VERSION=%%i)
+for /f "tokens=2 delims==" %%i in ('TYPE %TOPDIR%\gradle.properties ^| findstr /r "^scalaBaseVersion="') do (@set SCALA_PARSED_VERSION=%%i)
 
 rem Ensure that scala version contains only major version
 for /f "tokens=1,2 delims=." %%j in ("%SCALA_PARSED_VERSION%") do (@set SCALA_VERSION=%%j.%%k)

--- a/bin/sparkling-shell2.cmd
+++ b/bin/sparkling-shell2.cmd
@@ -29,7 +29,7 @@ rem end of main script
 
 rem define functions
 :checkSparkVersion
-for /f "delims=" %%i in ( 'CMD /C %SPARK_HOME%/bin/spark-submit.cmd --version 2^>^&1 1^>NUL ^| find "version" ') do set linewithversion=%%i
+for /f "delims=" %%i in ( 'CMD /C %SPARK_HOME%/bin/spark-submit.cmd --version 2^>^&1 1^>NUL ^| findstr "version" ') do set linewithversion=%%i
 set INSTALLED_SPARK_VERSION=%linewithversion:~-5%
 
 if NOT "%INSTALLED_SPARK_VERSION%"=="%SPARK_VERSION%" (


### PR DESCRIPTION
This commit fixes several problems in windows scripts

- find instead of findstr was used to find string
- gradle.properties has linux line ending, by using type command we print the result on screen first with correct line endings
  and then it can be processed later
- scala version wasn't detected ( it tried to get scala version from sparkVersion field)