### PR TITLE
[SW-453] [Minor] Use size method to get attr num

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
@@ -184,7 +184,7 @@ object H2OSchemaUtils {
     val allTypesIndx = arrayTypesIndx ++ vectorTypesIndx
     val attributesNum = (field: StructField) => {
       if (!field.dataType.isInstanceOf[ml.linalg.VectorUDT]) { None }
-      else { AttributeGroup.fromStructField(field).numAttributes }
+      else { AttributeGroup.fromStructField(field).size }
     }
 
     @tailrec

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
@@ -184,7 +184,8 @@ object H2OSchemaUtils {
     val allTypesIndx = arrayTypesIndx ++ vectorTypesIndx
     val attributesNum = (field: StructField) => {
       if (!field.dataType.isInstanceOf[ml.linalg.VectorUDT]) { None }
-      else { AttributeGroup.fromStructField(field).size }
+      else if (AttributeGroup.fromStructField(field).size != -1) { Some(AttributeGroup.fromStructField(field).size) }
+      else { None }
     }
 
     @tailrec


### PR DESCRIPTION
Minor fix to my previous PR. If fields had some attribute VectorAssembler would squash them to Array[Attribute] rather than numAttribute. Need to use size method: https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala#L80 - that would handle all cases to get num of attributes.