### PR TITLE
[SW-389] Print extended JAR  task every time when extendJar is called

### DIFF
--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -97,18 +97,18 @@ dependencies {
 task printExtendedJarLocation(){
     doLast {
         def fileName = h2oJarFileName(originalJar)
-        println(new File(projectDir, "private${File.separator}extended${File.separator}${fileName}.jar"))
+        println(file("private/extended/${fileName}.jar"))
     }
 }
 
 clean.doFirst{
-   delete "${projectDir}${File.separator}private${File.separator}extended"
+   delete file("private/extended")
 }
 
 task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparkling-water-core:jar", "clean"]) {
     exclude("META-INF/LICENSE")
     zip64 = true
-    destinationDir = file("private${File.separator}extended")
+    destinationDir = file("private/extended")
     mergeServiceFiles()
     def fileName = h2oJarFileName(originalJar)
     if(fileName != null){
@@ -120,7 +120,7 @@ task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparklin
     baseName = fileName
     classifier = null
     version = null
-    new File(projectDir, "private${File.separator}extended${File.separator}${fileName}.jar")
+    new File(projectDir, "private/extended/${fileName}.jar")
     finalizedBy "printExtendedJarLocation"
 }
 

--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -94,10 +94,21 @@ dependencies {
     }
 }
 
-task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparkling-water-core:jar"]) {
+task printExtendedJarLocation(){
+    doLast {
+        def fileName = h2oJarFileName(originalJar)
+        println(new File(projectDir, "private${File.separator}extended${File.separator}${fileName}.jar"))
+    }
+}
+
+clean.doFirst{
+   delete "${projectDir}${File.separator}private${File.separator}extended"
+}
+
+task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparkling-water-core:jar", "clean"]) {
     exclude("META-INF/LICENSE")
     zip64 = true
-    destinationDir = file("private")
+    destinationDir = file("private${File.separator}extended")
     mergeServiceFiles()
     def fileName = h2oJarFileName(originalJar)
     if(fileName != null){
@@ -109,9 +120,8 @@ task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparklin
     baseName = fileName
     classifier = null
     version = null
-    doLast{
-        println(new File(projectDir, "private${File.separator}${fileName}.jar"))
-    }
+    new File(projectDir, "private${File.separator}extended${File.separator}${fileName}.jar")
+    finalizedBy "printExtendedJarLocation"
 }
 
 task printHadoopDistributions(){
@@ -153,11 +163,7 @@ def getSupportedHadoopDistributions(){
     def jsonResp = new JsonSlurper().parseText(buildInfo)
     // we need to ensure that the distribution names does not contain minor versions
     def distributions = jsonResp.hadoop_distributions.collect{ it.distribution }
-    def parsed = distributions.collect{ distro ->
-        def splits = distro.split("\\.")
-        "${splits[0]}.${splits[1]}"
-    }
-    return parsed.join(" ")
+    return distributions.join(" ")
 }
 /**
  * Method determining whether the h2o or h2o driver jar is available.

--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -101,6 +101,10 @@ task printExtendedJarLocation(){
     }
 }
 
+task cleanH2OJars(type: Delete){
+    delete(file("private/downloaded"))
+}
+
 clean.doFirst{
    delete file("private/extended")
 }


### PR DESCRIPTION
This change also removes the part where we parse version in format x.y from hadoop distro as the parsing is no longer needed. The distributions have always name like that