### PR TITLE
[SW-400][SW-401][SW-365] Fix stopping of h2o when running standalone …

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -39,6 +39,18 @@ trait ExternalBackendConf extends SharedBackendConf {
   def isAutoClusterStartUsed = clusterStartMode == "auto"
   def isManualClusterStartUsed = !isAutoClusterStartUsed
   def clusterStartTimeout = sparkConf.getInt(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, PROP_EXTERNAL_CLUSTER_START_TIMEOUT._2)
+  def clientConnectionTimeout = sparkConf.getInt(PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._1, PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._2)
+  def clientCheckRetryTimeout = sparkConf.getInt(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._2)
+
+  def setClientConnectionTimeout(timeout: Int): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._1, timeout.toString)
+    self
+  }
+
+  def setClientCheckRetryTimeout(timeout: Int): H2OConf = {
+    sparkConf.set(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, timeout.toString)
+    self
+  }
 
   /**
     * Sets node and port representing H2O Cluster to which should H2O connect when started in external mode.
@@ -74,7 +86,7 @@ trait ExternalBackendConf extends SharedBackendConf {
   }
 
 
-  def setYARNQueue(queueName: String) = {
+  def setYARNQueue(queueName: String) : H2OConf = {
     sparkConf.set(PROP_EXTERNAL_CLUSTER_YARN_QUEUE._1, queueName)
     self
   }
@@ -102,19 +114,19 @@ trait ExternalBackendConf extends SharedBackendConf {
     self
   }
 
-  def setClusterConfigFile(path: String) = {
+  def setClusterConfigFile(path: String) : H2OConf = {
     sparkConf.set(PROP_EXTERNAL_CLUSTER_INFO_FILE._1, path)
     self
   }
 
-  def useAutoClusterStart() = {
+  def useAutoClusterStart() : H2OConf = {
     setExternalClusterMode()
     logWarning("Using external cluster mode!")
     sparkConf.set(PROP_EXTERNAL_CLUSTER_START_MODE._1, "auto")
     self
   }
 
-  def useManualClusterStart() = {
+  def useManualClusterStart() : H2OConf = {
     setExternalClusterMode()
     logWarning("Using external cluster mode!")
     sparkConf.set(PROP_EXTERNAL_CLUSTER_START_MODE._1, "manual")
@@ -135,8 +147,15 @@ trait ExternalBackendConf extends SharedBackendConf {
 
 object ExternalBackendConf {
 
+  /** Timeout in milliseconds specifying how often the check for connected watchdog client is done */
+  val PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT = ("spark.ext.h2o.cluster.client.retry.timeout", 10000)
+
   /** Timeout in seconds for starting h2o external cluster */
   val PROP_EXTERNAL_CLUSTER_START_TIMEOUT = ("spark.ext.h2o.cluster.start.timeout", 120)
+
+  /** Timeout in milliseconds for watchdog client connection. If client is not connected
+    * to the external cluster in the given time, the cluster is killed */
+  val PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT = ("spark.ext.h2o.cluster.client.connect.timeout", 120000 + 10000)
 
   val PROP_EXTERNAL_CLUSTER_INFO_FILE = ("spark.ext.h2o.cluster.info.name", None)
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -68,7 +68,10 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
       "-output", conf.HDFSOutputDir.get,
       "-J", "-log_level", "-J", conf.h2oNodeLogLevel,
       "-timeout", conf.clusterStartTimeout.toString,
-      "-disown"
+      "-disown",
+      "-J", "-watchdog_stop_without_client",
+      "-J", "-watchdog_client_connect_timeout", "-J", conf.clientConnectionTimeout.toString,
+      "-J", "-watchdog_client_retry_timeout", "-J", conf.clientCheckRetryTimeout.toString
     )
 
     // start external h2o cluster and log the output
@@ -111,12 +114,6 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
     logInfo(s"Yarn ID obtained from cluster file: $yarnAppId")
     logInfo(s"Cluster ip and port obtained from cluster file: $ipPort")
 
-    sys.ShutdownHookThread {
-      if(hc.getConf.isAutoClusterStartUsed){
-        stopExternalCluster()
-        deleteYarnFiles()
-      }
-    }
     assert(proc == 0, s"Starting external H2O cluster failed with return value $proc.")
     ipPort
   }
@@ -137,12 +134,6 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
         logError(s"Error when deleting cluster info file at ${hc.getConf.clusterInfoFile.get}" +
           s", original message: ${e.getMessage}")
     }
