### PR TITLE
Fix extended SW uber jar

### DIFF
--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -95,6 +95,7 @@ dependencies {
 }
 
 task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparkling-water-core:jar"]) {
+    exclude("META-INF/LICENSE")
     zip64 = true
     destinationDir = file("private")
     mergeServiceFiles()


### PR DESCRIPTION
On case insensitive systems (such as MacOS X) there's a conflict when sending the `h2odriver_extended.jar` to Hadoop: `META-INF/LICENSE` (a license file) and `META-INF/license` (a folder containing some licenses). It makes the whole job fail to run.

Other solution would be to rename `license` folder to `licenses` but the uber jar also contains `META-INF/LICENSE.txt` which seems like the same content (Apache 2.0 license).

Similar, old, issue in Mahout for reference: https://issues.apache.org/jira/browse/MAHOUT-780