### PR TITLE
[SW-333] Reporting via yarn resource manager UI

### DIFF
--- a/core/src/main/java/org/apache/spark/h2o/ui/SparklingWaterUITab.scala
+++ b/core/src/main/java/org/apache/spark/h2o/ui/SparklingWaterUITab.scala
@@ -17,7 +17,7 @@ private[h2o] class SparklingWaterUITab(val hc: H2OContext)
   val parent = getSparkUI(hc)
 
   attachPage(new SparklingWaterInfoPage(this))
-
+  
   def attach() {
     getSparkUI(hc).attachTab(this)
   }


### PR DESCRIPTION
This change:
  - attach tags with created H2O job cluster:
     - "h2o/sparkling-water"
     - "sparkling-water/spark/<spark_job_app_id>"

  - change name of create H2O Yarn job to `H2O_via_SparklingWater_<spark_job_app_id>`