### PR TITLE
[SW-369] Use only spark nodes with H2O nodes in internal backend

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -72,7 +72,7 @@ class H2OContext private(val sparkSession: SparkSession, conf: H2OConf) extends 
   /** REST port of H2O client */
   private var localClientPort: Int = _
   /** Runtime list of active H2O nodes */
-  private val h2oNodes = mutable.ArrayBuffer.empty[NodeDesc]
+  val h2oNodes = mutable.ArrayBuffer.empty[NodeDesc]
   private var stopped = false
 
   /** Used backend */

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContextImplicits.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContextImplicits.scala
@@ -21,6 +21,7 @@ import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.sql.DataFrame
 import water.Key
 import org.apache.spark._
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 /**
@@ -30,7 +31,7 @@ abstract class H2OContextImplicits {
 
   protected def _h2oContext: H2OContext
   /** Implicit conversion from RDD[Supported type] to H2OFrame */
-  implicit def asH2OFrameFromRDDProduct[A <: Product : TypeTag](rdd : RDD[A]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
+  implicit def asH2OFrameFromRDDProduct[A <: Product : ClassTag : TypeTag](rdd : RDD[A]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
   implicit def asH2OFrameFromRDDString(rdd: RDD[String]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
   implicit def asH2OFrameFromRDDBool(rdd: RDD[Boolean]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
   implicit def asH2OFrameFromRDDDouble(rdd: RDD[Double]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
@@ -44,7 +45,7 @@ abstract class H2OContextImplicits {
 
 
   /** Implicit conversion from RDD[Supported type] to H2OFrame key */
-  implicit def toH2OFrameKeyFromRDDProduct[A <: Product : TypeTag](rdd : RDD[A]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
+  implicit def toH2OFrameKeyFromRDDProduct[A <: Product : ClassTag : TypeTag](rdd : RDD[A]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
   implicit def toH2OFrameKeyFromRDDString(rdd: RDD[String]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
   implicit def toH2OFrameKeyFromRDDBool(rdd: RDD[Boolean]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
   implicit def toH2OFrameKeyFromRDDDouble(rdd: RDD[Double]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
@@ -55,6 +56,7 @@ abstract class H2OContextImplicits {
   implicit def toH2OFrameKeyFromRDDLabeledPoint(rdd: RDD[LabeledPoint]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
   implicit def toH2OFrameKeyFromRDDMLlibVector(rdd: RDD[mllib.linalg.Vector]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
   implicit def toH2OFrameKeyfromRDDMlVector(rdd: RDD[ml.linalg.Vector]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
+
 
 
   /** Implicit conversion from Spark DataFrame to H2OFrame */

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendUtils.scala
@@ -161,6 +161,8 @@ private[internal] trait InternalBackendUtils extends SharedBackendUtils {
         }
       }
     }.collect()
+
+
     // The accumulable should contain all IP:PORTs from all exeuctors
     if (bc.value.size != numOfExecutors ||
       executorStatus.groupBy(_._1).flatMap( x => x._2.find(_._2)).size != numOfExecutors) {

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -22,7 +22,8 @@ import org.apache.spark.h2o.backends.SparklingBackend
 import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OConf, H2OContext}
 import org.apache.spark.internal.Logging
-import org.apache.spark.listeners.ExecutorAddNotSupportedListener
+import org.apache.spark.listeners.H2OSparkListener
+import org.apache.spark.scheduler.SparkListenerExecutorAdded
 import water.api.RestAPIManager
 import water.{H2O, H2OStarter}
 
@@ -71,7 +72,11 @@ class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend
     if (hc.getConf.isClusterTopologyListenerEnabled) {
       // Attach listener which kills H2O cluster when new Spark executor has been launched ( which means
       // that this executors hasn't been discovered during the spreadRDD phase)
-      hc.sparkContext.addSparkListener(new ExecutorAddNotSupportedListener())
+      hc.sparkContext.addSparkListener(new H2OSparkListener {
+        override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = {
+          log.warn("New spark executor joined the cloud, however it won't be used for the H2O computations.")
+        }
+      })
     }
 
     // Start H2O nodes

--- a/core/src/main/scala/org/apache/spark/h2o/converters/PrimitiveRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/PrimitiveRDDConverter.scala
@@ -27,11 +27,12 @@ import water.Key
 import water.fvec.H2OFrame
 
 import scala.language.implicitConversions
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 private[converters] object PrimitiveRDDConverter extends Logging {
 
-  def toH2OFrame[T: TypeTag](hc: H2OContext, rdd: RDD[T], frameKeyName: Option[String]): H2OFrame = {
+  def toH2OFrame[T: ClassTag : TypeTag](hc: H2OContext, rdd: RDD[T], frameKeyName: Option[String]): H2OFrame = {
     import ReflectionUtils._
 
     val keyName = frameKeyName.getOrElse("frame_rdd_" + rdd.id + Key.rand())

--- a/core/src/main/scala/org/apache/spark/h2o/converters/ProductRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/ProductRDDConverter.scala
@@ -41,7 +41,7 @@ private[h2o] object ProductRDDConverter extends Logging {
   }
 
   /** Transform typed RDD into H2O Frame */
-  def toH2OFrame[T <: Product : TypeTag](hc: H2OContext, rdd: RDD[T], frameKeyName: Option[String]): H2OFrame = {
+  def toH2OFrame[T <: Product : ClassTag: TypeTag](hc: H2OContext, rdd: RDD[T], frameKeyName: Option[String]): H2OFrame = {
     val keyName = frameKeyName.getOrElse("frame_rdd_" + rdd.id + Key.rand()) // There are uniq IDs for RDD
 
     val fnames = ReflectionUtils.fieldNamesOf[T]

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SupportedRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SupportedRDDConverter.scala
@@ -48,7 +48,7 @@ trait SupportedRDD {
 
 private[this] object SupportedRDD {
 
-  class PrimitiveSupportedRDD[T: TypeTag](rdd: RDD[T]) extends SupportedRDD {
+  class PrimitiveSupportedRDD[T: TypeTag: ClassTag](rdd: RDD[T]) extends SupportedRDD {
     override def toH2OFrame(hc: H2OContext, frameKeyName: Option[String]): H2OFrame = PrimitiveRDDConverter.toH2OFrame(hc, rdd, frameKeyName)
   }
 
@@ -124,7 +124,7 @@ private[this] object SupportedRDD {
   implicit def toH2OFrameFromRDDProductNoTypeTag(rdd : RDD[Product]): SupportedRDD = new SupportedRDD {
     override def toH2OFrame(hc: H2OContext, frameKeyName: Option[String]): H2OFrame = ProductRDDConverter.toH2OFrame(hc, rdd, frameKeyName)
   }
-  implicit def toH2OFrameFromRDDProduct[A <: Product : TypeTag](rdd : RDD[A]): SupportedRDD = new SupportedRDD {
+  implicit def toH2OFrameFromRDDProduct[A <: Product : ClassTag: TypeTag](rdd : RDD[A]): SupportedRDD = new SupportedRDD {
     override def toH2OFrame(hc: H2OContext, frameKeyName: Option[String]): H2OFrame = ProductRDDConverter.toH2OFrame(hc, rdd, frameKeyName)
   }
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
@@ -17,15 +17,18 @@
 
 package org.apache.spark.h2o.converters
 
+import org.apache.spark.TaskContext
 import org.apache.spark.h2o.backends.external.ExternalWriteConverterCtx
 import org.apache.spark.h2o.backends.internal.InternalWriteConverterCtx
 import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OContext, _}
-import org.apache.spark.TaskContext
+import org.apache.spark.rdd.h2o.H2OAwareRDD
 import water.fvec.H2OFrame
 import water.{DKV, ExternalFrameUtils, Key}
 
 import scala.collection.immutable
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 
 object WriteConverterCtxUtils {
@@ -58,7 +61,7 @@ object WriteConverterCtxUtils {
     * Converts the RDD to H2O Frame using specified conversion function
     *
     * @param hc       H2O context
-    * @param rdd      rdd to convert
+    * @param rddInput rdd to convert
     * @param keyName  key of the resulting frame
     * @param colNames names of the columns in the H2O Frame
     * @param vecTypes types of the vectors in the H2O Frame
@@ -68,16 +71,26 @@ object WriteConverterCtxUtils {
     * @return H2O Frame
     */
 
-  def convert[T](hc: H2OContext, rdd: RDD[T], keyName: String, colNames: Array[String], vecTypes: Array[Byte],
-                 maxVecSizes: Array[Int], func: ConversionFunction[T]) = {
+  def convert[T: ClassTag: TypeTag](hc: H2OContext, rddInput: RDD[T], keyName: String, colNames: Array[String], vecTypes: Array[Byte],
+                                    maxVecSizes: Array[Int], func: ConversionFunction[T]) = {
+    // create new RDD which is located only on the nodes wit h2o
     // Make an H2O data Frame - but with no backing data (yet)
     initFrame(keyName, colNames)
 
     // prepare required metadata based on the used backend
     val uploadPlan = if (hc.getConf.runsInExternalClusterMode) {
-      Some(ExternalWriteConverterCtx.scheduleUpload(rdd.getNumPartitions))
+      Some(ExternalWriteConverterCtx.scheduleUpload(rddInput.getNumPartitions))
     } else {
       None
+    }
+    val rdd = if (hc.getConf.runsInInternalClusterMode) {
+      // this is only required in internal cluster mode
+      val prefs = hc.h2oNodes.map{ nodeDesc =>
+        s"executor_${nodeDesc.hostname}_${nodeDesc.nodeId}"
+      }
+      new H2OAwareRDD(prefs, rddInput)
+    } else {
+      rddInput
     }
 
     val operation: SparkJob[T] = func(keyName, vecTypes, uploadPlan, hc.getConf.externalWriteConfirmationTimeout)

--- a/core/src/main/scala/org/apache/spark/rdd/h2o/H2OAwareRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/h2o/H2OAwareRDD.scala
@@ -14,9 +14,21 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.apache.spark.listeners
+package org.apache.spark.rdd.h2o
 
-import org.apache.spark.scheduler.SparkListener
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, TaskContext}
 
-trait H2OSparkListener extends SparkListener{
+import scala.reflect.ClassTag
+
+
+class H2OAwareRDD[U: ClassTag](nodes: Seq[String], prev: RDD[U]) extends RDD[U](prev: RDD[U]) {
+
+  override def getPreferredLocations(split: Partition): Seq[String] = nodes
+
+  override def compute(split: Partition, context: TaskContext): Iterator[U] = prev.compute(split, context)
+
+  override protected def getPartitions: Array[Partition] = {
+    prev.partitions
+  }
 }

--- a/doc/tutorials/backends.rst
+++ b/doc/tutorials/backends.rst
@@ -9,9 +9,8 @@ of ``H2OContext.getOrCreate``. Since it's not technically possible to
 get number of executors in Spark, we try to discover all executors at
 the initiation of ``H2OContext`` and we start H2O instance inside of
 each discovered executor. This solution is easiest to deploy; however
-when Spark or YARN kills the executor - which is not an unusual case -
-the whole H2O cluster goes down since h2o doesn't support high
-availability.
+when Spark or YARN kills the executor the whole H2O cluster goes down
+since H2O doesn't support high availability.
 
 Internal backend is default for behaviour for Sparkling Water. It can be
 changed via spark configuration property


### PR DESCRIPTION
This change ensures that only executors discovered during the spread rdd phase will be used during the computations. Therefore, we are no longer affected by a new spark executor joining the cluster