### PR TITLE
Remove python version from egg so it works with 3.x

### DIFF
--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -54,11 +54,12 @@ FAT_JAR_FILE="$TOPDIR/assembly/build/libs/$FAT_JAR"
 major_version=`echo $VERSION | cut -d . -f 1,2`
 version_without_snapshot=`echo $VERSION | cut -d - -f 1`
 
-python_version=`python -c 'import sys; print(".".join(str(x) for x in sys.version_info[0:2]))'`
-PY_EGG="h2o_pysparkling_${major_version}-${version_without_snapshot}-py${python_version}.egg"
-PY_EGG_FILE="$TOPDIR/py/build/dist/$PY_EGG"
-
-checkPyEggFile ${python_version}
+python_version=`../py/pythonVersion.sh`
+if [ ! -z $python_version ]; then
+    PY_EGG="h2o_pysparkling_${major_version}-${version_without_snapshot}-py${python_version}.egg"
+    PY_EGG_FILE="$TOPDIR/py/build/dist/$PY_EGG"
+    checkPyEggFile ${python_version}
+fi
 
 # Default master
 DEFAULT_MASTER="local[*]"

--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -21,6 +21,12 @@ function getMasterArg() {
     done
 }
 
+function checkPyEggFile() {
+  if [ ! -f $PY_EGG_FILE ]; then
+    echo "WARN	Running pysparkling using Python $1 requires ${PY_EGG_FILE} egg file which does not exist. This might be because your project was built using a different Python version. Build the project using appropriate Python version or change your version."
+  fi
+}
+
 if [ -z $TOPDIR ]; then
   echo "Caller has to setup TOPDIR variable!"
   exit -1
@@ -48,9 +54,11 @@ FAT_JAR_FILE="$TOPDIR/assembly/build/libs/$FAT_JAR"
 major_version=`echo $VERSION | cut -d . -f 1,2`
 version_without_snapshot=`echo $VERSION | cut -d - -f 1`
 
-PYTHON_VERSION=`python -c 'import sys; print(".".join(str(x) for x in sys.version_info[0:2]))'`
-PY_EGG="h2o_pysparkling_${major_version}-${version_without_snapshot}-py$PYTHON_VERSION.egg"
+python_version=`python -c 'import sys; print(".".join(str(x) for x in sys.version_info[0:2]))'`
+PY_EGG="h2o_pysparkling_${major_version}-${version_without_snapshot}-py${python_version}.egg"
 PY_EGG_FILE="$TOPDIR/py/build/dist/$PY_EGG"
+
+checkPyEggFile ${python_version}
 
 # Default master
 DEFAULT_MASTER="local[*]"

--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -47,7 +47,9 @@ FAT_JAR="sparkling-water-assembly_$SCALA_VERSION-$VERSION-all.jar"
 FAT_JAR_FILE="$TOPDIR/assembly/build/libs/$FAT_JAR"
 major_version=`echo $VERSION | cut -d . -f 1,2`
 version_without_snapshot=`echo $VERSION | cut -d - -f 1`
-PY_EGG="h2o_pysparkling_${major_version}-${version_without_snapshot}-py2.7.egg"
+
+PYTHON_VERSION=`python -c 'import sys; print(".".join(str(x) for x in sys.version_info[0:2]))'`
+PY_EGG="h2o_pysparkling_${major_version}-${version_without_snapshot}-py$PYTHON_VERSION.egg"
 PY_EGG_FILE="$TOPDIR/py/build/dist/$PY_EGG"
 
 # Default master

--- a/py/README.rst
+++ b/py/README.rst
@@ -17,7 +17,7 @@ Setup and Installation
 
 Prerequisites:
     
