### PR TITLE
consider adding name parameter to as_spark_dataframe

### DIFF
--- a/r/rsparkling/R/h2o_context.R
+++ b/r/rsparkling/R/h2o_context.R
@@ -42,7 +42,7 @@ h2o_flow <- function(sc) {
 as_h2o_frame <- function(sc, x) {
   # sc is not actually required since the sc is monkey-patched into the Spark DataFrame
   # it is kept as an argument for API consistency
-  
+
   # Ensure we are dealing with a Spark DataFrame (might be e.g. a tbl)
   x <- sparklyr::spark_dataframe(x)
 
@@ -56,11 +56,12 @@ as_h2o_frame <- function(sc, x) {
 #'
 #' @param sc Object of type \code{spark_connection}.
 #' @param x An \code{H2OFrame}.
+#' @param name The name to assign the data frame in Spark.
 #'
 #' @export
-as_spark_dataframe <- function(sc, x) {
+as_spark_dataframe <- function(sc, x, name = deparse(substitute(x))) {
   # TO DO: ensure we are dealing with a H2OFrame
-  
+
   # Get SQLContext
   sqlContext <- sparklyr::invoke_static(sc, "org.apache.spark.sql.SQLContext", "getOrCreate", sparklyr::spark_context(sc))
   # Get H2OContext
@@ -68,5 +69,5 @@ as_spark_dataframe <- function(sc, x) {
   # Invoke H2OContext#asDataFrame method on the backend
   spark_df <- sparklyr::invoke(hc, "asDataFrame", h2o::h2o.getId(x), TRUE, sqlContext)
   # Register returned spark_jobj as a table for dplyr
-  sparklyr::sdf_register(spark_df)
+  sparklyr::sdf_register(spark_df, name = name)
 }

--- a/r/rsparkling/man/as_spark_dataframe.Rd
+++ b/r/rsparkling/man/as_spark_dataframe.Rd
@@ -4,12 +4,14 @@
 \alias{as_spark_dataframe}
 \title{Convert an H2O Frame to a Spark DataFrame}
 \usage{
-as_spark_dataframe(sc, x)
+as_spark_dataframe(sc, x, name = deparse(substitute(x)))
 }
 \arguments{
 \item{sc}{Object of type \code{spark_connection}.}
 
 \item{x}{An \code{H2OFrame}.}
+
+\item{name}{The name to assign the data frame in Spark.}
 }
 \description{
 Convert an H2O Frame to a Spark DataFrame


### PR DESCRIPTION
Some of our users expected a friendly default name once they convert their h2o frames back to spark data frames with `as_spark_dataframe`. Consider setting the default name to the name of the variable `x` which is what `sparklyr` does during `copy_to` and similar methods.
