### PR TITLE
upgrade h2o dep to next available on CRAN, closes SW-240

### DIFF
--- a/r/rsparkling/DESCRIPTION
+++ b/r/rsparkling/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R: c(
 Imports:
     utils,
     sparklyr (>= 0.3),
-    h2o (>= 3.8.2.9)
+    h2o (>= 3.8.3.3)
 Suggests: dplyr, testthat
 Description: An extension package for sparklyr that provides an R interface to
     H2O Sparkling Water machine learning library.


### PR DESCRIPTION
rsparkling passed tests on h2o 3.8.3.3, which is closest available on CRAN for currently stated h2o dep. There is new rsparkling job _*-h2o-oldrel_ that also runs tests on v3.8.3.3, this will help to maintain support for stated dependency.