### PR TITLE
[SW-456] Make shell scripts safe

### DIFF
--- a/bin/get-extended-h2o.sh
+++ b/bin/get-extended-h2o.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Current dir
-if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+TOPDIR=$(cd "$(dirname "$0")/.."; pwd)
 
 source "$TOPDIR/bin/sparkling-env.sh"
 

--- a/bin/get-extended-h2o.sh
+++ b/bin/get-extended-h2o.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Top-level directory for this product
-TOPDIR=$(cd "$(dirname "$0")/.."; pwd)
+# Current dir
+if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+
 source "$TOPDIR/bin/sparkling-env.sh"
 
 if [ ! $# -eq 1 ]; then
@@ -27,7 +28,7 @@ else
 fi
 
 h2odriver_file="h2odriver-$H2O_VERSION.$H2O_BUILD-${hadoop_version}extended.jar"
-h2odriver_url="${S3_RELEASE_BUCKET}/rel-${major_version}/${patch_version}/extended/${h2odriver_file}"
+h2odriver_url="${S3_RELEASE_BUCKET}/rel-${MAJOR_VERSION}/${PATCH_VERSION}/extended/${h2odriver_file}"
 output_file="h2odriver-${hadoop_version}extended.jar"
 
 echo "Getting h2odriver from ${output_file}..."

--- a/bin/launch-spark-cloud.sh
+++ b/bin/launch-spark-cloud.sh
@@ -12,17 +12,11 @@ if [ ! -d "$SPARK_HOME" ]; then
   exit -1
 fi
 
-# Spark dir
-TDIR=$(cd `dirname $0` &&  pwd)
 # Configure tmp dir
 tmpdir=${TMPDIR:-"/tmp/"}
 export SPARK_LOG_DIR="${tmpdir}spark/logs"
 export SPARK_WORKER_DIR="${tmpdir}spark/work"
 export SPARK_LOCAL_DIRS="${tmpdir}spark/work"
-
-# Cleanup
-rm -rf $TDIR/work/* 2>/dev/null
-rm -rf $TDIR/logs/* 2>/dev/null
 
 cat <<EOF
 Starting Spark cluster ... 1 master + $SPARK_WORKER_INSTANCES workers
@@ -31,12 +25,8 @@ Starting Spark cluster ... 1 master + $SPARK_WORKER_INSTANCES workers
 EOF
 
 echo "Starting master..."
-$SPARK_HOME/sbin/start-master.sh 
+"$SPARK_HOME"/sbin/start-master.sh
 
 echo "Starting $SPARK_WORKER_INSTANCES workers..."
-$SPARK_HOME/sbin/start-slave.sh $MASTER
-
-
-# launch spark shell
-#../bin/spark-shell
+"$SPARK_HOME"/sbin/start-slave.sh $MASTER
 

--- a/bin/pysparkling
+++ b/bin/pysparkling
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Current dir
-TOPDIR=$(cd `dirname $0`/.. &&  pwd)
-source $TOPDIR/bin/sparkling-env.sh
+if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+
+source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation
 checkSparkHome
 # Verify if correct Spark version is used
@@ -10,5 +11,5 @@ checkSparkVersion
 
 
 PYTHONPATH=$PY_ZIP_FILE:$PYTHONPATH \
-pyspark --py-files $PY_ZIP_FILE "$@"
+pyspark --py-files "$PY_ZIP_FILE" "$@"
 

--- a/bin/pysparkling
+++ b/bin/pysparkling
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Current dir
-if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+TOPDIR=$(cd "$(dirname "$0")/.."; pwd)
 
 source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation

--- a/bin/run-example.sh
+++ b/bin/run-example.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Current dir
-if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+TOPDIR=$(cd "$(dirname "$0")/.."; pwd)
 
 source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation

--- a/bin/run-example.sh
+++ b/bin/run-example.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Current dir
-TOPDIR=$(cd `dirname $0`/.. &&  pwd)
-source $TOPDIR/bin/sparkling-env.sh
+if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+
+source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation
 checkSparkHome
 
@@ -11,7 +12,7 @@ PREFIX=org.apache.spark.examples.h2o
 # Name of default example
 DEFAULT_EXAMPLE=AirlinesWithWeatherDemo2
 
-if [ $1 ] && [[ ${1} != "--"* ]]; then
+if [ "$1" ] && [[ ${1} != "--"* ]]; then
   EXAMPLE=$PREFIX.$1
   shift
 else
@@ -36,29 +37,13 @@ VERBOSE= #--verbose
 
 # Derive actual spark.driver.extraJavaOptions value
 if [ -f "$SPARK_HOME/conf/spark-defaults.conf" ]; then
-    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" "$SPARK_HOME"/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
 fi
 
-if [ "$EXAMPLE_MASTER" == "yarn-client" ] || [ "$EXAMPLE_MASTER" == "yarn-cluster" ]; then
-#EXAMPLE_DEPLOY_MODE does not have to be set when executing on yarn
- spark-submit \
- --class $EXAMPLE \
- --master $EXAMPLE_MASTER \
- --driver-memory $EXAMPLE_DRIVER_MEMORY \
- --driver-java-options "$EXAMPLE_H2O_SYS_OPS" \
- --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" \
- $VERBOSE \
- $FAT_JAR_FILE \
- "$@"
-else
- spark-submit \
- --class $EXAMPLE \
- --master $EXAMPLE_MASTER \
- --driver-memory $EXAMPLE_DRIVER_MEMORY \
- --driver-java-options "$EXAMPLE_H2O_SYS_OPS" \
- --deploy-mode $EXAMPLE_DEPLOY_MODE \
- --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" \
- $VERBOSE \
- $FAT_JAR_FILE \
- "$@"
-fi
+spark-submit --class $EXAMPLE \
+--master "$EXAMPLE_MASTER" \
+--driver-memory "$EXAMPLE_DRIVER_MEMORY" \
+--driver-java-options "$EXAMPLE_H2O_SYS_OPS" \
+--deploy-mode "$EXAMPLE_DEPLOY_MODE" \
+--conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" \
+$VERBOSE "$FAT_JAR_FILE" "$@"

--- a/bin/run-python-script.sh
+++ b/bin/run-python-script.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Current dir
-TOPDIR=$(cd `dirname $0`/.. &&  pwd)
-source $TOPDIR/bin/sparkling-env.sh
+TOPDIR=$(cd "$(dirname "$0")/.."; pwd)
+
+source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation
 checkSparkHome
 # Verify if correct Spark version is used
@@ -23,28 +24,14 @@ echo "---------"
 export SPARK_PRINT_LAUNCH_COMMAND=1
 VERBOSE=--verbose
 
-if [ "$EXAMPLE_MASTER" == "yarn-client" ] || [ "$EXAMPLE_MASTER" == "yarn-cluster" ]; then
-#EXAMPLE_DEPLOY_MODE does not have to be set when executing on yarn
 VERBOSE=
- spark-submit \
- --master $SCRIPT_MASTER \
- --driver-memory $SCRIPT_DRIVER_MEMORY \
- --driver-java-options "$SCRIPT_H2O_SYS_OPS" \
- --py-files $PY_ZIP_FILE \
- --conf spark.driver.extraJavaOptions="-XX:MaxPermSize=384m" \
- $VERBOSE \
- $SCRIPT \
-  "$@"
-else
-VERBOSE=
- spark-submit \
- --master $SCRIPT_MASTER \
- --driver-memory $SCRIPT_DRIVER_MEMORY \
- --driver-java-options "$SCRIPT_H2O_SYS_OPS" \
- --deploy-mode $SCRIPT_DEPLOY_MODE \
- --py-files $PY_ZIP_FILE \
- --conf spark.driver.extraJavaOptions="-XX:MaxPermSize=384m" \
- $VERBOSE \
- "$@"
-fi
+spark-submit \
+--master "$SCRIPT_MASTER" \
+--driver-memory "$SCRIPT_DRIVER_MEMORY" \
+--driver-java-options "$SCRIPT_H2O_SYS_OPS" \
+--deploy-mode "$SCRIPT_DEPLOY_MODE" \
+--py-files "$PY_ZIP_FILE" \
+--conf spark.driver.extraJavaOptions="-XX:MaxPermSize=384m" \
+$VERBOSE \
+"$@"
 

--- a/bin/run-sparkling.sh
+++ b/bin/run-sparkling.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Current dir
-if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+TOPDIR=$(cd "$(dirname "$0")/.."; pwd)
 
 source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation

--- a/bin/run-sparkling.sh
+++ b/bin/run-sparkling.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Current dir
-TOPDIR=$(cd `dirname $0`/.. &&  pwd)
-source $TOPDIR/bin/sparkling-env.sh
+if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+
+source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation
 checkSparkHome
 # Verify if correct Spark version is used
@@ -14,12 +15,12 @@ DRIVER_MEMORY=${DRIVER_MEMORY:-$DEFAULT_DRIVER_MEMORY}
 MASTER=${MASTER:-"$DEFAULT_MASTER"}
 VERBOSE=--verbose
 VERBOSE=
-if [ -f $SPARK_HOME/conf/spark-defaults.conf ]; then
-    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+if [ -f "$SPARK_HOME"/conf/spark-defaults.conf ]; then
+    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" "$SPARK_HOME"/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
 fi
 
 # Show banner
 banner 
 
-spark-submit "$@" $VERBOSE --driver-memory $DRIVER_MEMORY --master $MASTER --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" --class "$DRIVER_CLASS" $FAT_JAR_FILE
+spark-submit "$@" $VERBOSE --driver-memory "$DRIVER_MEMORY" --master "$MASTER" --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" --class "$DRIVER_CLASS" "$FAT_JAR_FILE"
 

--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -1,7 +1,9 @@
+#!/usr/bin/env bash
+
 function checkSparkHome() {
   # Example class prefix
   if [ ! -f "$SPARK_HOME/bin/spark-submit" ]; then
-    if [ -z "`which spark-submit`" ] ; then
+    if [ -z "$(which spark-submit)" ] ; then
       echo "Please setup SPARK_HOME variable to your Spark installation!"
       exit -1
     fi
@@ -12,16 +14,16 @@ function checkSparkHome() {
 
 function getMasterArg() {
     # Find master in arguments
-    while [[ $# > 0 ]] 
+    while [[ $# -gt 0 ]]
     do
       case "$1" in
-          --master*) shift; echo $1
+          --master*) shift; echo "$1"
       esac
       shift
     done
 }
 
-if [ -z $TOPDIR ]; then
+if [ -z "$TOPDIR" ]; then
   echo "Caller has to setup TOPDIR variable!"
   exit -1
 fi
@@ -34,27 +36,31 @@ function checkSparkVersion() {
   fi
 }
 # Disable grep options for this environment
-GREP_OPTIONS=
+export GREP_OPTIONS=
 # Version of this distribution
-VERSION=$(cat $TOPDIR/gradle.properties | grep version | grep -v '#' | sed -e "s/.*=//" )
-H2O_VERSION=$(cat $TOPDIR/gradle.properties | grep h2oMajorVersion | sed -e "s/.*=//")
-H2O_BUILD=$(cat $TOPDIR/gradle.properties | grep h2oBuild | sed -e "s/.*=//")
-H2O_NAME=$(cat $TOPDIR/gradle.properties | grep h2oMajorName | sed -e "s/.*=//")
-SPARK_VERSION=$(cat $TOPDIR/gradle.properties | grep sparkVersion | sed -e "s/.*=//")
-SCALA_VERSION=$(cat $TOPDIR/gradle.properties | grep scalaBaseVersion | sed -e "s/.*=//" | cut -d . -f 1,2)
+PROP_FILE="$TOPDIR/gradle.properties"
+VERSION=$(grep version "$PROP_FILE" | grep -v '#' | sed -e "s/.*=//" )
+H2O_VERSION=$(grep h2oMajorVersion "$PROP_FILE" | sed -e "s/.*=//")
+H2O_BUILD=$(grep h2oBuild "$PROP_FILE" | sed -e "s/.*=//")
+H2O_NAME=$(grep h2oMajorName "$PROP_FILE" | sed -e "s/.*=//")
+SPARK_VERSION=$(grep sparkVersion "$PROP_FILE" | sed -e "s/.*=//")
+SCALA_VERSION=$(grep scalaBaseVersion "$PROP_FILE" | sed -e "s/.*=//" | cut -d . -f 1,2)
 # Fat jar for this distribution
 FAT_JAR="sparkling-water-assembly_$SCALA_VERSION-$VERSION-all.jar"
-FAT_JAR_FILE="$TOPDIR/assembly/build/libs/$FAT_JAR"
-major_version=$(echo $VERSION | cut -d . -f 1,2)
-patch_version=$(echo $VERSION | cut -d . -f 3)
-version_without_snapshot=`echo $VERSION | cut -d - -f 1`
-PY_ZIP="h2o_pysparkling_${major_version}-${VERSION}.zip"
-PY_ZIP_FILE="$TOPDIR/py/build/dist/$PY_ZIP"
+export FAT_JAR_FILE="$TOPDIR/assembly/build/libs/$FAT_JAR"
+export MAJOR_VERSION
+MAJOR_VERSION=$(echo "$VERSION" | cut -d . -f 1,2)
+export PATCH_VERSION
+PATCH_VERSION=$(echo "$VERSION" | cut -d . -f 3)
+
+PY_ZIP="h2o_pysparkling_${MAJOR_VERSION}-${VERSION}.zip"
+export PY_ZIP_FILE="$TOPDIR/py/build/dist/$PY_ZIP"
+export AVAILABLE_H2O_DRIVERS
 AVAILABLE_H2O_DRIVERS=$( [ -f "$TOPDIR/h2o_drivers.txt" ] && cat "$TOPDIR/h2o_drivers.txt" || echo "N/A" )
 
 # Default master
-DEFAULT_MASTER="local[*]"
-DEFAULT_DRIVER_MEMORY=2G
+export DEFAULT_MASTER="local[*]"
+export DEFAULT_DRIVER_MEMORY=2G
 
 # Setup loging and outputs
 tmpdir="${TMPDIR:-"/tmp/"}/$USER/"
@@ -62,7 +68,7 @@ export SPARK_LOG_DIR="${tmpdir}spark/logs"
 export SPARK_WORKER_DIR="${tmpdir}spark/work"
 export SPARK_LOCAL_DIRS="${tmpdir}spark/work"
 
-S3_RELEASE_BUCKET="http://h2o-release.s3.amazonaws.com/sparkling-water"
+export S3_RELEASE_BUCKET="http://h2o-release.s3.amazonaws.com/sparkling-water"
 
 function banner() {
 cat <<EOF

--- a/bin/sparkling-shell
+++ b/bin/sparkling-shell
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Top-level directory for this product
-TOPDIR=$(cd `dirname $0`/..; pwd)
-source $TOPDIR/bin/sparkling-env.sh
+# Current dir
+if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation
 checkSparkHome
 # Verify if correct Spark version is used
@@ -17,10 +17,10 @@ USER_MASTER=${MASTER:-$(getMasterArg "$@")}
 USER_MASTER=${USER_MASTER:-"$DEFAULT_MASTER"}
 export MASTER="$USER_MASTER"
 if [ -f "$SPARK_HOME/conf/spark-defaults.conf" ]; then
-    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" $SPARK_HOME/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
+    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" "$SPARK_HOME"/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
 fi
 
 banner
 
 # If extra java properties are defined use them and append our property
-spark-shell --jars $FAT_JAR_FILE --driver-memory $DRIVER_MEMORY --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" "$@"
+spark-shell --jars "$FAT_JAR_FILE" --driver-memory "$DRIVER_MEMORY" --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS -XX:MaxPermSize=384m" "$@"

--- a/bin/sparkling-shell
+++ b/bin/sparkling-shell
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # Current dir
-if cd "$(dirname "$0")/.."; then TOPDIR=$(pwd); else exit; fi
+TOPDIR=$(cd "$(dirname "$0")/.."; pwd)
+
 source "$TOPDIR/bin/sparkling-env.sh"
 # Verify there is Spark installation
 checkSparkHome

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -93,7 +93,7 @@ SPARK_MAJOR_VERSION=$(echo $SPARK_VERSION | cut -f 1,2 -d .)
 # Copy dist dir files
 cat "$DIST_DIR/index.html" \
   | sed -e "s/SUBST_PROJECT_VERSION/$VERSION/g"\
-  | sed -e "s/SUBST_PROJECT_PATCH_VERSION/$patch_version/g"\
+  | sed -e "s/SUBST_PROJECT_PATCH_VERSION/$PATCH_VERSION/g"\
   | sed -e "s/SUBST_PROJECT_GITHASH/${GITHASH}/g"\
   | sed -e "s~SUBST_PROJECT_GITBRANCH~${GITBRANCH}~g"\
   | sed -e "s/SUBST_H2O_VERSION/${H2O_VERSION}/g"\


### PR DESCRIPTION
Wanted to do this for a long time already

There is no semantic change except in the `run-example` where I removed the unnecessary condition. The deploy mode should be specified in all cases. It has effect only when running on yarn and spark properly handles the MASTER and DEPLOY_MODE configurations since some are not valid.