### PR TITLE
[SW-267][FIX] Few fixes to task extending h2o jars

### DIFF
--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -1,5 +1,8 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
@@ -61,6 +64,19 @@ def originalJar = getOrDownloadOriginalJar()
 dependencies {
     artifactsToMerge("ai.h2o:h2o-scala_${scalaBaseVersion}:${h2oVersion}") { transitive = false }
     artifactsToMerge("org.scala-lang:scala-library:${scalaVersion}")
+    artifactsToMerge(project(":sparkling-water-ml")){
+        transitive = false
+    }
+    artifactsToMerge(project(":sparkling-water-core")){
+        transitive = false
+    }
+    artifactsToMerge("org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}"){
+        exclude group: "org.apache.spark", module: "spark-core_${scalaBaseVersion}"
+        exclude group: "org.apache.spark", module: "spark-streaming_${scalaBaseVersion}"
+        exclude group: "org.apache.spark", module: "spark-sql_${scalaBaseVersion}"
+        exclude group: "org.apache.spark", module: "spark-graphx_${scalaBaseVersion}"
+    }
+    artifactsToMerge("org.scalanlp:breeze_${scalaBaseVersion}")
     originalJar = getOrDownloadOriginalJar()
     if (originalJar != null) {
         artifactsToMerge files(originalJar)
@@ -68,23 +84,44 @@ dependencies {
 }
 
 task extendJar(type: ShadowJar) {
-    configurations = [project.configurations.artifactsToMerge]
-    if (originalJar != null) {
-        def h2oJarFile = new File(originalJar).getName().toLowerCase()
-        if (h2oJarFile.contains("h2odriver")) {
-            baseName = "h2odriver_extended"
-        } else {
-            baseName = "h2o_extended"
+    mergeServiceFiles()
+    if(h2oJarFileName(originalJar) != null){
+        manifest {
+            attributes 'Main-Class': getJarMainClass(originalJar)
         }
-    } else {
-        baseName = null
     }
+    configurations = [project.configurations.artifactsToMerge]
+    baseName = h2oJarFileName(originalJar)
     classifier = null
     version = null
 }
 
 if (originalJar != null) {
     build.dependsOn extendJar
+}
+
+def static String h2oJarFileName(String pathToH2OJar){
+    if(pathToH2OJar != null) {
+        return isJarH2ODriver(pathToH2OJar) ? "h2odriver_extended" : "h2o_extended"
+    }else{
+        return null
+    }
+}
+
+def static String getJarMainClass(String pathToH2OJar){
+    return isJarH2ODriver(pathToH2OJar) ? 'water.hadoop.h2odriver' : 'water.H2OApp'
+}
+
+/**
+ * Check if the jar on the path is regular h2o jar or h2o driver jar
+ * @param pathToH2OJar path to the jar to be checked
+ * @return true if it is h2o driver jar, false otherwise
+ */
+def static boolean isJarH2ODriver(String pathToH2OJar){
+    def jarFile = Paths.get(pathToH2OJar)
+    def fs = FileSystems.newFileSystem(jarFile, null)
+    def driverClass = fs.getPath("water/hadoop/h2odriver.class")
+    return Files.exists(driverClass)
 }
 
 /**
@@ -148,7 +185,7 @@ consult h2o documentation for available hadoop versions.
 def static downloadFileFromZip(URL fromZip, File to, String fullFileName) {
     fromZip.withInputStream { is ->
         ZipInputStream zin = new ZipInputStream(is)
-        ZipEntry ze = zin.getNextEntry();
+        ZipEntry ze = zin.getNextEntry()
         // read the files before we hit the one we are interested in
         while (ze.getName() != fullFileName) {
             zin.closeEntry()


### PR DESCRIPTION
 - remove unnecessary semicolon
 - don't depend on file name but check if it's h2o driver jar file based on availability of class specific only to h2o driver jar
 - merge service files
 - Add `Main-Class` attribute to the extended jar