### PR TITLE
making tests portable, and fixes to pass R check, closes SW-259

### DIFF
--- a/r/examples/example_rsparkling.R
+++ b/r/examples/example_rsparkling.R
@@ -28,7 +28,7 @@ library(rsparkling)
 spark_install(version = "1.6.2")
 
 # Create a spark connection
-sc <- spark_connect(master = "local",version = "1.6.2")
+sc <- spark_connect(master = "local", version = "1.6.2")
 
 # Inspect the H2OContext for our Spark connection
 # This will also start an H2O cluster

--- a/r/rsparkling/R/package.R
+++ b/r/rsparkling/R/package.R
@@ -5,9 +5,9 @@ NULL
 
 # define required spark packages
 spark_dependencies <- function(spark_version, scala_version, ...) {
-  sw_version = getOption("rsparkling.sparklingwater.version", default = NULL)
+  sw_version <- getOption("rsparkling.sparklingwater.version", default = NULL)
   if(is.null(sw_version)){
-    stop("Sparkling Water version is not set. Please choose a correct version")
+    stop("Sparkling Water version is not set. Please choose a correct version using options, for example: options(rsparkling.sparklingwater.version = '1.6.7')")
   }
   if(as.package_version(spark_version)$major != as.package_version(sw_version)$major){
     stop(cat(paste0("Major version of Sparkling Water does not correspond to major Spark version.
@@ -20,13 +20,13 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
      "\nMinor Spark Version = ",as.package_version(spark_version)$minor)))
   }
   spark_dependency(packages = c(
-     sprintf("ai.h2o:sparkling-water-core_%s:%s", scala_version, sw_version),
-     sprintf("ai.h2o:sparkling-water-ml_%s:%s", scala_version, sw_version),
-     sprintf("ai.h2o:sparkling-water-repl_%s:%s", scala_version, sw_version)
+    sprintf("ai.h2o:sparkling-water-core_%s:%s", scala_version, sw_version),
+    sprintf("ai.h2o:sparkling-water-ml_%s:%s", scala_version, sw_version),
+    sprintf("ai.h2o:sparkling-water-repl_%s:%s", scala_version, sw_version)
   ))
 }
 
 .onLoad <- function(libname, pkgname) {
-    register_extension(pkgname)
+  register_extension(pkgname)
 }
 

