### PR TITLE
[SW-479] Fix CHANGELOG location in make-dist.sh

### DIFF
--- a/make-dist.sh
+++ b/make-dist.sh
@@ -46,7 +46,6 @@ $(find py/pysparkling -type f -name '*.py')
 LICENSE
 README.rst
 $(find doc -type f)
-CHANGELOG.md
 gradle.properties
 EOF
 


### PR DESCRIPTION
It was moved to doc/CHANGELOG.rst which is already collected by: `$(find doc -type f)`