### PR TITLE
[SW-398] Specify timeout for reading/writing confirmation

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -41,6 +41,8 @@ trait ExternalBackendConf extends SharedBackendConf {
   def clusterStartTimeout = sparkConf.getInt(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, PROP_EXTERNAL_CLUSTER_START_TIMEOUT._2)
   def clientConnectionTimeout = sparkConf.getInt(PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._1, PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._2)
   def clientCheckRetryTimeout = sparkConf.getInt(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._2)
+  def externalReadConfirmationTimeout = sparkConf.getInt(PROP_EXTERNAL_READ_TIMEOUT._1, PROP_EXTERNAL_READ_TIMEOUT._2)
+  def externalWriteConfirmationTimeout = sparkConf.getInt(PROP_EXTERNAL_WRITE_TIMEOUT._1, PROP_EXTERNAL_WRITE_TIMEOUT._2)
 
   def setClientConnectionTimeout(timeout: Int): H2OConf = {
     sparkConf.set(PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._1, timeout.toString)
@@ -49,6 +51,16 @@ trait ExternalBackendConf extends SharedBackendConf {
 
   def setClientCheckRetryTimeout(timeout: Int): H2OConf = {
     sparkConf.set(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, timeout.toString)
+    self
+  }
+
+  def setExternalReadConfirmationTimeout(timeout: Int): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_READ_TIMEOUT._1, timeout.toString)
+    self
+  }
+
+  def setExternalWriteConfirmationTimeout(timeout: Int): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_WRITE_TIMEOUT._1, timeout.toString)
     self
   }
 
