### PR TITLE
[FIXES] SW-303 adds support for Spark's DecimalType

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -134,6 +134,15 @@ private[h2o] object SparkDataFrameConverter extends Logging {
             case IntegerType => con.put(idx, if (isAry) ary(aryIdx).asInstanceOf[Int] else subRow.getInt(aidx))
             case LongType => con.put(idx, if (isAry) ary(aryIdx).asInstanceOf[Long] else subRow.getLong(aidx))
             case FloatType => con.put(idx, if (isAry) ary(aryIdx).asInstanceOf[Float] else subRow.getFloat(aidx))
+            case _: DecimalType => con.put(idx, if (isAry) {
+              ary(aryIdx).asInstanceOf[BigDecimal].doubleValue()
+            } else {
+              if (isVec) {
+                getVecVal(subRow, aidx, idx - startOfSeq)
+              } else {
+                subRow.getDecimal(aidx).doubleValue()
+              }
+            })
             case DoubleType => con.put(idx, if (isAry) {
               ary(aryIdx).asInstanceOf[Double]
             } else {

--- a/core/src/main/scala/org/apache/spark/h2o/utils/ReflectionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/ReflectionUtils.scala
@@ -127,7 +127,7 @@ object ReflectionUtils {
   /** Method translating SQL types into Sparkling Water types */
   def vecTypeFor(dt : DataType) : Byte =
     dt match {
-      case d: DecimalType => Vec.T_NUM
+      case _: DecimalType => Vec.T_NUM
       case _ => bySparkType(dt).vecType
     }
 

--- a/core/src/main/scala/org/apache/spark/h2o/utils/ReflectionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/ReflectionUtils.scala
@@ -125,7 +125,11 @@ object ReflectionUtils {
   def vecTypeOf[T](implicit ttag: TypeTag[T]) = vecTypeFor(typeOf[T])
 
   /** Method translating SQL types into Sparkling Water types */
-  def vecTypeFor(dt : DataType) : Byte = bySparkType(dt).vecType
+  def vecTypeFor(dt : DataType) : Byte =
+    dt match {
+      case d: DecimalType => Vec.T_NUM
+      case _ => bySparkType(dt).vecType
+    }
 
   import SupportedTypes._
 

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -543,6 +543,15 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     h2oFrameEnum.delete()
   }
 
+  test("SW-303 Decimal column conversion failure") {
+    import sqlContext.implicits._
+    val df = sc.parallelize(Array("ok", "bad", "ok", "bad", "bad")).toDF("status")
+    df.createOrReplaceTempView("responses")
+    val dfDouble = spark.sqlContext.sql("SELECT IF(r.status = 'ok', 0.0, 1.0) AS cancelled FROM responses AS r")
+    val frame = hc.asH2OFrame(dfDouble)
+    assertVectorDoubleValues(frame.vec(0), Seq(0.0, 1.0, 0.0, 1.0, 1.0))
+  }
+
   def fp(it:Iterator[Row]):Unit = {
     println(it.size)
   }


### PR DESCRIPTION
Basic `DecimalType` support since Spark 2.x seems to use it in places where Spark 1.6 used `DoubleType`.