### PR TITLE
[MINOR] Add tags of sw and h2o for latest official sparkling-water re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ pip install future
 > To build only a specific module, use, for example, `./gradlew :sparkling-water-examples:build`.
 > To build and test a specific module, use, for example,  `./gradlew :sparkling-water-examples:check`.
 
+Developers who want to build sparkling water and also h2o manually need to ensure ensure they are using
+correct versions of both dependencies. 
+
+Here we provide links to tags of sparkling water latest official release and corresponding h2o official release.
+
+- For Spark 2.0: [sparkling-water-tag](https://github.com/h2oai/sparkling-water/releases/tag/RELEASE-2.0.0)  [H2O-tag](https://github.com/h2oai/h2o-3/releases/tag/jenkins-rel-turing-7)
+- For Spark 1.6: [sparkling-water-tag](https://github.com/h2oai/sparkling-water/releases/tag/RELEASE-1.6.8)  [H2O-tag](https://github.com/h2oai/h2o-3/releases/tag/jenkins-rel-turing-7)
+ 
+
 ---
 <a name="Binary"></a>
 ### Download Binaries


### PR DESCRIPTION
…lease into readme

People who wants to build sparkling-water and h2o manually need to ensure they are using the same sparkling-water and h2o version ( for example in external cluster ). These links points to sparkling-water release tag and corresponding h2o release tag.

This was small change so I decided to make a pull request first and then decide whether we approve or not.