### PR TITLE
[SW-219] RSparkling: as_h2o_frame should properly name the frame

### DIFF
--- a/r/rsparkling/R/h2o_context.R
+++ b/r/rsparkling/R/h2o_context.R
@@ -37,9 +37,9 @@ h2o_flow <- function(sc) {
 #'
 #' @param sc Object of type \code{spark_connection}.
 #' @param x A \code{spark_dataframe}.
-#'
+#' @param name The name of the H2OFrame
 #' @export
-as_h2o_frame <- function(sc, x) {
+as_h2o_frame <- function(sc, x, name=NULL) {
   # sc is not actually required since the sc is monkey-patched into the Spark DataFrame
   # it is kept as an argument for API consistency
   
@@ -47,7 +47,12 @@ as_h2o_frame <- function(sc, x) {
   x <- sparklyr::spark_dataframe(x)
 
   # Convert the Spark DataFrame to an H2OFrame
-  jhf <- sparklyr::invoke(h2o_context(x), "asH2OFrame", x)
+  if(is.null(name)){
+    jhf <- sparklyr::invoke(h2o_context(x), "asH2OFrame", x)
+  }else{
+    jhf <- sparklyr::invoke(h2o_context(x), "asH2OFrame", x, name)
+  }
+  
   key <- sparklyr::invoke(sparklyr::invoke(jhf, "key"), "toString")
   h2o::h2o.getFrame(key)
 }

--- a/r/rsparkling/tests/test_h2o_name.R
+++ b/r/rsparkling/tests/test_h2o_name.R
@@ -1,0 +1,25 @@
+# Test of transformations from dataframe to h2o frame and from h2o frame back to dataframe
+
+library(testthat)
+library(rsparkling)
+library(dplyr)
+
+# Testing passing name to a dataframe
+test_h2o_name = function(){
+
+   mtcars_tbl <- copy_to(sc, mtcars, overwrite = TRUE)
+   mtcars_hf_name <- as_h2o_frame(sc, mtcars_tbl, name = "frame1")
+
+   expect_equal(h2o.getId(mtcars_hf), "frame1")
+
+
+}
+
+#If Spark is not installed on the machine, otherwise it will not
+spark_install(version = "1.6.2")
+
+#Create a spark connection
+sc <- spark_connect(master = "local")
+
+#Run tests
+test_h2o_name()


### PR DESCRIPTION
*Right now `as_h2o_frame` creates the name of the frame as "frame_rdd_xxx" but it should allow the user to pass actual name of frame: as_h2o_frame(table, "myTable").
*This PR solves this issue.