### PR TITLE
[SW-342][SPARK-2.1] Fixed detection of Spark version.

### DIFF
--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -27,7 +27,7 @@ if [ -z $TOPDIR ]; then
 fi
 
 function checkSparkVersion() {
-  installed_spark_version=$(spark-submit --version 2>&1 | grep version | sed -e "s/.*version //" | sed -e "s/\([0-9][0-9]*.[0-9][0-9]*\).*/\1/")
+  installed_spark_version=$(spark-submit --version 2>&1 | grep version | grep -v Scala | sed -e "s/.*version //" | sed -e "s/\([0-9][0-9]*.[0-9][0-9]*\).*/\1/")
   if ! [[ "$SPARK_VERSION" =~ "$installed_spark_version".* ]]; then
     echo "You are trying to use Sparkling Water built for Spark ${SPARK_VERSION}, but your \$SPARK_HOME(=$SPARK_HOME) property points to Spark of version ${installed_spark_version}. Please ensure correct Spark is provided and re-run Sparkling Water."
     exit -1


### PR DESCRIPTION
This is Spark 2.1 specific fix, since the code used to detect Spark version was confused by reported Scala version:
```
➜  sparkling-water git:(master) ✗ $SPARK_HOME/bin/spark-submit --version 2>&1 | grep version | sed -e "s/.*version //" | sed -e "s/\([0-9][0-9]*.[0-9][0-9]*\).*/\1/"
2.1
2.11
```