### PR TITLE
Adds missing method to Spark's 1.6.2 Logging required by CDH

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -20,13 +20,14 @@ package org.apache.spark.h2o
 import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.h2o.backends.external.ExternalBackendConf
 import org.apache.spark.h2o.backends.internal.InternalBackendConf
-import org.apache.spark.{Logging, SparkConf, SparkContext}
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
 
 /**
   * Configuration holder which is representing
   * properties passed from user to Sparkling Water.
   */
-class H2OConf(val sparkConf: SparkConf) extends Logging with InternalBackendConf with ExternalBackendConf {
+class H2OConf(val sparkConf: SparkConf) extends H2OLogging with InternalBackendConf with ExternalBackendConf {
 
   /** Support for creating H2OConf in Java environments */
   def this(jsc: JavaSparkContext) = this(jsc.sc.getConf)

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -59,7 +59,7 @@ import scala.util.control.NoStackTrace
   * @param sparkContext Spark Context
   * @param conf H2O configuration
   */
-class H2OContext private (val sparkContext: SparkContext, conf: H2OConf) extends Logging with H2OContextUtils {
+class H2OContext private (val sparkContext: SparkContext, conf: H2OConf) extends H2OLogging with H2OContextUtils {
   self =>
 
   val sqlc: SQLContext = SQLContext.getOrCreate(sparkContext)
@@ -230,7 +230,7 @@ class H2OContext private (val sparkContext: SparkContext, conf: H2OConf) extends
   // scalastyle:on
 }
 
-object H2OContext extends Logging {
+object H2OContext extends H2OLogging {
 
   private[H2OContext] def setInstantiatedContext(h2oContext: H2OContext): Unit = {
     synchronized {

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
@@ -19,13 +19,13 @@ package org.apache.spark.h2o.backends
 
 import java.io.File
 
-import org.apache.spark.{Logging, SparkEnv}
-import org.apache.spark.h2o.H2OConf
+import org.apache.spark.SparkEnv
+import org.apache.spark.h2o.{H2OConf, H2OLogging}
 
 /**
   * Shared functions which can be used by both backends
   */
-private[backends] trait SharedBackendUtils extends Logging with Serializable{
+private[backends] trait SharedBackendUtils extends H2OLogging with Serializable{
 
   /**
     * Return hostname of this node based on SparkEnv

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.h2o.backends.internal
 
-import org.apache.spark.{Logging, SparkEnv}
+import org.apache.spark.SparkEnv
 import org.apache.spark.h2o.backends.SparklingBackend
 import org.apache.spark.h2o.utils.NodeDesc
-import org.apache.spark.h2o.{H2OConf, H2OContext}
+import org.apache.spark.h2o.{H2OConf, H2OContext, H2OLogging}
 import org.apache.spark.listeners.ExecutorAddNotSupportedListener
 import water.api.RestAPIManager
 import water.{H2O, H2OStarter}
@@ -28,7 +28,7 @@ import water.{H2O, H2OStarter}
 import scala.util.Random
 
 
-class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend with InternalBackendUtils with Logging{
+class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend with InternalBackendUtils with H2OLogging{
 
   override def stop(stopSparkContext: Boolean): Unit = {
     if (stopSparkContext) hc.sparkContext.stop()

--- a/core/src/main/scala/org/apache/spark/h2o/converters/DatasetConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/DatasetConverter.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.h2o.converters
 
 
-import org.apache.spark.Logging
 import org.apache.spark.h2o._
 import org.apache.spark.h2o.utils.CrossScalaUtils
 
@@ -26,7 +25,7 @@ import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.runtime.universe._
 
 
-private[h2o] object DatasetConverter extends Logging {
+private[h2o] object DatasetConverter extends H2OLogging {
 
   /** Transform Spark's Dataset into H2O Frame */
   def toH2OFrame[T <: Product](hc: H2OContext, ds: Dataset[T], frameKeyName: Option[String])(implicit ttag:TypeTag[T]) = {

--- a/core/src/main/scala/org/apache/spark/h2o/converters/LabeledPointConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/LabeledPointConverter.scala
@@ -18,16 +18,16 @@
 package org.apache.spark.h2o.converters
 
 import org.apache.spark.Logging
-import org.apache.spark.TaskContext
 import org.apache.spark.h2o._
 import org.apache.spark.h2o.converters.WriteConverterCtxUtils.UploadPlan
 import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.TaskContext
 import water.fvec.{H2OFrame, Vec}
 import water.{ExternalFrameUtils, Key}
 
 import scala.language.{implicitConversions, postfixOps}
 
-private[converters] object LabeledPointConverter extends Logging {
+private[converters] object LabeledPointConverter extends H2OLogging {
 
   /** Transform RDD[LabeledPoint] to appropriate H2OFrame */
   def toH2OFrame(hc: H2OContext, rdd: RDD[LabeledPoint], frameKeyName: Option[String]): H2OFrame = {

--- a/core/src/main/scala/org/apache/spark/h2o/converters/PrimitiveRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/PrimitiveRDDConverter.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.h2o.converters
 
 
-import org.apache.spark.{Logging, TaskContext}
+import org.apache.spark.TaskContext
 import org.apache.spark.h2o._
 import org.apache.spark.h2o.converters.WriteConverterCtxUtils.UploadPlan
 import org.apache.spark.h2o.utils.ReflectionUtils
@@ -28,7 +28,7 @@ import water.{ExternalFrameUtils, Key}
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe._
 
-private[converters] object PrimitiveRDDConverter extends Logging {
+private[converters] object PrimitiveRDDConverter extends H2OLogging {
 
   def toH2OFrame[T: TypeTag](hc: H2OContext, rdd: RDD[T], frameKeyName: Option[String]): H2OFrame = {
     import ReflectionUtils._

--- a/core/src/main/scala/org/apache/spark/h2o/converters/ProductRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/ProductRDDConverter.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.h2o.converters
 
-
-import org.apache.spark.Logging
 import org.apache.spark.h2o._
 import org.apache.spark.h2o.utils.ReflectionUtils
 import water.{ExternalFrameUtils, Key}
@@ -27,7 +25,7 @@ import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
-private[h2o] object ProductRDDConverter extends Logging {
+private[h2o] object ProductRDDConverter extends H2OLogging {
 
   /** Transform H2OFrame to Product RDD */
   def toRDD[A <: Product : TypeTag : ClassTag, T <: Frame](hc: H2OContext, fr: T): H2ORDD[A, T] = {

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.h2o.converters
 
 import org.apache.spark._
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.h2o.converters.WriteConverterCtxUtils.UploadPlan
+import org.apache.spark.h2o.{H2OContext, H2OLogging}
 import org.apache.spark.h2o.utils.ReflectionUtils._
 import org.apache.spark.h2o.utils.H2OSchemaUtils
 import org.apache.spark.sql.types._
@@ -27,7 +27,7 @@ import org.apache.spark.sql.{DataFrame, H2OFrameRelation, Row, SQLContext}
 import water.{ExternalFrameUtils, Key}
 import water.fvec.{Frame, H2OFrame}
 
-private[h2o] object SparkDataFrameConverter extends Logging {
+private[h2o] object SparkDataFrameConverter extends H2OLogging {
 
   /**
     * Create a Spark DataFrame from given H2O frame.

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextUtils.scala
@@ -17,15 +17,15 @@
 
 package org.apache.spark.h2o.utils
 
-import org.apache.spark.Logging
 import org.apache.spark.h2o.WrongSparkVersion
-import org.apache.spark.SparkContext
 import language.postfixOps
+import org.apache.spark.h2o.H2OLogging
+import org.apache.spark.SparkContext
 
 /**
   * Support methods for H2OContext.
   */
-private[spark] trait H2OContextUtils extends Logging{
+private[spark] trait H2OContextUtils extends H2OLogging{
 
   /**
     * Open browser for given address.

--- a/repl/src/main/scala/org/apache/spark/h2o/H2OLogging.scala
+++ b/repl/src/main/scala/org/apache/spark/h2o/H2OLogging.scala
@@ -1,0 +1,99 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.spark.h2o
+
+import org.apache.log4j.{Level, LogManager, PropertyConfigurator}
+import org.apache.spark.Logging
+import org.apache.spark.util.Utils
+import org.slf4j.impl.StaticLoggerBinder
+
+/**
+  * This is a copy/paste of https://github.com/cloudera/spark/blob/master/core/src/main/scala/org/apache/spark/Logging.scala
+  * Cloudera's 1.6.0-cdh5.9 Spark changed some of the Logging methods to have isInterpreter as an argument, without them if
+  * we compile against vanilla Spark 1.6.0 we'll get runtime AbstractMethodException exceptions.
+  */
+trait H2OLogging extends Logging {
+  protected def initializeLogIfNecessary(isInterpreter: Boolean): Unit = {
+    if (!H2OLogging.initialized) {
+      Logging.initLock.synchronized {
+        if (!H2OLogging.initialized) {
+          initializeLogging(isInterpreter)
+        }
+      }
+    }
+  }
+
+  protected def initializeLogging(isInterpreter: Boolean): Unit = {
+    // Don't use a logger in here, as this is itself occurring during initialization of a logger
+    // If Log4j 1.2 is being used, but is not initialized, load a default properties file
+    val binderClass = StaticLoggerBinder.getSingleton.getLoggerFactoryClassStr
+    // This distinguishes the log4j 1.2 binding, currently
+    // org.slf4j.impl.Log4jLoggerFactory, from the log4j 2.0 binding, currently
+    // org.apache.logging.slf4j.Log4jLoggerFactory
+    val usingLog4j12 = "org.slf4j.impl.Log4jLoggerFactory".equals(binderClass)
+    if (usingLog4j12) {
+      val log4j12Initialized = LogManager.getRootLogger.getAllAppenders.hasMoreElements
+      // scalastyle:off println
+      if (!log4j12Initialized) {
+        val defaultLogProps = "org/apache/spark/log4j-defaults.properties"
+        Option(Utils.getSparkClassLoader.getResource(defaultLogProps)) match {
+          case Some(url) =>
+            PropertyConfigurator.configure(url)
+            System.err.println(s"Using Spark's default log4j profile: $defaultLogProps")
+          case None =>
+            System.err.println(s"Spark was unable to load $defaultLogProps")
+        }
+      }
+
+      if (isInterpreter) {
+        // Use the repl's main class to define the default log level when running the shell,
+        // overriding the root logger's config if they're different.
+        val rootLogger = LogManager.getRootLogger()
+        val replLogger = LogManager.getLogger(logName)
+        val replLevel = Option(replLogger.getLevel()).getOrElse(Level.WARN)
+        if (replLevel != rootLogger.getEffectiveLevel()) {
+          System.err.printf("Setting default log level to \"%s\".\n", replLevel)
+          System.err.println("To adjust logging level use sc.setLogLevel(newLevel).")
+          rootLogger.setLevel(replLevel)
+        }
+      }
+      // scalastyle:on println
+    }
+    H2OLogging.initialized = true
+
+    // Force a call into slf4j to initialize it. Avoids this happening from multiple threads
+    // and triggering this: http://mailman.qos.ch/pipermail/slf4j-dev/2010-April/002956.html
+    log
+  }
+}
+
+private object H2OLogging {
+  @volatile private var initialized = false
+  val initLock = new Object()
+  try {
+    // We use reflection here to handle the case where users remove the
+    // slf4j-to-jul bridge order to route their logs to JUL.
+    val bridgeClass = Utils.classForName("org.slf4j.bridge.SLF4JBridgeHandler")
+    bridgeClass.getMethod("removeHandlersForRootLogger").invoke(null)
+    val installed = bridgeClass.getMethod("isInstalled").invoke(null).asInstanceOf[Boolean]
+    if (!installed) {
+      bridgeClass.getMethod("install").invoke(null)
+    }
+  } catch {
+    case e: ClassNotFoundException => // can't log anything yet so just fail silently
+  }
+}

--- a/repl/src/main/scala/org/apache/spark/repl/h2o/BaseH2OInterpreter.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/h2o/BaseH2OInterpreter.scala
@@ -24,7 +24,9 @@ package org.apache.spark.repl.h2o
 
 
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.{Logging, SparkConf, SparkContext}
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
+import org.apache.spark.h2o.H2OLogging
 
 import scala.annotation.tailrec
 import scala.language.{existentials, implicitConversions, postfixOps}
@@ -38,7 +40,7 @@ import scala.tools.nsc.interpreter.{Results => IR, _}
   * @param sparkContext spark context
   * @param sessionId session ID for interpreter
   */
-private[repl] abstract class BaseH2OInterpreter(val sparkContext: SparkContext, var sessionId: Int) extends Logging {
+private[repl] abstract class BaseH2OInterpreter(val sparkContext: SparkContext, var sessionId: Int) extends H2OLogging {
 
   private val ContinueString = "     | "
   private val consoleStream = new IntpConsoleStream()


### PR DESCRIPTION
CDH 5.9 rewrote the Logging class used by Spark (and us), changing some method signature, this PR adds those methods to a new trait and uses the new trait for logging instead.