### PR TITLE
Add strict version check to h2o_flow()

### DIFF
--- a/r/rsparkling/R/h2o_context.R
+++ b/r/rsparkling/R/h2o_context.R
@@ -26,9 +26,10 @@ h2o_context.spark_jobj <- function(x, strict_version_check = TRUE) {
 #' @inheritParams h2o_context
 #'
 #' @param sc Object of type \code{spark_connection}.
+#' @param strict_version_check (Optional) Setting this to FALSE does not cross check version of H2O and attempts to connect.
 #' @export
-h2o_flow <- function(sc) {
-  flow <- invoke(h2o_context(sc), "h2oLocalClient")
+h2o_flow <- function(sc, strict_version_check = TRUE) {
+  flow <- invoke(h2o_context(sc, strict_version_check = strict_version_check), "h2oLocalClient")
   browseURL(paste0("http://", flow))
 }
 

--- a/r/rsparkling/man/h2o_flow.Rd
+++ b/r/rsparkling/man/h2o_flow.Rd
@@ -4,10 +4,12 @@
 \alias{h2o_flow}
 \title{Open the H2O Flow UI in a browser}
 \usage{
-h2o_flow(sc)
+h2o_flow(sc, strict_version_check = TRUE)
 }
 \arguments{
 \item{sc}{Object of type \code{spark_connection}.}
+
+\item{strict_version_check}{(Optional) Setting this to FALSE does not cross check version of H2O and attempts to connect.}
 }
 \description{
 Open the H2O Flow UI in a browser


### PR DESCRIPTION
* This PR adds a `strict_version_check` parameter to `h2o_flow`.
* This is needed to invoke H2O flow from a rsparkling instance if H2O versions do not match via the `h2o.init()` call. 