--- a/r/rsparkling/man/as_h2o_frame.Rd
+++ b/r/rsparkling/man/as_h2o_frame.Rd
@@ -4,14 +4,16 @@
 \alias{as_h2o_frame}
 \title{Convert a Spark DataFrame to an H2O Frame}
 \usage{
-as_h2o_frame(sc, x, name = NULL)
+as_h2o_frame(sc, x, name = NULL, strict_version_check = TRUE)
 }
 \arguments{
 \item{sc}{Object of type \code{spark_connection}.}
 
 \item{x}{A \code{spark_dataframe}.}
 
-\item{name}{The name of the H2OFrame}
+\item{name}{The name of the H2OFrame.}
+
+\item{strict_version_check}{(Optional) Setting this to FALSE does not cross check version of H2O and attempts to connect.}
 }
 \description{
 Convert a Spark DataFrame to an H2O Frame

--- a/r/rsparkling/man/as_spark_dataframe.Rd
+++ b/r/rsparkling/man/as_spark_dataframe.Rd
@@ -4,7 +4,8 @@
 \alias{as_spark_dataframe}
 \title{Convert an H2O Frame to a Spark DataFrame}
 \usage{
-as_spark_dataframe(sc, x, name = deparse(substitute(x)))
+as_spark_dataframe(sc, x, name = paste(deparse(substitute(x)), collapse = ""),
+  strict_version_check = TRUE)
 }
 \arguments{
 \item{sc}{Object of type \code{spark_connection}.}
@@ -12,6 +13,8 @@ as_spark_dataframe(sc, x, name = deparse(substitute(x)))
 \item{x}{An \code{H2OFrame}.}
 
 \item{name}{The name to assign the data frame in Spark.}
+
+\item{strict_version_check}{(Optional) Setting this to FALSE does not cross check version of H2O and attempts to connect.}
 }
 \description{
 Convert an H2O Frame to a Spark DataFrame

--- a/r/rsparkling/man/h2o_context.Rd
+++ b/r/rsparkling/man/h2o_context.Rd
@@ -4,10 +4,12 @@
 \alias{h2o_context}
 \title{Get the H2OContext. Will create the context if it has not been previously created.}
 \usage{
-h2o_context(x)
+h2o_context(x, strict_version_check = TRUE)
 }
 \arguments{
 \item{x}{Object of type \code{spark_connection} or \code{spark_jobj}.}
+
+\item{strict_version_check}{(Optional) Setting this to FALSE does not cross check version of H2O and attempts to connect.}
 }
 \description{
 Get the H2OContext. Will create the context if it has not been previously created.

--- a/r/rsparkling/tests/testthat.R
+++ b/r/rsparkling/tests/testthat.R
@@ -4,5 +4,11 @@ library(sparklyr)
 library(h2o)
 library(rsparkling)
 
-test_check("rsparkling")
+options(rsparkling.sparklingwater.version = Sys.getenv("SPARKLINGWATER_VERSION","1.6.7"),
+        rsparkling.spark.version =          Sys.getenv("SPARK_VERSION","1.6.2"))
 
+if(identical(Sys.getenv("NOT_CRAN"), "true")) { # testthat::skip_on_cran
+  test_check("rsparkling")
+} else {
+  cat("Skipping tests\n")
+}

--- a/r/rsparkling/tests/testthat/test_aaa_install_spark.R
+++ b/r/rsparkling/tests/testthat/test_aaa_install_spark.R
@@ -1,0 +1,19 @@
+
+context("Test if spark is installed, if it isn't it will install spark")
+
+test_that("Test spark installation", {
+  
+  expected_version <- getOption("rsparkling.spark.version")
+  
+  installed_version <- spark_installed_versions()
+  expected_installed <- expected_version %in% installed_version$spark
+  
+  if(!expected_installed) {
+    inst <- spark_install(version=expected_version)
+    expect_true(is.list(inst) && length(inst))
+    installed_version <- spark_installed_versions()
+    expected_installed <- expected_version %in% installed_version$spark
+  }
+  
+  expect_true(expected_installed)
+})

--- a/r/rsparkling/tests/testthat/test_transforms.R
+++ b/r/rsparkling/tests/testthat/test_transforms.R
@@ -3,98 +3,89 @@ context("Test transformations of H2O frames and Spark frames in rsparkling")
 
 test_that("Test transformation from h2o frame to data frame", {
   sc <- spark_connect(master = "local[*]")
-  df = copy_to(sc,as.data.frame(t(c(1,2,3,4,"A"))))
-  df_hex = as_h2o_frame(sc,df)
-  df_tbl = as_spark_dataframe(sc,df_hex)
+  df <- as.data.frame(t(c(1,2,3,4,"A"))) # workaround for sparklyr#316
+  sdf <- copy_to(sc, df)
+  hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
+  sdf2 <- as_spark_dataframe(sc, hf, strict_version_check=FALSE)
 
-  expect_equal(as.data.frame(tally(df_tbl))$n,nrow(df_hex))
-  expect_equal(ncol(df_tbl),ncol(df_hex))
-  expect_equal(colnames(df_tbl),colnames(df_hex))
-
-
+  expect_equal(as.data.frame(tally(sdf2))$n, nrow(hf))
+  expect_equal(ncol(sdf2), ncol(hf))
+  expect_equal(colnames(sdf2), colnames(hf))
 })
 
 test_that("Test transformation of a spark data_frame of bools to an h2o frame of bools", {
   sc <- spark_connect(master = "local[*]")
-  df = copy_to(sc,as.data.frame(t(c(TRUE,FALSE,TRUE,FALSE))),overwrite = TRUE)
-  df_hex = as_h2o_frame(sc,df)
+  df <- as.data.frame(t(c(TRUE,FALSE,TRUE,FALSE)))
+  sdf <- copy_to(sc, df, overwrite = TRUE)
+  hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
 
-  expect_equal(df_hex[1,1],1)
-  expect_equal(df_hex[1,2],0)
-  expect_equal(df_hex[1,3],1)
-  expect_equal(df_hex[1,4],0)
-
-
+  expect_equal(hf[1,1],1)
+  expect_equal(hf[1,2],0)
+  expect_equal(hf[1,3],1)
+  expect_equal(hf[1,4],0)
 })
 
 test_that("Test transformation of a spark data_frame of complex types to an h2o frame of complex types", {
   sc <- spark_connect(master = "local[*]")
-  n = c(2)
-  s = c("aa")
-  b = c(TRUE)
-  df_r = data.frame(n, s, b)
-  df = copy_to(sc,df_r,overwrite = TRUE)
-  df_hex = as_h2o_frame(sc,df)
+  n <- c(2)
+  s <- c("aa")
+  b <- c(TRUE)
+  df <- data.frame(n, s, b)
+  sdf <- copy_to(sc, df, overwrite = TRUE)
+  hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
 
-  expect_equal(df_hex[1,1],2)
-  expect_equal(df_hex[1,2],"aa")
-  expect_equal(df_hex[1,3],1)
-
-
+  expect_equal(hf[1,1],2)
+  expect_equal(hf[1,2],"aa")
+  expect_equal(hf[1,3],1)
 })
 
 test_that("Test transformation of a spark data_frame of float types to an h2o frame of floats", {
   sc <- spark_connect(master = "local[*]")
-  df = copy_to(sc,as.data.frame(t(c(1.5,1.3333333333,178.5555))),overwrite = TRUE)
-  df_hex = as_h2o_frame(sc,df)
+  df <- as.data.frame(t(c(1.5,1.3333333333,178.5555)))
+  sdf <- copy_to(sc, df, overwrite = TRUE)
+  hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
 
-  expect_equal(df_hex[1,1],1.5)
-  expect_equal(df_hex[1,2],1.3333333333)
-  expect_equal(df_hex[1,3],178.5555)
-
-
+  expect_equal(hf[1,1],1.5)
+  expect_equal(hf[1,2],1.3333333333)
+  expect_equal(hf[1,3],178.5555)
 })
 
 test_that("Test transformation of a spark data_frame of int types to an h2o frame of ints", {
   sc <- spark_connect(master = "local[*]")
-  df = copy_to(sc,as.data.frame(t(c(1,125,1778))),overwrite = TRUE)
-  df_hex = as_h2o_frame(sc,df)
+  df <- as.data.frame(t(c(1,125,1778)))
+  sdf <- copy_to(sc, df, overwrite = TRUE)
+  hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
 
-  expect_equal(df_hex[1,1],1)
-  expect_equal(df_hex[1,2],125)
-  expect_equal(df_hex[1,3],1778)
-
+  expect_equal(hf[1,1],1)
+  expect_equal(hf[1,2],125)
+  expect_equal(hf[1,3],1778)
 })
 
 test_that("Test transformation of a spark data_frame of str types to an h2o frame of str", {
   sc <- spark_connect(master = "local[*]")
-  df = copy_to(sc,as.data.frame(t(c("A","B","C"))),overwrite = TRUE)
-  df_hex = as_h2o_frame(sc,df)
+  df <- as.data.frame(t(c("A","B","C")))
+  sdf <- copy_to(sc, df, overwrite = TRUE)
+  hf <- as_h2o_frame(sc, sdf, strict_version_check=FALSE)
 
-  expect_equal(df_hex[1,1],"A")
-  expect_equal(df_hex[1,2],"B")
-  expect_equal(df_hex[1,3],"C")
-
+  expect_equal(hf[1,1],"A")
+  expect_equal(hf[1,2],"B")
+  expect_equal(hf[1,3],"C")
 })
 
 test_that("Test transformation from dataframe to h2o frame", {
   sc <- spark_connect(master = "local[*]")
-   mtcars_tbl <- copy_to(sc, mtcars, overwrite = TRUE)
-   mtcars_hf <- as_h2o_frame(sc, mtcars_tbl)
-
-   expect_equal(as.data.frame(tally(mtcars_tbl))$n,nrow(mtcars_hf))
-   expect_equal(ncol(mtcars_tbl),ncol(mtcars_hf))
-   expect_equal(colnames(mtcars_tbl),colnames(mtcars_hf))
-
+  mtcars_tbl <- copy_to(sc, mtcars, overwrite = TRUE)
+  mtcars_hf <- as_h2o_frame(sc, mtcars_tbl, strict_version_check=FALSE)
+  
+  expect_equal(as.data.frame(tally(mtcars_tbl))$n, nrow(mtcars_hf))
+  expect_equal(ncol(mtcars_tbl), ncol(mtcars_hf))
+  expect_equal(colnames(mtcars_tbl), colnames(mtcars_hf))
 })
-
 
 test_that("Test transformation from dataframe to h2o frame", {
-   sc <- spark_connect(master = "local[*]")
-   mtcars_tbl <- copy_to(sc, mtcars, overwrite = TRUE)
-   mtcars_hf_name <- as_h2o_frame(sc, mtcars_tbl, name = "frame1")
-
-   expect_equal(h2o.getId(mtcars_hf_name), "frame1")
-
+  sc <- spark_connect(master = "local[*]")
+  mtcars_tbl <- copy_to(sc, mtcars, overwrite = TRUE)
+  mtcars_hf_name <- as_h2o_frame(sc, mtcars_tbl, name = "frame1", strict_version_check=FALSE)
+  
+  expect_equal(h2o.getId(mtcars_hf_name), "frame1")
 })
-


### PR DESCRIPTION
rsparkling tests are now portable and _escaped on CRAN_, few minor fixes had been made to pass R check, also additional argument `strict_version_check` was added to make tests working (they can eventually be removed when we improve handling `h2o_context` in rsparkling.
I also added few comments in-line for clarify the changes.
To run unit tests we need to, should run on your local machine.
```sh
R CMD build r/rsparkling
export NOT_CRAN="true"
R CMD check rsparkling_0.1.0.tar.gz
```
To change spark/sw version use env vars:
```sh
# default
export SPARKLINGWATER_VERSION="1.6.7"
export SPARK_VERSION="1.6.2"
# or
export SPARKLINGWATER_VERSION="2.0.0"
export SPARK_VERSION="2.0.1"
```
other values has not been tested, if software in specific version is missing it will be installed (if valid).