-  }
-
-  private def stopExternalCluster(): Unit = {
-    // Send disconnect command from the watchdog client in case of orderly shutdown
-    UDPClientEvent.ClientEvent.Type.DISCONNECT.broadcast(H2O.SELF)
-    log.info("Stopping external H2O cluster!")
   }
 
   override def init(): Array[NodeDesc] = {
@@ -208,14 +199,11 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
     // otherwise stopping is not supported
     if(hc.getConf.isAutoClusterStartUsed){
       deleteYarnFiles()
-      stopExternalCluster()
-    }else {
-      if (stopSparkContext) {
-        hc.sparkContext.stop()
-      }
-      H2O.orderlyShutdown(1000)
-      H2O.exit(0)
     }
+    if (stopSparkContext) {
+      hc.sparkContext.stop()
+    }
+    H2O.orderlyShutdown(1000)
   }
 
   override def checkAndUpdateConf(conf: H2OConf): H2OConf = {

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -102,7 +102,21 @@ class H2OConf(object):
         self._jconf.setH2OClientLogLevel(level)
         return self
 
+    def set_client_connection_timeout(self, timeout):
+        self._jconf.setClientConnectionTimeout(timeout)
+        return self
+
+    def set_client_check_retry_timeout(self, timeout):
+        self._jconf.setClientCheckRetryTimeout(timeout)
+        return self
+
 # getters
+
+    def client_connection_timeout(self):
+        return self._jconf.clientConnectionTimeout()
+
+    def client_check_retry_timeout(self):
+        return self._jconf.clientCheckRetryTimeout()
 
     def cluster_start_timeout(self):
         return self._jconf.clusterStartTimeout()

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -94,7 +94,15 @@ class H2OConf(object):
     def set_h2o_node_log_level(self, level):
         self._jconf.setH2ONodeLogLevel(level)
         return self
+
     def set_cluster_start_timeout(self, timeout):
+        """Set timeout for start of external cluster. If the cluster is not able to cloud within the timeout the
+        the exception is thrown.
+
+        Arguments:
+        timeout -- timeout in seconds
+        
+        """
         self._jconf.setClusterStartTimeout(timeout)
         return self
 
@@ -103,10 +111,23 @@ class H2OConf(object):
         return self
 
     def set_client_connection_timeout(self, timeout):
+        """Set timeout for watchdog client connection in external cluster mode. If the client is not connected to the
+         cluster within the specified time, the cluster kill itself.
+
+        Arguments:
+        timeout -- timeout in milliseconds
+        
+        """
         self._jconf.setClientConnectionTimeout(timeout)
         return self
 
     def set_client_check_retry_timeout(self, timeout):
+        """Set retry interval how often nodes in the external cluster mode check for the presence of the h2o client.
+        
+        Arguments:
+        timeout -- timeout in milliseconds
+        
+        """
         self._jconf.setClientCheckRetryTimeout(timeout)
         return self
 

--- a/py/pysparkling/context.py
+++ b/py/pysparkling/context.py
@@ -10,6 +10,7 @@ import h2o
 from pysparkling.conversions import FrameConversions as fc
 import warnings
 import atexit
+import sys
 
 def _monkey_patch_H2OFrame(hc):
     @staticmethod
@@ -120,11 +121,15 @@ class H2OContext(object):
         h2o.connect(ip=h2o_context._client_ip, port=h2o_context._client_port)
         h2o_context.is_initialized = True
         # Stop h2o when running standalone pysparkling scripts and the user does not explicitly close h2o
-        atexit.register(lambda: h2o_context.stop())
+        atexit.register(lambda: h2o_context.stop_with_jvm())
         return h2o_context
 
+    def stop_with_jvm(self):
+        h2o.cluster().shutdown()
+        self.stop()
+
     def stop(self):
-        warnings.warn("H2OContext stopping is not yet fully supported...")
+        warnings.warn("Stopping H2OContext. (Restarting H2O is not yet fully supported...) ")
         self._jhc.stop(False)
 
     def __del__(self):


### PR DESCRIPTION
…python jobs. Also ensures that when client doesn't connect to external cluster in specified timeout, the cluster will kill itself.

This fix introduces two additional commands on the configuration for the external backend:
 - setClientConnectionTimeout - sets the timeout in milliseconds how long the cluster waits for the client to conenct before it kill itself
 - setClientCheckRetryTimeout - sets the timeout in milliseconds how often the cluster checks for the presence of the client

The following methods are available also in pysparkling as
 - set_client_connection_timeout
 - set_client_check_retry_timeout

This fix does several additional fixes:
 - better log message when stopping the context in pysparkling
 - removes unnecessary shutdown hook in external h2o backend
 - use H2O.orderShutdown instead of shutdown