### PR TITLE
[SW-316] Encryption support to newly created H2O external clusters

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -40,20 +40,20 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
 
   def launchH2OOnYarn(conf: H2OConf): String = {
 
-    var cmdToLaunch = Seq[String]("hadoop")
+    var cmdToLaunch = Seq[String]("hadoop",
+      "jar", conf.h2oDriverPath.get)
 
     conf.sslConf match {
       case Some(ssl) =>
-        cmdToLaunch ++ Array("-internal_security", ssl)
         val sslConfig = new Properties()
         sslConfig.load(new FileInputStream(ssl))
         cmdToLaunch = cmdToLaunch ++ Array("-files", sslConfig.get("h2o_ssl_jks_internal") + "," + sslConfig.get("h2o_ssl_jts"))
+        cmdToLaunch = cmdToLaunch ++ Array("-internal_security", ssl)
+        logInfo(s"Running external cluster in encrypted mode with config $ssl")
       case _ =>
     }
 
     cmdToLaunch = cmdToLaunch ++ Seq[String](
-      "jar",
-      conf.h2oDriverPath.get,
       conf.YARNQueue.map("-Dmapreduce.job.queuename=" + _ ).getOrElse(""),
       "-nodes", conf.numOfExternalH2ONodes.get,
       "-notify", conf.clusterInfoFile.get,
@@ -65,7 +65,7 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
     )
 
     // start external h2o cluster and log the output
-    logInfo("Command used to start H2O on yarn: " + cmdToLaunch.mkString)
+    logInfo("Command used to start H2O on yarn: " + cmdToLaunch.mkString(" "))
     import scala.sys.process._
     val processOut = new StringBuffer()
     val processErr = new StringBuffer()

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -44,7 +44,7 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
 
     conf.sslConf match {
       case Some(ssl) =>
-        cmdToLaunch ++ Array("-internal_security_config", ssl)
+        cmdToLaunch ++ Array("-internal_security", ssl)
         val sslConfig = new Properties()
         sslConfig.load(new FileInputStream(ssl))
         cmdToLaunch = cmdToLaunch ++ Array("-files", sslConfig.get("h2o_ssl_jks_internal") + "," + sslConfig.get("h2o_ssl_jts"))

--- a/core/src/main/scala/org/apache/spark/network/Security.scala
+++ b/core/src/main/scala/org/apache/spark/network/Security.scala
@@ -16,6 +16,8 @@
 */
 package org.apache.spark.network
 
+import java.io.File
+
 import org.apache.spark.SparkContext
 import org.apache.spark.deploy.SparkHadoopUtil
 import water.network.SecurityUtils
@@ -28,7 +30,7 @@ object Security {
     if(SparkHadoopUtil.get.isYarnMode) {
       sc.conf.set("spark.yarn.dist.files", s"${sslPair.jks.path},$config")
     } else {
-      sc.addFile(sslPair.jks.path)
+      sc.addFile(if (sslPair.jks.path.isEmpty) sslPair.jks.name else sslPair.jks.path + File.separator + sslPair.jks.name)
       sc.addFile(config)
     }
     sc.conf.set("spark.ext.h2o.internal_security_conf", config)

--- a/core/src/main/scala/org/apache/spark/network/Security.scala
+++ b/core/src/main/scala/org/apache/spark/network/Security.scala
@@ -18,22 +18,29 @@ package org.apache.spark.network
 
 import java.io.File
 
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.h2o.H2OConf
+import org.apache.spark.internal.Logging
 import water.network.SecurityUtils
 
-object Security {
+object Security extends Logging {
 
-  def enableSSL(sc: SparkContext) = {
+  def enableSSL(sc: SparkContext, conf: SparkConf): Unit = {
     val sslPair = SecurityUtils.generateSSLPair()
     val config = SecurityUtils.generateSSLConfig(sslPair)
     if(SparkHadoopUtil.get.isYarnMode) {
-      sc.conf.set("spark.yarn.dist.files", s"${sslPair.jks.path},$config")
+      conf.set("spark.yarn.dist.files", s"${sslPair.jks.path},$config")
     } else {
       sc.addFile(if (sslPair.jks.path.isEmpty) sslPair.jks.name else sslPair.jks.path + File.separator + sslPair.jks.name)
       sc.addFile(config)
     }
-    sc.conf.set("spark.ext.h2o.internal_security_conf", config)
+    conf.set("spark.ext.h2o.internal_security_conf", config)
+    logInfo(s"Added spark.ext.h2o.internal_security_conf configuration set to $config")
   }
+
+  def enableSSL(sc: SparkContext): Unit = enableSSL(sc, sc.conf)
+
+  def enableSSL(sc: SparkContext, conf: H2OConf): Unit = enableSSL(sc, conf.sparkConf)
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,11 @@
 group=ai.h2o
 version=2.0.99999-SNAPSHOT
 # Major version of H2O release
-h2oMajorVersion=3.11.0
+h2oMajorVersion=3.10.1
 # Name of H2O major version
 h2oMajorName=turnbull
 # H2O Build version, defined here to be overriden by -P option
-h2oBuild=99999
+h2oBuild=2
 # Spark version
 sparkVersion=2.0.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,11 @@
 group=ai.h2o
 version=2.0.99999-SNAPSHOT
 # Major version of H2O release
-h2oMajorVersion=3.10.1
+h2oMajorVersion=3.11.0
 # Name of H2O major version
 h2oMajorName=turnbull
 # H2O Build version, defined here to be overriden by -P option
-h2oBuild=2
+h2oBuild=99999
 # Spark version
 sparkVersion=2.0.1
 


### PR DESCRIPTION
This this is the only change needed in SW as the actual encryption/decryption is done on the H2O core side. This will need an H2O core version bump to work properly (with actual encryption, as it is now it should still work but the data between Spark nodes and H2O nodes won't be encrypted).

EDIT: this PR needs changes from https://github.com/h2oai/h2o-3/pull/727 to be fully functional, without them it will be working fine except for external SSL mode.