### PR TITLE
[SW-232] rsparkling: fix CRAN note on invalid url

### DIFF
--- a/r/rsparkling/DESCRIPTION
+++ b/r/rsparkling/DESCRIPTION
@@ -19,5 +19,5 @@ LazyData: true
 NeedsCompilation: no
 SystemRequirements: Java (>= 1.6)
 URL: https://github.com/h2oai/sparkling-water/tree/master/r/rsparkling
-BugReports: https://jira.h2o.ai
+BugReports: http://jira.h2o.ai
 RoxygenNote: 5.0.1


### PR DESCRIPTION
Fix for a NOTE on invalid url
```
* checking CRAN incoming feasibility ... NOTE
Maintainer: ‘Erin LeDell <erin@h2o.ai>’

New submission

Non-FOSS package license (file LICENSE)

Found the following (possibly) invalid URLs:
  URL: https://jira.h2o.ai
    From: DESCRIPTION
    Status: Error
    Message: libcurl error code 7
    	Failed to connect to jira.h2o.ai port 443: Connection timed out
```
we do have ssl on our jira, but not on jira.h2o.ai, so it cannot be used here