@@ -149,6 +161,12 @@ object ExternalBackendConf {
 
   /** Timeout in milliseconds specifying how often the check for connected watchdog client is done */
   val PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT = ("spark.ext.h2o.cluster.client.retry.timeout", 10000)
+
+  /** Timeout for confirmation of read operation ( h2o frame => spark frame) on external cluster. */
+  val PROP_EXTERNAL_READ_TIMEOUT = ("spark.ext.h2o.external.read.confirmation.timeout", 20)
+
+  /** Timeout for confirmation of write operation ( spark frame => h2o frame) on external cluster. */
+  val PROP_EXTERNAL_WRITE_TIMEOUT = ("spark.ext.h2o.external.write.confirmation.timeout", 20)
 
   /** Timeout in seconds for starting h2o external cluster */
   val PROP_EXTERNAL_CLUSTER_START_TIMEOUT = ("spark.ext.h2o.cluster.start.timeout", 120)

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ODataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ODataFrame.scala
@@ -42,6 +42,7 @@ class H2ODataFrame[T <: water.fvec.Frame](@transient val frame: T,
                                          (@transient val hc: H2OContext)
   extends {
     override val isExternalBackend = hc.getConf.runsInExternalClusterMode
+    override val readTimeout = hc.getConf.externalReadConfirmationTimeout
   } with RDD[InternalRow](hc.sparkContext, Nil) with H2ORDDLike[T] {
 
   def this(@transient frame: T)

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2OFrameFromRDDProductBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2OFrameFromRDDProductBuilder.scala
@@ -111,11 +111,11 @@ object H2OFrameFromRDDProductBuilder{
     * @return pair (partition ID, number of rows in this partition)
     */
   private[converters] def perTypedDataPartition[T<:Product]()
-                                                           (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan])
+                                                           (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan], writeTimeout: Int)
                                                            (context: TaskContext, it: Iterator[T]): (Int, Long) = {
     val (iterator, dataSize) = WriteConverterCtxUtils.bufferedIteratorWithSize(uploadPlan, it)
     // An array of H2O NewChunks; A place to record all the data in this partition
-    val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize)
+    val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize, writeTimeout)
 
     con.createChunks(keyName, vecTypes, context.partitionId())
     iterator.foreach(prod => { // For all rows which are subtype of Product

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDD.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDD.scala
@@ -48,6 +48,7 @@ class H2ORDD[A <: Product: TypeTag: ClassTag, T <: Frame] private(@(transient @p
                                                                  (@(transient @param @field) hc: H2OContext)
   extends {
     override val isExternalBackend = hc.getConf.runsInExternalClusterMode
+    override val readTimeout = hc.getConf.externalReadConfirmationTimeout
   } with RDD[A](hc.sparkContext, Nil) with H2ORDDLike[T] {
 
   // Get product type before building an RDD

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDDLike.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDDLike.scala
@@ -32,6 +32,9 @@ private[converters] trait H2ORDDLike[T <: Frame] {
   /** Is the external backend in use */
   val isExternalBackend: Boolean
 
+  /** Timeout for read confirmation */
+  val readTimeout: Int
+
   /** Cache frame key to get H2OFrame from the K/V store */
   val frameKeyName: String = frame._key.toString
 
@@ -69,7 +72,7 @@ private[converters] trait H2ORDDLike[T <: Frame] {
         partIndex,
         // we need to send list of all expected types, not only the list filtered for expected columns
         // because on the h2o side we get the expected type using index from selectedColumnIndices array
-        chksLocation, expectedTypes, selectedColumnIndices
+        chksLocation, expectedTypes, selectedColumnIndices, readTimeout
       )
 
     override def hasNext: Boolean = converterCtx.hasNext

--- a/core/src/main/scala/org/apache/spark/h2o/converters/LabeledPointConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/LabeledPointConverter.scala
@@ -65,10 +65,10 @@ private[converters] object LabeledPointConverter extends Logging {
     */
   private[this]
   def perLabeledPointRDDPartition(maxNumFeatures: Int)
-                                 (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan])
+                                 (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan], writeTimeout: Int)
                                  (context: TaskContext, it: Iterator[LabeledPoint]): (Int, Long) = {
     val (iterator, dataSize) = WriteConverterCtxUtils.bufferedIteratorWithSize(uploadPlan, it)
-    val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize)
+    val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize, writeTimeout)
     // Creates array of H2O NewChunks; A place to record all the data in this partition
     con.createChunks(keyName, vecTypes, context.partitionId())
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/PrimitiveRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/PrimitiveRDDConverter.scala
@@ -65,11 +65,11 @@ private[converters] object PrimitiveRDDConverter extends Logging{
     */
   private[this]
   def perPrimitiveRDDPartition[T]() // extra arguments for this transformation
-                                 (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan]) // general arguments
+                                 (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan], writeTimeout: Int) // general arguments
                                  (context: TaskContext, it: Iterator[T]): (Int, Long) = { // arguments and return types needed for spark's runJob input
 
     val (iterator, dataSize) = WriteConverterCtxUtils.bufferedIteratorWithSize(uploadPlan, it)
-    val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize)
+    val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize, writeTimeout)
     con.createChunks(keyName, vecTypes, context.partitionId())
     iterator.foreach {con.putAnySupportedType(0, _)}
     //Compress & write data in partitions to H2O Chunks

--- a/core/src/main/scala/org/apache/spark/h2o/converters/ReadConverterCtxUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/ReadConverterCtxUtils.scala
@@ -26,9 +26,10 @@ object ReadConverterCtxUtils{
   def create(keyName: String, chunkIdx: Int,
              chksLocation: Option[Array[NodeDesc]],
              expectedTypes : Option[Array[Byte]],
-             selectedColumnIndices: Array[Int]): ReadConverterCtx = {
+             selectedColumnIndices: Array[Int],
+             readTimeout: Int): ReadConverterCtx = {
 
-    chksLocation.map(loc => new ExternalReadConverterCtx(keyName, chunkIdx, loc(chunkIdx), expectedTypes.get, selectedColumnIndices))
+    chksLocation.map(loc => new ExternalReadConverterCtx(keyName, chunkIdx, loc(chunkIdx), expectedTypes.get, selectedColumnIndices, readTimeout))
       .getOrElse(new InternalReadConverterCtx(keyName, chunkIdx))
 
   }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -86,11 +86,11 @@ private[h2o] object SparkDataFrameConverter extends Logging {
     */
   private[this]
   def perSQLPartition(types: Seq[(Seq[Int], StructField, Byte)])
-                     (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan])
+                     (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan], writeTimeout: Int)
                      (context: TaskContext, it: Iterator[Row]): (Int, Long) = {
 
     val (iterator, dataSize) = WriteConverterCtxUtils.bufferedIteratorWithSize(uploadPlan, it)
-    val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize)
+    val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize, writeTimeout)
     // Creates array of H2O NewChunks; A place to record all the data in this partition
     con.createChunks(keyName, vecTypes, context.partitionId())
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ h2oMajorVersion=3.10.4
 # Name of H2O major version
 h2oMajorName=ueno
 # H2O Build version, defined here to be overriden by -P option
-h2oBuild=3
+h2oBuild=4
 # Spark version
 sparkVersion=2.1.0
 

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -131,6 +131,14 @@ class H2OConf(object):
         self._jconf.setClientCheckRetryTimeout(timeout)
         return self
 
+    def set_external_read_confirmation_timeout(self, timeout):
+        self._jconf.setExternalReadConfirmationTimeout(timeout)
+        return self
+
+    def set_external_write_confirmation_timeout(self, timeout):
+        self._jconf.setExternalWriteConfirmationTimeout(timeout)
+        return self
+
 # getters
 
     def client_connection_timeout(self):
@@ -138,6 +146,12 @@ class H2OConf(object):
 
     def client_check_retry_timeout(self):
         return self._jconf.clientCheckRetryTimeout()
+
+    def external_read_confirmation_timeout(self):
+        return self._jconf.externalReadConfirmationTimeout()
+
+    def external_write_confirmation_timeout(self):
+        return self._jconf.externalWriteConfirmationTimeout()
 
     def cluster_start_timeout(self):
         return self._jconf.clusterStartTimeout()


### PR DESCRIPTION
When timeout is reached, the exception is thrown. It is not catched on purpose since the spark will stop the job on the current executor and restart it. That should fix several intermittent issues together with  the problem of a few jobs never finishing ( the problem appeared and the confirmation never appeared)