### PR TITLE
[SW-362] Fix Pysparkling by fixing initialization of spark session in…

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -27,7 +27,7 @@ import org.apache.spark.h2o.converters._
 import org.apache.spark.h2o.ui.SparklingWaterUITab
 import org.apache.spark.h2o.utils.{H2OContextUtils, LogUtil, NodeDesc}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{DataFrame, SQLContext, SparkSession}
+import org.apache.spark.sql.{DataFrame, SQLContext}
 import water._
 
 import scala.collection.mutable
@@ -61,9 +61,6 @@ import scala.util.control.NoStackTrace
   */
 class H2OContext private (val sparkContext: SparkContext, conf: H2OConf) extends Logging with H2OContextUtils {
   self =>
-
-  val sqlc: SQLContext = SparkSession.builder().getOrCreate().sqlContext
-
   val announcementService = AnnouncementServiceFactory.create(conf)
 
   /** IP of H2O client */
@@ -94,7 +91,7 @@ class H2OContext private (val sparkContext: SparkContext, conf: H2OConf) extends
   // also with regards to used backend and store the fix the state of prepared configuration
   // so it can't be changed anymore
   /** H2O and Spark configuration */
-  val _conf = backend.checkAndUpdateConf(conf).clone()
+  val _conf: H2OConf = backend.checkAndUpdateConf(conf).clone()
 
   /**
     * This method connects to external H2O cluster if spark.ext.h2o.externalClusterMode is set to true,

--- a/py/pysparkling/context.py
+++ b/py/pysparkling/context.py
@@ -10,6 +10,7 @@ import h2o
 from pysparkling.conversions import FrameConversions as fc
 import warnings
 
+
 def _monkey_patch_H2OFrame(hc):
     @staticmethod
     def determine_java_vec_type(vec):
@@ -26,7 +27,6 @@ def _monkey_patch_H2OFrame(hc):
                 return "int"
         else:
             return "real"
-
 
     def get_java_h2o_frame(self):
         if hasattr(self, '_java_frame'):
@@ -54,12 +54,12 @@ def _is_of_simple_type(rdd):
     else:
         return False
 
+
 def _get_first(rdd):
     if rdd.isEmpty():
         raise ValueError('rdd is empty')
 
     return rdd.first()
-
 
 
 class H2OContext(object):
@@ -77,7 +77,6 @@ class H2OContext(object):
 
         except:
             raise
-
 
     def __do_init(self, spark_context):
         self._sc = spark_context
@@ -104,8 +103,8 @@ class H2OContext(object):
         """
         h2o_context = H2OContext(spark_context)
 
-        jvm = h2o_context._jvm # JVM
-        jsc = h2o_context._jsc # JavaSparkContext
+        jvm = h2o_context._jvm  # JVM
+        jsc = h2o_context._jsc  # JavaSparkContext
 
         if conf is not None:
             selected_conf = conf
@@ -128,9 +127,9 @@ class H2OContext(object):
 
     def __str__(self):
         if self.is_initialized:
-          return "H2OContext: ip={}, port={} (open UI at http://{}:{} )".format(self._client_ip, self._client_port, self._client_ip, self._client_port)
+            return "H2OContext: ip={}, port={} (open UI at http://{}:{} )".format(self._client_ip, self._client_port, self._client_ip, self._client_port)
         else:
-          return "H2OContext: not initialized, call H2OContext.getOrCreate(sc) or H2OContext.getOrCreate(sc, conf)"
+            return "H2OContext: not initialized, call H2OContext.getOrCreate(sc) or H2OContext.getOrCreate(sc, conf)"
 
     def __repr__(self):
         self.show()

--- a/repl/src/main/scala/org/apache/spark/repl/h2o/BaseH2OInterpreter.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/h2o/BaseH2OInterpreter.scala
@@ -50,7 +50,6 @@ private[repl] abstract class BaseH2OInterpreter(val sparkContext: SparkContext, 
   protected var intp: H2OIMain = _
   private var in: InteractiveReader = _
   private[repl] var pendingThunks: List[() => Unit] = Nil
-  val sparkConf = sparkContext.getConf
 
   def closeInterpreter() {
     if (intp ne null) {
@@ -101,7 +100,7 @@ private[repl] abstract class BaseH2OInterpreter(val sparkContext: SparkContext, 
   private def initializeInterpreter(): Unit = {
     settings = createSettings()
     intp = createInterpreter()
-    val spark = SparkSession.builder().config(sparkConf).getOrCreate()
+    val spark = SparkSession.builder().getOrCreate()
     addThunk(
       intp.beQuietDuring{
         intp.bind("sc", "org.apache.spark.SparkContext", sparkContext, List("@transient"))

--- a/repl/src/main/scala_2.11/org/apache/spark/repl/h2o/H2OInterpreter.scala
+++ b/repl/src/main/scala_2.11/org/apache/spark/repl/h2o/H2OInterpreter.scala
@@ -75,6 +75,7 @@ class H2OInterpreter(sparkContext: SparkContext, sessionId: Int) extends BaseH2O
     settings
   }
 
+
   override def valueOfTerm(term: String): Option[Any] = {
     try Some(intp.eval(term))  catch { case _ : Exception => None }
   }


### PR DESCRIPTION
…side repl

See brief explanation here https://0xdata.atlassian.net/browse/SW-362

This commit also brings  tiny stylistic changes and removes `sqlc` from `H2OContext` since it's not used there anywhere