### PR TITLE
[SW-435] Upgrade shadow jar plugin to 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.0'
         classpath 'org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.10:0.8.2'
         classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
         classpath 'net.researchgate:gradle-release:2.4.1'


### PR DESCRIPTION
This version fixes several issues which are not affecting us, but it's good to be up-to-date,
see https://github.com/johnrengelman/shadow/releases