-  - Python 2.7
+  - Python 2.7+ or 3.5+
   - Numpy 1.9.2
 
 For windows users, please grab a .whl from http://www.lfd.uci.edu/~gohlke/pythonlibs/#numpy

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -4,12 +4,7 @@ ext {
     FS = File.separator
     FPS = File.pathSeparator
 
-    def command = ["python", "py/pythonVersion.py"]
-    def sout = new StringBuffer(), serr = new StringBuffer()
-    def proc = command.execute()
-    proc.waitForProcessOutput(sout, serr)
-
-    PYTHON_VERSION = sout.toString().trim()
+    PYTHON_VERSION = "py/pythonVersion.sh".execute().text.trim()
 }
 
 

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -3,6 +3,13 @@ apply from: "$rootDir/gradle/utils.gradle"
 ext {
     FS = File.separator
     FPS = File.pathSeparator
+
+    def command = ["python", "py/pythonVersion.py"]
+    def sout = new StringBuffer(), serr = new StringBuffer()
+    def proc = command.execute()
+    proc.waitForProcessOutput(sout, serr)
+
+    PYTHON_VERSION = sout.toString().trim()
 }
 
 
@@ -139,7 +146,7 @@ configurations{
 }
 
 artifacts {
-    eggs file("${project.buildDir}/dist/h2o_pysparkling_${version.substring(0, version.lastIndexOf('.'))}-${version.replace("-SNAPSHOT","")}-py2.7.egg").getAbsoluteFile()
+    eggs file("${project.buildDir}/dist/h2o_pysparkling_${version.substring(0, version.lastIndexOf('.'))}-${version.replace("-SNAPSHOT","")}-py${PYTHON_VERSION}.egg").getAbsoluteFile()
 }
 
 //

--- a/py/examples/notebooks/README.md
+++ b/py/examples/notebooks/README.md
@@ -3,7 +3,7 @@ Launching iPython Examples
 
 ##Prerequisites:
 
-- Python 2.7
+- Python 2.7+ or 3.5+
 
 ---
 

--- a/py/pythonVersion.py
+++ b/py/pythonVersion.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+import sys
+
+print(".".join(str(x) for x in sys.version_info[0:2]))

--- a/py/pythonVersion.py
+++ b/py/pythonVersion.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-import sys
-
-print(".".join(str(x) for x in sys.version_info[0:2]))

--- a/py/pythonVersion.sh
+++ b/py/pythonVersion.sh
@@ -1,0 +1,11 @@
+pythonExists()
+{
+  command -v python >/dev/null 2>&1
+}
+
+if pythonExists; then
+    python -c 'import sys; print(".".join(str(x) for x in sys.version_info[0:2]))'
+else
+    echo ''
+fi
+

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,6 +1,5 @@
 [bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3.
+# This flag says that the code is written to work on both Python 2 and Python 3.
 # I.e.:
 #   1. Your project runs on Python 2 and 3 with no changes (i.e. it does not require 2to3).
 #   2. Your project does not have any C extensions.

--- a/py/setup.py
+++ b/py/setup.py
@@ -13,7 +13,6 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 with open(path.join(here, 'build', 'version.txt'), encoding='utf-8') as f:
     version = f.read()
 
-
 setup(
     name='h2o_pysparkling_'+version[:version.rindex(".")],
 
@@ -30,16 +29,28 @@ setup(
     author_email='support@h2o.ai',
     license='Apache v2',
     classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
         'Development Status :: 5 - Production/Stable',
+
+        # Indicate who your project is intended for
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
+
+        # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: Apache Software License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     keywords='machine learning, data mining, statistical analysis, modeling, big data, distributed, parallel',
 


### PR DESCRIPTION
Until now we were only building pysparkling for 2.7 it seems? And the pysparkling shell had that version hardcoded - think it's about time to support also 3.5 (anyway I need this as I set up all my env in a Python3.5 conda env).

This isn't 100% ready as sometimes, while switching conda env's the `setup.py` part of the gradle build does not recognize the change, I have no idea why though as the `environment` variable seems to be properly set and when I try to run the `pythonVersion.py` script from that task it always prints the right version. Also when I tried rewriting that task from `Exec` task to using a simple `["python", otherArgs].execute()` it also always works but for that I would also need to rewrite the other python tasks - I'm ok with that but not sure if that's the way to go?

tl;dr seems like gradle's exec task has some problems with conda