### PR TITLE
Adds zip64 to assembly-h2o

### DIFF
--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -95,6 +95,7 @@ dependencies {
 }
 
 task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparkling-water-core:jar"]) {
+    zip64 = true
     destinationDir = file("private")
     mergeServiceFiles()
     if(h2oJarFileName(originalJar) != null){

--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -95,6 +95,7 @@ dependencies {
 }
 
 task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparkling-water-core:jar"]) {
+    exclude("META-INF/LICENSE")
     zip64 = true
     destinationDir = file("private")
     mergeServiceFiles()


### PR DESCRIPTION
Running `./gradlew extendJar -x check -PdownloadH2O=cdh5.4` without that option fails because of our zip being too large.