### PR TITLE
Issue 127 (CDH 5.9) fix

### DIFF
--- a/repl/src/main/scala/org/apache/spark/repl/h2o/H2OIMain.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/h2o/H2OIMain.scala
@@ -43,10 +43,12 @@ private[repl] class H2OIMain private(initialSettings: Settings,
     * running
     */
   private def stopClassServer() = {
-    val fieldClassServer = this.getClass.getSuperclass.getDeclaredField("classServer")
-    fieldClassServer.setAccessible(true)
-    val classServer = fieldClassServer.get(this).asInstanceOf[HttpServer]
-    classServer.stop()
+    if(this.getClass.getSuperclass.getDeclaredFields.map(_.getName).contains("classServer")) {
+      val fieldClassServer = this.getClass.getSuperclass.getDeclaredField("classServer")
+      fieldClassServer.setAccessible(true)
+      val classServer = fieldClassServer.get(this).asInstanceOf[HttpServer]
+      classServer.stop()
+    }
   }
 
   /**

--- a/repl/src/main/scala/org/apache/spark/repl/h2o/H2OInterpreter.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/h2o/H2OInterpreter.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.util.Utils
 import org.apache.spark.{Logging, SparkContext}
 
-import scala.Predef.{println => _, _}
 import scala.annotation.tailrec
 import scala.language.{existentials, implicitConversions, postfixOps}
 import scala.reflect._
@@ -352,9 +351,11 @@ object H2OInterpreter{
     * @return
     */
   def classServerUri = {
-    if (org.apache.spark.repl.Main.interp != null) {
+    if (org.apache.spark.repl.Main.interp != null &&
+      org.apache.spark.repl.Main.interp.intp.getClass.getDeclaredFields.map(_.getName).contains("classServerUri")) {
       // Application was started using SparkSubmit
-      org.apache.spark.repl.Main.interp.intp.classServerUri
+      val interpreter = org.apache.spark.repl.Main.interp.intp
+      interpreter.getClass.getField("classServerUri").get(interpreter).asInstanceOf[String]
     } else {
       REPLClassServer.classServerUri
     }


### PR DESCRIPTION
Stop the class server only if present - Spark 1.6.x in CDH 5.9 does not use it.

Still needs to be tested on an actual CDH cluster. I was able to bootstrap SparklingWaterDriver with Spark 1.6.0-CDH5.9.1 as dependency, though.

Edit: this is still a relevant fix (for CDH 5.8+) but doesn't fix the original issue #127 