### PR TITLE
[SW-457] Clean up windows scripts

### DIFF
--- a/bin/pysparkling2.cmd
+++ b/bin/pysparkling2.cmd
@@ -11,12 +11,9 @@ rem end of checking Sparkling environment
 call %LIBSW% :banner
 
 rem setup pysparkling command line
-rem Because of SPARK-18648 we need to put assembly also on driver/executor class paths
-SET SPARK_OPT_JARS=--jars !FAT_JAR_FILE! --conf spark.driver.extraClassPath=!FAT_JAR_FILE! --conf spark.executor.extraClassPath=!FAT_JAR_FILE!
 SET SPARK_OPT_PYFILES=--py-files !PY_ZIP_FILE!
-cd %TOPDIR%
 SET PYTHONPATH=%PY_ZIP_FILE%:%PYTHONPATH%
-call !SPARK_HOME!/bin/pyspark2.cmd !SPARK_OPT_PYFILES! %SPARK_OPT_JARS% %*
+call !SPARK_HOME!/bin/pyspark2.cmd !SPARK_OPT_PYFILES! %*
 
 exit /b %ERRORLEVEL%
 rem end of main script

--- a/bin/pysparkling2.cmd
+++ b/bin/pysparkling2.cmd
@@ -11,9 +11,11 @@ rem end of checking Sparkling environment
 call %LIBSW% :banner
 
 rem setup pysparkling command line
+rem Because of SPARK-18648 we need to put assembly also on driver/executor class paths
+SET SPARK_OPT_JARS=--jars !FAT_JAR_FILE! --conf spark.driver.extraClassPath=!FAT_JAR_FILE! --conf spark.executor.extraClassPath=!FAT_JAR_FILE!
 SET SPARK_OPT_PYFILES=--py-files !PY_ZIP_FILE!
 SET PYTHONPATH=%PY_ZIP_FILE%:%PYTHONPATH%
-call !SPARK_HOME!/bin/pyspark2.cmd !SPARK_OPT_PYFILES! %*
+call !SPARK_HOME!/bin/pyspark2.cmd !SPARK_OPT_PYFILES! %SPARK_OPT_JARS% %*
 
 exit /b %ERRORLEVEL%
 rem end of main script

--- a/bin/run-example2.cmd
+++ b/bin/run-example2.cmd
@@ -57,30 +57,7 @@ echo ---------
 
 set SPARK_PRINT_LAUNCH_COMMAND=1
 set VERBOSE=--verbose
-if "%EXAMPLE_MASTER%" == "yarn-client" (
-   goto :withoutdeploymode
-) else (
-if "%EXAMPLE_MASTER%" == "yarn-cluster" (
-   goto :withoutdeploymode
-) else (
-   goto :withdeploymode
-)
-)
-:withoutdeploymode
-cd %TOPDIR%
-call %SPARK_HOME%/bin/spark-submit2.cmd ^
- --class %EXAMPLE% ^
- --master %EXAMPLE_MASTER% ^
- --driver-memory %EXAMPLE_DRIVER_MEMORY% ^
- --driver-java-options "%EXAMPLE_H2O_SYS_OPS%" ^
- --conf spark.driver.extraJavaOptions="-XX:MaxPermSize=384m" ^
- %VERBOSE% ^
- %TOPDIR%/assembly/build/libs/%FAT_JAR% ^
- %*
-exit /b %ERRORLEVEL%
 
-:withdeploymode
-cd %TOPDIR%
 call %SPARK_HOME%/bin/spark-submit2.cmd ^
  --class %EXAMPLE% ^
  --master %EXAMPLE_MASTER% ^
@@ -89,9 +66,8 @@ call %SPARK_HOME%/bin/spark-submit2.cmd ^
  --deploy-mode %EXAMPLE_DEPLOY_MODE% ^
  --conf spark.driver.extraJavaOptions="-XX:MaxPermSize=384m" ^
  %VERBOSE% ^
- %TOPDIR%/assembly/build/libs/%FAT_JAR% ^
+ %FAT_JAR_FILE% ^
  %*
 exit /b %ERRORLEVEL%
-
 rem end of main script
 


### PR DESCRIPTION
Clean up some parts of windows scripts. Removing the condition inside run-example as it's not necessary.
Also, no need to put jar files on class-path when running pysparkling since it's already handled by --py-files ( the same is done in sparkling-shell )