### PR TITLE
[SW-266] H2OContext should not implement Serializable

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -59,7 +59,7 @@ import scala.util.control.NoStackTrace
   * @param conf H2O configuration
   */
 class H2OContext private (@(transient @param @field) val sparkContext: SparkContext, @(transient @param @field) conf: H2OConf) extends Logging
-  with Serializable with SparkDataFrameConverter with SupportedRDDConverter with DatasetConverter
+  with SparkDataFrameConverter with SupportedRDDConverter with DatasetConverter
   with H2OContextUtils { self =>
 
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/ConverterUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/ConverterUtils.scala
@@ -28,7 +28,7 @@ import scala.collection.mutable.ListBuffer
 import scala.reflect.runtime.universe._
 
 
-private[converters] trait ConverterUtils {
+private[converters] trait ConverterUtils extends Serializable {
 
 
   def initFrame[T](keyName: String, names: Array[String]):Unit = {
@@ -90,7 +90,7 @@ private[converters] trait ConverterUtils {
     }
 
     val operation: SparkJob[T] = func(keyName, vecTypes, uploadPlan)
-
+    
     val rows = hc.sparkContext.runJob(preparedRDD, operation) // eager, not lazy, evaluation
     val res = new Array[Long](preparedRDD.partitions.length)
     rows.foreach { case (cidx,  nrows) => res(cidx) = nrows }


### PR DESCRIPTION
H2OContext now doesn't implement `Serializable`, but we need to make `ConverterUtils` `Serializable` because inner class generated by scala to java conversion  references instance of `SparkDataFrameConverter`, `PrimiveRDDConverter` and so on in outer scope.

There is a commit in https://github.com/h2oai/sparkling-water/pull/87 removing `ConverterUtils` and splitting the code in in into `ReadConverterCtxUtils` and `WriteConverterCtxUtils` for better readability and code separation. As a side effect it also removes the need of having `ConverterUtils `and related classes `Serializable`

So maybe we can wait, don't merge this PR and wait for PR-87 ? What do you think @mmalohlava ?