### PR TITLE
[SW-449] Support for Sparse Vectors and Upgrade to H2O 3.14.0.2

### DIFF
--- a/assembly/build.gradle
+++ b/assembly/build.gradle
@@ -45,6 +45,7 @@ shadowJar {
     include(dependency("ai.h2o:h2o-scala_${scalaBaseVersion}"))
     include(dependency("ai.h2o:h2o-web"))
     include(dependency("ai.h2o:h2o-algos"))
+    include(dependency("ai.h2o:h2o-automl"))
     include(dependency("ai.h2o:h2o-persist-hdfs"))
     include(dependency("ai.h2o:h2o-persist-s3"))
     include(dependency("ai.h2o:h2o-avro-parser"))

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ configure(subprojects) { project ->
 
     repositories {
         // Should be enabled only in development mode
-        if (h2oBuild == '99999' || project.hasProperty('useMavenLocal')) {
+        if (h2oBuild == '99999' || project.hasProperty('useMavenLocal') || h2oBuild.endsWith("-SNAPSHOT")) {
             mavenLocal()
         }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -47,6 +47,8 @@ dependencies {
   compile("ai.h2o:h2o-persist-s3:${h2oVersion}") {
       exclude(group: "com.fasterxml.jackson.core")
   }
+  // H2O AutoML
+  compile "ai.h2o:h2o-automl:${h2oVersion}"
 
   // Spark components
   // - core

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContextImplicits.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContextImplicits.scala
@@ -20,6 +20,7 @@ package org.apache.spark.h2o
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.sql.DataFrame
 import water.Key
+import org.apache.spark._
 import scala.reflect.runtime.universe._
 
 /**
@@ -38,6 +39,9 @@ abstract class H2OContextImplicits {
   implicit def asH2OFrameFromRDDShort(rdd: RDD[Short]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
   implicit def asH2OFrameFromRDDTimeStamp(rdd: RDD[java.sql.Timestamp]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
   implicit def asH2OFrameFromRDDLabeledPoint(rdd: RDD[LabeledPoint]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
+  implicit def asH2OFrameFromRDDMLlibVector(rdd: RDD[mllib.linalg.Vector]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
+  implicit def asH2OFrameFromRDDMlVector(rdd: RDD[ml.linalg.Vector]): H2OFrame = _h2oContext.asH2OFrame(rdd, None)
+
 
   /** Implicit conversion from RDD[Supported type] to H2OFrame key */
   implicit def toH2OFrameKeyFromRDDProduct[A <: Product : TypeTag](rdd : RDD[A]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
@@ -49,6 +53,9 @@ abstract class H2OContextImplicits {
   implicit def toH2OFrameKeyFromRDDShort(rdd: RDD[Short]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
   implicit def toH2OFrameKeyFromRDDTimeStamp(rdd: RDD[java.sql.Timestamp]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
   implicit def toH2OFrameKeyFromRDDLabeledPoint(rdd: RDD[LabeledPoint]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
+  implicit def toH2OFrameKeyFromRDDMLlibVector(rdd: RDD[mllib.linalg.Vector]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
+  implicit def toH2OFrameKeyfromRDDMlVector(rdd: RDD[ml.linalg.Vector]): Key[_] = _h2oContext.toH2OFrameKey(rdd, None)
+
 
   /** Implicit conversion from Spark DataFrame to H2OFrame */
   implicit def asH2OFrameFromDataFrame(df : DataFrame) : H2OFrame = _h2oContext.asH2OFrame(df, None)

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendUtils.scala
@@ -20,12 +20,12 @@ package org.apache.spark.h2o.backends.external
 import org.apache.spark.h2o.H2OConf
 import org.apache.spark.h2o.backends.SharedBackendUtils
 import org.apache.spark.h2o.utils.NodeDesc
-import water.H2O
+import water.{ExternalFrameUtils, H2O}
 
 /**
   * Various helper methods used in the external backend
   */
-private[external] trait ExternalBackendUtils extends SharedBackendUtils{
+private[external] trait ExternalBackendUtils extends SharedBackendUtils {
 
   /**
     * Get arguments for H2O client
@@ -42,4 +42,37 @@ private[external] trait ExternalBackendUtils extends SharedBackendUtils{
     conf.h2oCluster.map(clusterStr => Array("-flatfile", saveAsFile(clusterStr).getAbsolutePath)).getOrElse(Array())
   }
 }
-private[external] object ExternalBackendUtils extends ExternalBackendUtils
+
+object ExternalBackendUtils extends ExternalBackendUtils {
+
+  def prepareExpectedTypes(classes: Array[Class[_]]): Array[Byte] = {
+    classes.map { clazz =>
+      if (clazz == classOf[java.lang.Boolean]) {
+        ExternalFrameUtils.EXPECTED_BOOL
+      } else if (clazz == classOf[java.lang.Byte]) {
+        ExternalFrameUtils.EXPECTED_BYTE
+      } else if (clazz == classOf[java.lang.Short]) {
+        ExternalFrameUtils.EXPECTED_SHORT
+      } else if (clazz == classOf[java.lang.Character]) {
+        ExternalFrameUtils.EXPECTED_CHAR
+      } else if (clazz == classOf[java.lang.Integer]) {
+        ExternalFrameUtils.EXPECTED_INT
+      } else if (clazz == classOf[java.lang.Long]) {
+        ExternalFrameUtils.EXPECTED_LONG
+      } else if (clazz == classOf[java.lang.Float]) {
+        ExternalFrameUtils.EXPECTED_FLOAT
+      } else if (clazz == classOf[java.lang.Double]) {
+        ExternalFrameUtils.EXPECTED_DOUBLE
+      } else if (clazz == classOf[java.lang.String]) {
+        ExternalFrameUtils.EXPECTED_STRING
+      } else if (clazz == classOf[java.sql.Timestamp]) {
+        ExternalFrameUtils.EXPECTED_TIMESTAMP
+      } else if (clazz == classOf[org.apache.spark.mllib.linalg.Vector]) {
+        ExternalFrameUtils.EXPECTED_VECTOR
+      } else {
+        throw new RuntimeException("Unsupported class: " + clazz)
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ODataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ODataFrame.scala
@@ -19,13 +19,13 @@ package org.apache.spark.h2o.converters
 
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.h2o.H2OContext
+import org.apache.spark.h2o.backends.external.ExternalBackendUtils
 import org.apache.spark.h2o.utils.ReflectionUtils
 import org.apache.spark.h2o.utils.SupportedTypes._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.{Partition, TaskContext}
-import water.ExternalFrameUtils
 
 import scala.language.postfixOps
 
@@ -63,7 +63,7 @@ class H2ODataFrame[T <: water.fvec.Frame](@transient val frame: T,
     if (isExternalBackend) {
       // prepare expected type selected columns in the same order as are selected columns
       val javaClasses = selectedColumnIndices.map{ idx => ReflectionUtils.supportedType(frame.vec(idx)).javaClass }
-      Option(ExternalFrameUtils.prepareExpectedTypes(javaClasses))
+      Option(ExternalBackendUtils.prepareExpectedTypes(javaClasses))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDD.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDD.scala
@@ -21,7 +21,7 @@ package org.apache.spark.h2o.converters
 import java.lang.reflect.Constructor
 
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.backends.external.ExternalReadConverterCtx
+import org.apache.spark.h2o.backends.external.{ExternalBackendUtils, ExternalReadConverterCtx, ExternalWriteConverterCtx}
 import org.apache.spark.h2o.utils.ProductType
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, TaskContext}
@@ -113,7 +113,7 @@ class H2ORDD[A <: Product: TypeTag: ClassTag, T <: Frame] private(@(transient @p
     // there is no need to prepare expected types in internal backend
     if (isExternalBackend) {
       // prepare expected types for selected columns in the same order ar are selected columns(
-      Option(ExternalFrameUtils.prepareExpectedTypes(productType.memberClasses))
+      Option(ExternalBackendUtils.prepareExpectedTypes(productType.memberClasses))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/MLLibVectorConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/MLLibVectorConverter.scala
@@ -17,41 +17,43 @@
 
 package org.apache.spark.h2o.converters
 
-import org.apache.spark.TaskContext
 import org.apache.spark.h2o._
 import org.apache.spark.h2o.converters.WriteConverterCtxUtils.UploadPlan
 import org.apache.spark.internal.Logging
-import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.{TaskContext, mllib}
 import water.fvec.{H2OFrame, Vec}
 import water.{ExternalFrameUtils, Key}
 
 import scala.language.{implicitConversions, postfixOps}
 
-private[converters] object LabeledPointConverter extends Logging {
+private[converters] object MLLibVectorConverter extends Logging {
 
   /** Transform RDD[LabeledPoint] to appropriate H2OFrame */
-  def toH2OFrame(hc: H2OContext, rdd: RDD[LabeledPoint], frameKeyName: Option[String]): H2OFrame = {
+  def toH2OFrame(hc: H2OContext, rdd: RDD[mllib.linalg.Vector], frameKeyName: Option[String]): H2OFrame = {
 
     val keyName = frameKeyName.getOrElse("frame_rdd_" + rdd.id + Key.rand())
 
-    // first convert vector to dense vector
-    val rddDense = rdd.map(labeledPoint => new LabeledPoint(labeledPoint.label, labeledPoint.features.toDense))
-    val numFeatures = rddDense.map(labeledPoint => labeledPoint.features.size)
+    // lets assume this is sparse for now, all of those guys
+
+    // we can work with sparse vector
+    val numFeatures = rdd.map(v => v.size)
     val maxNumFeatures = numFeatures.max()
     val minNumFeatures = numFeatures.min()
     if (minNumFeatures < maxNumFeatures) {
       // Features vectors of different sizes, filling missing with n/a
       logWarning("WARNING: Converting RDD[LabeledPoint] to H2OFrame where features vectors have different size, filling missing with n/a")
     }
-    val fnames = ("label" :: 0.until(maxNumFeatures).map("feature" +).toList).toArray[String]
+
+    val fnames = 0.until(maxNumFeatures).map("v_" +).toArray[String]
 
     // in case of internal backend, store regular vector types
     // otherwise for external backend store expected types
     val typeToUse = if (hc.getConf.runsInInternalClusterMode) Vec.T_NUM else ExternalFrameUtils.EXPECTED_DOUBLE
-    val expectedTypes = Array.fill(maxNumFeatures + 1)(typeToUse)
+    val expectedTypes = Array.fill(maxNumFeatures)(typeToUse)
 
-    WriteConverterCtxUtils.convert[LabeledPoint](hc, rdd, keyName, fnames, expectedTypes, Array.empty[Int], perLabeledPointRDDPartition(maxNumFeatures))
+    WriteConverterCtxUtils.convert[mllib.linalg.Vector](hc, rdd, keyName, fnames, expectedTypes, Array(maxNumFeatures), perMLlibVectorPartition(maxNumFeatures))
   }
+
 
   /**
     *
@@ -64,34 +66,15 @@ private[converters] object LabeledPointConverter extends Logging {
     * @return pair (partition ID, number of rows in this partition)
     */
   private[this]
-  def perLabeledPointRDDPartition(maxNumFeatures: Int)
-                                 (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan], writeTimeout: Int)
-                                 (context: TaskContext, it: Iterator[LabeledPoint]): (Int, Long) = {
+  def perMLlibVectorPartition(maxNumFeatures: Int)
+                             (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan], writeTimeout: Int)
+                             (context: TaskContext, it: Iterator[mllib.linalg.Vector]): (Int, Long) = {
     val (iterator, dataSize) = WriteConverterCtxUtils.bufferedIteratorWithSize(uploadPlan, it)
     val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize, writeTimeout)
     // Creates array of H2O NewChunks; A place to record all the data in this partition
-    con.createChunks(keyName, vecTypes, context.partitionId(), Array.empty[Int])
+    con.createChunks(keyName, vecTypes, context.partitionId(), Array(maxNumFeatures))
 
-    iterator.foreach(labeledPoint => {
-      // For all LabeledPoints in RDD
-      var nextChunkId = 0
-
-      // Add LabeledPoint label
-      con.put(nextChunkId, labeledPoint.label)
-      nextChunkId = nextChunkId + 1
-
-      for (i <- 0 until labeledPoint.features.size) {
-        // For all features...
-        con.put(nextChunkId, labeledPoint.features(i))
-        nextChunkId = nextChunkId + 1
-      }
-
-      for (i <- labeledPoint.features.size until maxNumFeatures) {
-        // Fill missing features with n/a
-        con.putNA(nextChunkId)
-        nextChunkId = nextChunkId + 1
-      }
-    })
+    iterator.foreach(vec => con.putVector(0, vec, maxNumFeatures))
 
     //Compress & write data in partitions to H2O Chunks
     con.closeChunks()

--- a/core/src/main/scala/org/apache/spark/h2o/converters/MLVectorConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/MLVectorConverter.scala
@@ -1,0 +1,34 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.converters
+
+import org.apache.spark.h2o.{H2OContext, RDD}
+import org.apache.spark.internal.Logging
+import org.apache.spark.ml
+import org.apache.spark.mllib.linalg.Vectors
+import water.fvec.H2OFrame
+
+private[converters] object MLVectorConverter extends Logging {
+
+
+  /** Transform RDD[ml.linalg.Vector] to appropriate H2OFrame */
+  def toH2OFrame(hc: H2OContext, rdd: RDD[ml.linalg.Vector], frameKeyName: Option[String]): H2OFrame = {
+    // convert to mllib vector so we have single place in code where we handle this case
+    MLLibVectorConverter.toH2OFrame(hc, rdd.map(Vectors.fromML), frameKeyName)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/h2o/converters/ProductRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/ProductRDDConverter.scala
@@ -19,9 +19,10 @@ package org.apache.spark.h2o.converters
 
 
 import org.apache.spark.h2o._
+import org.apache.spark.h2o.backends.external.ExternalBackendUtils
 import org.apache.spark.h2o.utils.ReflectionUtils
 import org.apache.spark.internal.Logging
-import water.{ExternalFrameUtils, Key}
+import water.Key
 
 import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.ClassTag
@@ -54,10 +55,10 @@ private[h2o] object ProductRDDConverter extends Logging {
     val expectedTypes = if (hc.getConf.runsInInternalClusterMode) {
       vecTypes
     } else {
-      ExternalFrameUtils.prepareExpectedTypes(ftypes)
+      ExternalBackendUtils.prepareExpectedTypes(ftypes)
     }
 
-    WriteConverterCtxUtils.convert[T](hc, rdd, keyName, fnames, expectedTypes, H2OFrameFromRDDProductBuilder.perTypedDataPartition())
+    WriteConverterCtxUtils.convert[T](hc, rdd, keyName, fnames, expectedTypes, Array.empty[Int], H2OFrameFromRDDProductBuilder.perTypedDataPartition())
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -120,32 +120,32 @@ private[h2o] object SparkDataFrameConverter extends Logging {
     * Converts a single Spark Row to H2O Row with expanded vectors and arrays
     */
   def sparkRowToH2ORow(row: Row, con: WriteConverterCtx, startIndices: Array[Int], elemSizes: Array[Int]) {
-    row.schema.fields.zipWithIndex.foreach { case (entry, idxRow) =>
-      val idxH2O = startIndices(idxRow)
-      if (row.isNullAt(idxRow)) {
+    row.schema.fields.zipWithIndex.foreach { case (entry, idxField) =>
+      val idxH2O = startIndices(idxField)
+      if (row.isNullAt(idxField)) {
         con.putNA(idxH2O)
       } else {
         entry.dataType match {
-          case BooleanType => con.put(idxH2O, if (row.getBoolean(idxRow)) 1 else 0)
+          case BooleanType => con.put(idxH2O, if (row.getBoolean(idxField)) 1 else 0)
           case BinaryType =>
-          case ByteType => con.put(idxH2O, row.getByte(idxRow))
-          case ShortType => con.put(idxH2O, row.getShort(idxRow))
-          case IntegerType => con.put(idxH2O, row.getInt(idxRow))
-          case LongType => con.put(idxH2O, row.getLong(idxRow))
-          case FloatType => con.put(idxH2O, row.getFloat(idxRow))
-          case _: DecimalType => con.put(idxH2O, row.getDecimal(idxRow).doubleValue())
-          case DoubleType => con.put(idxH2O, row.getDouble(idxRow))
-          case StringType => con.put(idxH2O, row.getString(idxRow))
-          case TimestampType => con.put(idxH2O, row.getAs[java.sql.Timestamp](idxRow))
-          case DateType => con.put(idxH2O, row.getAs[java.sql.Date](idxRow))
-          case ArrayType(elemType, _) => putArray(row.getAs[Seq[_]](idxRow), elemType, con, idxH2O, elemSizes(idxRow))
+          case ByteType => con.put(idxH2O, row.getByte(idxField))
+          case ShortType => con.put(idxH2O, row.getShort(idxField))
+          case IntegerType => con.put(idxH2O, row.getInt(idxField))
+          case LongType => con.put(idxH2O, row.getLong(idxField))
+          case FloatType => con.put(idxH2O, row.getFloat(idxField))
+          case _: DecimalType => con.put(idxH2O, row.getDecimal(idxField).doubleValue())
+          case DoubleType => con.put(idxH2O, row.getDouble(idxField))
+          case StringType => con.put(idxH2O, row.getString(idxField))
+          case TimestampType => con.put(idxH2O, row.getAs[java.sql.Timestamp](idxField))
+          case DateType => con.put(idxH2O, row.getAs[java.sql.Date](idxField))
+          case ArrayType(elemType, _) => putArray(row.getAs[Seq[_]](idxField), elemType, con, idxH2O, elemSizes(idxField))
           case _: UserDefinedType[_ /*mllib.linalg.Vector*/ ] => {
-            val value = row.get(idxRow)
+            val value = row.get(idxField)
             value match {
               case vector: mllib.linalg.Vector =>
-                con.putVector(idxH2O, vector, elemSizes(idxH2O))
+                con.putVector(idxH2O, vector, elemSizes(idxField))
               case vector: ml.linalg.Vector =>
-                con.putVector(idxH2O, vector, elemSizes(idxH2O))
+                con.putVector(idxH2O, vector, elemSizes(idxField))
             }
           }
           case _ => con.putNA(idxH2O)

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -17,16 +17,16 @@
 
 package org.apache.spark.h2o.converters
 
-import org.apache.spark._
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.backends.external.ExternalWriteConverterCtx
+import org.apache.spark.h2o.backends.external.{ExternalBackendUtils, ExternalWriteConverterCtx}
 import org.apache.spark.h2o.converters.WriteConverterCtxUtils.UploadPlan
 import org.apache.spark.h2o.utils.{H2OSchemaUtils, ReflectionUtils}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DateType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, TimestampType, _}
 import org.apache.spark.sql.{DataFrame, H2OFrameRelation, Row, SQLContext}
+import org.apache.spark.{mllib, _}
+import water.Key
 import water.fvec.{Frame, H2OFrame}
-import water.{ExternalFrameUtils, Key}
 
 
 private[h2o] object SparkDataFrameConverter extends Logging {
@@ -48,124 +48,66 @@ private[h2o] object SparkDataFrameConverter extends Logging {
     sqlContext.baseRelationToDataFrame(relation)
   }
 
+
   /** Transform Spark's DataFrame into H2O Frame */
   def toH2OFrame(hc: H2OContext, dataFrame: DataFrame, frameKeyName: Option[String]): H2OFrame = {
     import H2OSchemaUtils._
-    // Cache DataFrame RDD's
-    val dfRdd = dataFrame.rdd
-    val keyName = frameKeyName.getOrElse("frame_rdd_" + dfRdd.id + Key.rand())
 
-    // Flattens and expands RDD's schema
-    val flatRddSchema = expandedSchema(hc.sparkContext, dataFrame)
+    // Flatten the dataframe so we don't have any nested rows
+    val flatDataFrame = flattenDataFrame(dataFrame)
+
+    val dfRdd = flatDataFrame.rdd
+    val keyName = frameKeyName.getOrElse("frame_rdd_" + dfRdd.id + Key.rand())
+    val elemMaxSizes = collectMaxElementSizes(hc.sparkContext, flatDataFrame)
+    val vecMaxSizes = collectVectorLikeTypes(flatDataFrame.schema).map(elemMaxSizes(_)).toArray
+    val startPositions = collectElemStartPositions(elemMaxSizes)
+
+    // Expands RDD's schema ( Arrays and Vectors)
+    val flatRddSchema = expandedSchema(hc.sparkContext, H2OSchemaUtils.flattenSchema(dataFrame.schema), elemMaxSizes)
     // Patch the flat schema based on information about types
-    val fnames = flatRddSchema.map(t => t._2.name).toArray
+    val fnames = flatRddSchema.map(_.name).toArray
 
     // in case of internal backend, store regular vector types
     // otherwise for external backend store expected types
     val expectedTypes = if (hc.getConf.runsInInternalClusterMode) {
       // Transform datatype into h2o types
-      flatRddSchema.map(f => ReflectionUtils.vecTypeFor(f._2.dataType)).toArray
+      flatRddSchema.map(f => ReflectionUtils.vecTypeFor(f.dataType)).toArray
     } else {
-      val internalJavaClasses = flatRddSchema.map { f =>
-        ExternalWriteConverterCtx.internalJavaClassOf(f._2.dataType)
+      val internalJavaClasses = H2OSchemaUtils.expandWithoutVectors(hc.sparkContext, H2OSchemaUtils.flattenSchema(dataFrame.schema), elemMaxSizes).map { f =>
+        ExternalWriteConverterCtx.internalJavaClassOf(f.dataType)
       }.toArray
-      ExternalFrameUtils.prepareExpectedTypes(internalJavaClasses)
+      ExternalBackendUtils.prepareExpectedTypes(internalJavaClasses)
     }
-    WriteConverterCtxUtils.convert[Row](hc, dfRdd, keyName, fnames, expectedTypes, perSQLPartition(flatRddSchema))
+
+    WriteConverterCtxUtils.convert[Row](hc, dfRdd, keyName, fnames, expectedTypes, vecMaxSizes,
+      perSQLPartition(flatRddSchema, elemMaxSizes, vecMaxSizes, startPositions))
   }
 
   /**
     *
-    * @param keyName    key of the frame
-    * @param vecTypes   h2o vec types
-    * @param types      flat RDD schema
-    * @param uploadPlan plan which assigns each partition h2o node where the data from that partition will be uploaded
-    * @param context    spark task context
-    * @param it         iterator over data in the partition
+    * @param keyName        key of the frame
+    * @param vecTypes       h2o vec types
+    * @param types          flat RDD schema
+    * @param elemMaxSizes   array containing max size of each element in the dataframe
+    * @param startPositions array containing positions in h2o frame corresponding to spark frame
+    * @param uploadPlan     plan which assigns each partition h2o node where the data from that partition will be uploaded
+    * @param context        spark task context
+    * @param it             iterator over data in the partition
     * @return pair (partition ID, number of rows in this partition)
     */
   private[this]
-  def perSQLPartition(types: Seq[(Seq[Int], StructField, Byte)])
+  def perSQLPartition(types: Seq[StructField], elemMaxSizes: Array[Int], vecMaxSizes: Array[Int], startPositions: Array[Int])
                      (keyName: String, vecTypes: Array[Byte], uploadPlan: Option[UploadPlan], writeTimeout: Int)
                      (context: TaskContext, it: Iterator[Row]): (Int, Long) = {
 
     val (iterator, dataSize) = WriteConverterCtxUtils.bufferedIteratorWithSize(uploadPlan, it)
     val con = WriteConverterCtxUtils.create(uploadPlan, context.partitionId(), dataSize, writeTimeout)
     // Creates array of H2O NewChunks; A place to record all the data in this partition
-    con.createChunks(keyName, vecTypes, context.partitionId())
+    con.createChunks(keyName, vecTypes, context.partitionId(), vecMaxSizes)
 
-    iterator.foreach(row => {
-      var startOfSeq = -1
-      // Fill row in the output frame
-      types.indices.foreach { idx => // Index of column
-        val field = types(idx)
-        val path = field._1
-        val dataType = field._2.dataType
-        // Helpers to distinguish embedded collection types
-        val isAry = field._3 == H2OSchemaUtils.ARRAY_TYPE
-        val isVec = field._3 == H2OSchemaUtils.VEC_TYPE
-        val isNewPath = if (idx > 0) path != types(idx - 1)._1 else true
-        // Reset counter for sequences
-        if ((isAry || isVec) && isNewPath) startOfSeq = idx
-        else if (!isAry && !isVec) startOfSeq = -1
-
-        var i = 0
-        var subRow = row
-        while (i < path.length - 1 && !subRow.isNullAt(path(i))) {
-          subRow = subRow.getAs[Row](path(i))
-          i += 1
-        }
-        val aidx = path(i) // actual index into row provided by path
-        if (subRow.isNullAt(aidx)) {
-          con.putNA(idx)
-        } else {
-          val ary = if (isAry) subRow.getAs[Seq[_]](aidx) else null
-          val aryLen = if (isAry) ary.length else -1
-          val aryIdx = idx - startOfSeq // shared index to position in array/vector
-          val vecLen = if (isVec) getVecLen(subRow, aidx) else -1
-          if (isAry && aryIdx >= aryLen) con.putNA(idx)
-          else if (isVec && aryIdx >= vecLen) con.put(idx, 0.0) // Add zeros for double vectors
-          else dataType match {
-            case BooleanType => con.put(idx, if (isAry)
-              if (ary(aryIdx).asInstanceOf[Boolean]) 1 else 0
-            else if (subRow.getBoolean(aidx)) 1 else 0)
-            case BinaryType =>
-            case ByteType => con.put(idx, if (isAry) ary(aryIdx).asInstanceOf[Byte] else subRow.getByte(aidx))
-            case ShortType => con.put(idx, if (isAry) ary(aryIdx).asInstanceOf[Short] else subRow.getShort(aidx))
-            case IntegerType => con.put(idx, if (isAry) ary(aryIdx).asInstanceOf[Int] else subRow.getInt(aidx))
-            case LongType => con.put(idx, if (isAry) ary(aryIdx).asInstanceOf[Long] else subRow.getLong(aidx))
-            case FloatType => con.put(idx, if (isAry) ary(aryIdx).asInstanceOf[Float] else subRow.getFloat(aidx))
-            case _: DecimalType => con.put(idx, if (isAry) {
-              ary(aryIdx).asInstanceOf[BigDecimal].doubleValue()
-            } else {
-              if (isVec) {
-                getVecVal(subRow, aidx, idx - startOfSeq)
-              } else {
-                subRow.getDecimal(aidx).doubleValue()
-              }
-            })
-            case DoubleType => con.put(idx, if (isAry) {
-              ary(aryIdx).asInstanceOf[Double]
-            } else {
-              if (isVec) {
-                getVecVal(subRow, aidx, idx - startOfSeq)
-              } else {
-                subRow.getDouble(aidx)
-              }
-            })
-            case StringType =>
-              val sv = if (isAry) ary(aryIdx).asInstanceOf[String] else subRow.getString(aidx)
-              // Always produce string vectors
-              con.put(idx, sv)
-
-            case TimestampType => con.put(idx, subRow.getAs[java.sql.Timestamp](aidx))
-            case DateType => con.put(idx, subRow.getAs[java.sql.Date](aidx))
-            case _ => con.putNA(idx)
-          }
-        }
-
-      }
-    })
+    iterator.foreach {
+      sparkRowToH2ORow(_, con, startPositions, elemMaxSizes)
+    }
 
     //Compress & write data in partitions to H2O Chunks
     con.closeChunks()
@@ -174,27 +116,64 @@ private[h2o] object SparkDataFrameConverter extends Logging {
     (context.partitionId, con.numOfRows())
   }
 
-  private def getVecLen(r: Row, idx: Int): Int = {
-    val value = r.get(idx)
-    value match {
-      case vector: mllib.linalg.Vector =>
-        vector.size
-      case vector: ml.linalg.Vector =>
-        vector.size
-      case _ =>
-        -1
+  /**
+    * Converts a single Spark Row to H2O Row with expanded vectors and arrays
+    */
+  def sparkRowToH2ORow(row: Row, con: WriteConverterCtx, startIndices: Array[Int], elemSizes: Array[Int]) {
+    row.schema.fields.zipWithIndex.foreach { case (entry, idxRow) =>
+      val idxH2O = startIndices(idxRow)
+      if (row.isNullAt(idxRow)) {
+        con.putNA(idxH2O)
+      } else {
+        entry.dataType match {
+          case BooleanType => con.put(idxH2O, if (row.getBoolean(idxRow)) 1 else 0)
+          case BinaryType =>
+          case ByteType => con.put(idxH2O, row.getByte(idxRow))
+          case ShortType => con.put(idxH2O, row.getShort(idxRow))
+          case IntegerType => con.put(idxH2O, row.getInt(idxRow))
+          case LongType => con.put(idxH2O, row.getLong(idxRow))
+          case FloatType => con.put(idxH2O, row.getFloat(idxRow))
+          case _: DecimalType => con.put(idxH2O, row.getDecimal(idxRow).doubleValue())
+          case DoubleType => con.put(idxH2O, row.getDouble(idxRow))
+          case StringType => con.put(idxH2O, row.getString(idxRow))
+          case TimestampType => con.put(idxH2O, row.getAs[java.sql.Timestamp](idxRow))
+          case DateType => con.put(idxH2O, row.getAs[java.sql.Date](idxRow))
+          case ArrayType(elemType, _) => putArray(row.getAs[Seq[_]](idxRow), elemType, con, idxH2O, elemSizes(idxRow))
+          case _: UserDefinedType[_ /*mllib.linalg.Vector*/ ] => {
+            val value = row.get(idxRow)
+            value match {
+              case vector: mllib.linalg.Vector =>
+                con.putVector(idxH2O, vector, elemSizes(idxH2O))
+              case vector: ml.linalg.Vector =>
+                con.putVector(idxH2O, vector, elemSizes(idxH2O))
+            }
+          }
+          case _ => con.putNA(idxH2O)
+        }
+      }
     }
   }
 
-  private def getVecVal(r: Row, ridx: Int, vidx: Int): Double = {
-    val value = r.get(ridx)
-    value match {
-      case vector: mllib.linalg.Vector =>
-        vector(vidx)
-      case vector: ml.linalg.Vector =>
-        vector(vidx)
-      case _ =>
-        throw new ArrayIndexOutOfBoundsException(s"Row: ${r}, row index: ${ridx}, vector index: ${vidx}")
+  private def putArray(arr: Seq[_], elemType: DataType, con: WriteConverterCtx, idx: Int, maxArrSize: Int) {
+    arr.indices.foreach { arrIdx =>
+      val currentIdx = idx + arrIdx
+      elemType match {
+        case BooleanType => con.put(currentIdx, if (arr(arrIdx).asInstanceOf[Boolean]) 1 else 0)
+        case BinaryType =>
+        case ByteType => con.put(currentIdx, arr(arrIdx).asInstanceOf[Byte])
+        case ShortType => con.put(currentIdx, arr(arrIdx).asInstanceOf[Short])
+        case IntegerType => con.put(currentIdx, arr(arrIdx).asInstanceOf[Int])
+        case LongType => con.put(currentIdx, arr(arrIdx).asInstanceOf[Long])
+        case FloatType => con.put(currentIdx, arr(arrIdx).asInstanceOf[Float])
+        case _: DecimalType => con.put(currentIdx, arr(arrIdx).asInstanceOf[BigDecimal].doubleValue())
+        case DoubleType => con.put(currentIdx, arr(arrIdx).asInstanceOf[Double])
+        case StringType => con.put(currentIdx, arr(arrIdx).asInstanceOf[String])
+        case TimestampType => con.put(currentIdx, arr(arrIdx).asInstanceOf[java.sql.Timestamp])
+        case DateType => con.put(currentIdx, arr(arrIdx).asInstanceOf[java.sql.Date])
+        case _ => con.putNA(currentIdx)
+      }
     }
+
+    (arr.size until maxArrSize).foreach { arrIdx => con.putNA(idx + arrIdx) }
   }
 }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SupportedRDDConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SupportedRDDConverter.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.h2o.converters
 
 import org.apache.spark.h2o._
+import org.apache.spark._
 import org.apache.spark.mllib.regression.LabeledPoint
 
 import scala.language.implicitConversions
@@ -125,5 +126,13 @@ private[this] object SupportedRDD {
   }
   implicit def toH2OFrameFromRDDProduct[A <: Product : TypeTag](rdd : RDD[A]): SupportedRDD = new SupportedRDD {
     override def toH2OFrame(hc: H2OContext, frameKeyName: Option[String]): H2OFrame = ProductRDDConverter.toH2OFrame(hc, rdd, frameKeyName)
+  }
+
+  implicit def toH2OFrameFromRDDMLlibVector(rdd: RDD[mllib.linalg.Vector]): SupportedRDD = new SupportedRDD {
+    override def toH2OFrame(hc: H2OContext, frameKeyName: Option[String]): H2OFrame = MLLibVectorConverter.toH2OFrame(hc, rdd, frameKeyName)
+  }
+
+  implicit def toH2OFrameFromRDDmlVector(rdd: RDD[ml.linalg.Vector]): SupportedRDD = new SupportedRDD {
+    override def toH2OFrame(hc: H2OContext, frameKeyName: Option[String]): H2OFrame = MLVectorConverter.toH2OFrame(hc, rdd, frameKeyName)
   }
 }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtx.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtx.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.h2o.converters
 
 import org.apache.spark._
-import org.apache.spark.mllib.linalg.{SparseVector, Vectors}
+import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vectors}
 
 /**
   * Methods which each WriteConverterCtx has to implement.
@@ -78,11 +78,9 @@ trait WriteConverterCtx {
 
   def putVector(startIdx: Int, vec: mllib.linalg.Vector, maxVecSize: Int): Unit = {
     if (vec.isInstanceOf[SparseVector]) {
-      val sparseVec = vec.toSparse
-      putSparseVector(startIdx, sparseVec, maxVecSize)
+      putSparseVector(startIdx, vec.asInstanceOf[SparseVector], maxVecSize)
     } else {
-      val denseVector = vec.toDense
-      putDenseVector(startIdx, denseVector, maxVecSize)
+      putDenseVector(startIdx, vec.asInstanceOf[DenseVector], maxVecSize)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
@@ -37,7 +37,7 @@ object WriteConverterCtxUtils {
   def create(uploadPlan: Option[UploadPlan],
              partitionId: Int, totalNumOfRows: Option[Int], writeTimeout: Int): WriteConverterCtx = {
     uploadPlan
-      .map { plan => new ExternalWriteConverterCtx(uploadPlan.get(partitionId), totalNumOfRows.get, writeTimeout) }
+      .map { _ => new ExternalWriteConverterCtx(uploadPlan.get(partitionId), totalNumOfRows.get, writeTimeout) }
       .getOrElse(new InternalWriteConverterCtx())
   }
 
@@ -67,8 +67,9 @@ object WriteConverterCtxUtils {
     * @tparam T type of RDD to convert
     * @return H2O Frame
     */
+
   def convert[T](hc: H2OContext, rdd: RDD[T], keyName: String, colNames: Array[String], vecTypes: Array[Byte],
-                 func: ConversionFunction[T]) = {
+                 maxVecSizes: Array[Int], func: ConversionFunction[T]) = {
     // Make an H2O data Frame - but with no backing data (yet)
     initFrame(keyName, colNames)
 
@@ -80,6 +81,7 @@ object WriteConverterCtxUtils {
     }
 
     val operation: SparkJob[T] = func(keyName, vecTypes, uploadPlan, hc.getConf.externalWriteConfirmationTimeout)
+
     val rows = hc.sparkContext.runJob(rdd, operation) // eager, not lazy, evaluation
     val res = new Array[Long](rdd.partitions.length)
     rows.foreach { case (cidx, nrows) => res(cidx) = nrows }
@@ -87,7 +89,7 @@ object WriteConverterCtxUtils {
 
     // get the vector types from expected types in case of external h2o cluster
     val types = if (hc.getConf.runsInExternalClusterMode) {
-      ExternalFrameUtils.vecTypesFromExpectedTypes(vecTypes)
+      ExternalFrameUtils.vecTypesFromExpectedTypes(vecTypes, maxVecSizes)
     } else {
       vecTypes
     }

--- a/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
@@ -34,8 +34,8 @@ class H2OSchemaUtilsTestSuite extends FunSuite {
         StructField("b", IntegerType, false)
         :: Nil
     )
-    val flatSchema = H2OSchemaUtils.flatSchema(expSchema)
-    assert (flatSchema === Seq(StructField("a", IntegerType, true), StructField("b", IntegerType, false)))
+    val flatSchema = H2OSchemaUtils.flattenSchema(expSchema)
+    assert (flatSchema.fields === Seq(StructField("a", IntegerType, true), StructField("b", IntegerType, false)))
   }
 
   test("Test flatSchema on composed schema") {
@@ -50,8 +50,8 @@ class H2OSchemaUtilsTestSuite extends FunSuite {
         ), false)
         :: Nil
     )
-    val flatSchema = H2OSchemaUtils.flatSchema(expSchema)
-    assert (flatSchema === Seq(StructField("a.a1", DoubleType, true),
+    val flatSchema = H2OSchemaUtils.flattenSchema(expSchema)
+    assert (flatSchema.fields === Seq(StructField("a.a1", DoubleType, true),
                                 StructField("a.a2", StringType, true),
                                 StructField("b.b1", DoubleType, false),
                                 StructField("b.b2", StringType, true)))
@@ -71,10 +71,11 @@ class H2OSchemaUtilsTestSuite extends FunSuite {
         :: Nil
     )
 
-    val stringIndices = H2OSchemaUtils.collectStringTypesIndx(expSchema.fields)
-    val arrayIndices = H2OSchemaUtils.collectArrayLikeTypes(expSchema.fields)
+    val flattenSchema = H2OSchemaUtils.flattenSchema(expSchema)
+    val stringIndices = H2OSchemaUtils.collectStringIndices(flattenSchema)
+    val arrayIndices = H2OSchemaUtils.collectArrayLikeTypes(flattenSchema)
 
-    assert (stringIndices === List ( List(0, 1), List(1, 0), List(1, 1), List(2)))
+    assert (stringIndices === List (1, 2, 3, 4))
     assert (arrayIndices === Nil)
   }
 

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -18,13 +18,14 @@ package org.apache.spark.h2o.converters
 
 import java.io.File
 import java.sql.Timestamp
+import java.util
 import java.util.UUID
 
 import hex.splitframe.ShuffleSplitFrame
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.testdata._
+import org.apache.spark.h2o.utils.H2OAsserts._
 import org.apache.spark.h2o.utils.{H2OSchemaUtils, SharedSparkTestContext}
-import org.apache.spark.h2o.{Frame => _, H2OFrame => _}
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
@@ -456,9 +457,7 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     val values = (1 to num).map(x => PrimitiveB(1 to x))
     val df = sc.parallelize(values).toDF
 
-    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
-    val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
-    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
+    val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
 
     val metadatas = expandedSchema.map(f => f.metadata)
 
@@ -474,6 +473,7 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     // Basic invariants
     assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
     assert(5 == h2oFrame.numCols(), "Number columns should match")
+    assert(h2oFrame.names() === expandedSchema.map(_.name))
 
     // Verify data stored in h2oFrame after transformation
     assertVectorIntValues(h2oFrame.vec(0), Seq(1, 1, 1, 1, 1))
@@ -483,45 +483,14 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     assertVectorIntValues(h2oFrame.vec(4), Seq(-1, -1, -1, -1, 5))
   }
 
-  test("Expand schema with dense vectors") {
+  test("Expand schema with MLLIB dense vectors") {
     import spark.implicits._
 
-    val num = 2
-    val values = (1 to num).map(x => PrimitiveC(Vectors.dense((1 to x).map(1.0 * _).toArray)))
+    val num = 3
+    val values = (1 to num).map(x => PrimitiveMllibFixture(Vectors.dense((1 to x).map(1.0 * _).toArray)))
     val df = sc.parallelize(values).toDF
 
-    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
-    val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
-    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
-
-    assert(expandedSchema === Vector(
-      StructField("f0", DoubleType),
-      StructField("f1", DoubleType)))
-
-    // Verify transformation into DataFrame
-    val h2oFrame = hc.asH2OFrame(df)
-    // Basic invariants
-    assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
-    assert(2 == h2oFrame.numCols(), "Number columns should match")
-
-    // Verify data stored in h2oFrame after transformation
-    assertVectorDoubleValues(h2oFrame.vec(0), Seq(1.0, 1.0))
-    // For vectors missing values are replaced by zeros
-    assertVectorDoubleValues(h2oFrame.vec(1), Seq(0.0, 2.0))
-  }
-
-  test("Expand schema with sparse vectors") {
-    import spark.implicits._
-    val num = 3
-    val values = (0 until num).map(x =>
-      PrimitiveC(
-        Vectors.sparse(num, Seq((x, 1.0)))
-      ))
-    val df = sc.parallelize(values).toDF()
-
-    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
-    val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
-    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
+    val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
 
     assert(expandedSchema === Vector(
       StructField("f0", DoubleType),
@@ -532,12 +501,132 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     val h2oFrame = hc.asH2OFrame(df)
     // Basic invariants
     assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
-    assert(3 == h2oFrame.numCols(), "Number columns should match")
+    assert(expandedSchema.length == h2oFrame.numCols(), "Number columns should match")
+    assert(h2oFrame.names() === expandedSchema.map(_.name))
 
     // Verify data stored in h2oFrame after transformation
-    assertVectorDoubleValues(h2oFrame.vec(0), Seq(1.0, 0.0, 0.0))
-    assertVectorDoubleValues(h2oFrame.vec(1), Seq(0.0, 1.0, 0.0))
-    assertVectorDoubleValues(h2oFrame.vec(2), Seq(0.0, 0.0, 1.0))
+    assertDoubleFrameValues(h2oFrame, values.map(pojo => util.Arrays.copyOf(pojo.f.toArray, num)))
+  }
+
+  test("Expand schema with MLLIB sparse vectors") {
+    import spark.implicits._
+    val num = 3
+    val values = (0 until num).map(x =>
+      PrimitiveMllibFixture(
+        Vectors.sparse(num, Seq((x, 1.0)))
+      ))
+    val df = sc.parallelize(values).toDF()
+
+    val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
+
+    assert(expandedSchema === Vector(
+      StructField("f0", DoubleType),
+      StructField("f1", DoubleType),
+      StructField("f2", DoubleType)))
+
+    // Verify transformation into DataFrame
+    val h2oFrame = hc.asH2OFrame(df)
+    // Basic invariants
+    assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
+    assert(expandedSchema.length == h2oFrame.numCols(), "Number columns should match")
+    assert(h2oFrame.names() === expandedSchema.map(_.name))
+
+    // Verify data stored in h2oFrame after transformation
+    assertDoubleFrameValues(h2oFrame, values.map(_.f.toArray))
+  }
+
+  test("Expand schema with ML dense vectors") {
+   import spark.implicits._
+
+   val num = 2
+   val values = (1 to num).map(x =>
+     PrimitiveMlFixture(org.apache.spark.ml.linalg.Vectors.dense((1 to x).map(1.0 * _).toArray))
+   )
+   val df = sc.parallelize(values).toDF
+
+   val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
+
+   assert(expandedSchema === Vector(
+     StructField("f0", DoubleType),
+     StructField("f1", DoubleType)))
+
+   // Verify transformation into DataFrame
+   val h2oFrame = hc.asH2OFrame(df)
+   // Basic invariants
+   assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
+   assert(expandedSchema.length == h2oFrame.numCols(), "Number columns should match")
+   assert(h2oFrame.names() === expandedSchema.map(_.name))
+
+   // Verify data stored in h2oFrame after transformation
+   assertVectorDoubleValues(h2oFrame.vec(0), Seq(1.0, 1.0))
+   // For vectors missing values are replaced by zeros
+   assertVectorDoubleValues(h2oFrame.vec(1), Seq(0.0, 2.0))
+ }
+
+
+  test("Expand schema with ML sparse vectors") {
+    import spark.implicits._
+    val num = 3
+    val values = (0 until num).map(x =>
+     PrimitiveMlFixture(
+       org.apache.spark.ml.linalg.Vectors.sparse(num, Seq((x, 1.0)))
+     ))
+    val df = sc.parallelize(values, num).toDF()
+
+    val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
+
+    assert(expandedSchema === Vector(
+      StructField("f0", DoubleType),
+      StructField("f1", DoubleType),
+      StructField("f2", DoubleType)))
+
+    // Verify transformation into DataFrame
+    val h2oFrame = hc.asH2OFrame(df)
+    // Basic invariants
+    assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
+    assert(expandedSchema.length == h2oFrame.numCols(), "Number columns should match")
+    assert(h2oFrame.names() === expandedSchema.map(_.name))
+
+    // Verify data stored in h2oFrame after transformation
+    assertDoubleFrameValues(h2oFrame, values.map(_.f.toArray))
+  }
+  
+  test("Expand complex schema with sparse and dense vectors") {
+    import spark.implicits._
+    val num = 3
+    val values = (0 until num).map(x =>
+     ComplexMlFixture(
+       org.apache.spark.ml.linalg.Vectors.sparse(num, Seq((x, 1.0))),
+       x,
+       org.apache.spark.ml.linalg.Vectors.dense((1 to x).map(1.0 * _).toArray)
+     ))
+    println(values.mkString("\n"))
+    val df = sc.parallelize(values, num).toDF()
+
+    val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
+
+    assert(expandedSchema === Vector(
+      StructField("f10", DoubleType),
+      StructField("f11", DoubleType),
+      StructField("f12", DoubleType),
+      StructField("idx", IntegerType),
+      StructField("f20", DoubleType),
+      StructField("f21", DoubleType)
+      )
+    )
+
+    // Verify transformation into DataFrame
+    val h2oFrame = hc.asH2OFrame(df)
+    
+    // Basic invariants
+    assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
+    assert(expandedSchema.length == h2oFrame.numCols(), "Number columns should match")
+    assert(h2oFrame.names() === expandedSchema.map(_.name))
+
+    // Verify data stored in h2oFrame after transformation
+    assertDoubleFrameValues(h2oFrame, Seq(Array(1.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                                          Array(0.0, 1.0, 0.0, 1.0, 1.0, 0.0),
+                                          Array(0.0, 0.0, 1.0, 2.0, 1.0, 2.0)))
   }
 
   test("Add metadata to Dataframe") {
@@ -602,35 +691,10 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     assert(df.numCols() == H2OSchemaUtils.flattenSchema(inputDF.schema).length, "Number columns should match")
   }
 
-  def assertVectorIntValues(vec: water.fvec.Vec, values: Seq[Int]): Unit = {
-    (0 until vec.length().toInt).foreach { rIdx =>
-      assert(if (vec.isNA(rIdx)) -1 == values(rIdx)
-      else vec.at8(rIdx) == values(rIdx), "Values stored in H2OFrame has to match specified values")
-    }
-  }
-
-  def assertVectorDoubleValues(vec: water.fvec.Vec, values: Seq[Double]): Unit = {
-    (0 until vec.length().toInt).foreach { rIdx =>
-      assert(if (vec.isNA(rIdx)) values(rIdx) == Double.NaN // this is Scala i can do NaN comparision
-      else vec.at(rIdx) == values(rIdx), "Values stored in H2OFrame has to match specified values")
-    }
-  }
-
-  def assertVectorEnumValues(vec: water.fvec.Vec, values: Seq[String]): Unit = {
-    val vecDom = vec.domain()
-    (0 until vec.length().toInt).foreach { rIdx =>
-      assert(vecDom(vec.at8(rIdx).asInstanceOf[Int]) == values(rIdx), "Values stored in H2OFrame has to match specified values")
-    }
-  }
-
-  def assertVectorStringValues(vec: water.fvec.Vec, values: Seq[String]): Unit = {
-    val valString = new BufferedString()
-    (0 until vec.length().toInt).foreach { rIdx =>
-      assert(
-        vec.isNA(rIdx) || {
-          vec.atStr(valString, rIdx)
-          valString.toSanitizedString == values(rIdx)
-        }, "Values stored in H2OFrame has to match specified values")
-    }
+  def getSchemaInfo(df: DataFrame): (DataFrame, Array[Int], Seq[StructField]) = {
+    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
+    val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
+    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
+    (flattenDF, maxElementSizes, expandedSchema)
   }
 }

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -618,7 +618,7 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
       assert(
         vec.isNA(rIdx) || {
           vec.atStr(valString, rIdx)
-          valString.bytesToString() == values(rIdx)
+          valString.toSanitizedString == values(rIdx)
         }, "Values stored in H2OFrame has to match specified values")
     }
   }

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -23,7 +23,6 @@ import java.util.UUID
 import hex.splitframe.ShuffleSplitFrame
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.testdata._
-import org.apache.spark.h2o.utils.H2OSchemaUtils.flatSchema
 import org.apache.spark.h2o.utils.{H2OSchemaUtils, SharedSparkTestContext}
 import org.apache.spark.h2o.{Frame => _, H2OFrame => _}
 import org.apache.spark.mllib.linalg.Vectors
@@ -425,14 +424,16 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
 
     val expectObjectsNullableByDefault = true
 
-    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, df)
-    val expected: Vector[(List[Int], StructField, Int)] = Vector(
-      (List(0, 0), StructField("a.n", IntegerType), 0),
-      (List(0, 1), StructField("a.name", StringType), 0),
-      (List(1), StructField("weight", DoubleType, nullable = expectObjectsNullableByDefault), 0))
+    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
+    val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
+    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
+    val expected: Vector[StructField] = Vector(
+      StructField("a.n", IntegerType),
+      StructField("a.name", StringType),
+      StructField("weight", DoubleType, nullable = expectObjectsNullableByDefault))
     Assertions.assertResult(expected.length)(expandedSchema.length)
 
-    assertResult(expectObjectsNullableByDefault, "Nullability in component#2")(expandedSchema(2)._2.nullable)
+    assertResult(expectObjectsNullableByDefault, "Nullability in component#2")(expandedSchema(2).nullable)
     for {i <- expected.indices} {
       assertResult(expected(i), s"@$i")(expandedSchema(i))
     }
@@ -454,15 +455,19 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     val num = 5
     val values = (1 to num).map(x => PrimitiveB(1 to x))
     val df = sc.parallelize(values).toDF
-    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, df)
-    val metadatas = expandedSchema.map(f => f._2.metadata)
+
+    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
+    val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
+    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
+
+    val metadatas = expandedSchema.map(f => f.metadata)
 
     assert(expandedSchema === Vector(
-      (List(0), StructField("f0", IntegerType, nullable = false, metadatas.head), 1),
-      (List(0), StructField("f1", IntegerType, nullable = false, metadatas(1)), 1),
-      (List(0), StructField("f2", IntegerType, nullable = false, metadatas(2)), 1),
-      (List(0), StructField("f3", IntegerType, nullable = false, metadatas(3)), 1),
-      (List(0), StructField("f4", IntegerType, nullable = false, metadatas(4)), 1)))
+      (StructField("f0", IntegerType, nullable = false, metadatas.head)),
+      (StructField("f1", IntegerType, nullable = false, metadatas(1))),
+      (StructField("f2", IntegerType, nullable = false, metadatas(2))),
+      (StructField("f3", IntegerType, nullable = false, metadatas(3))),
+      (StructField("f4", IntegerType, nullable = false, metadatas(4)))))
 
     // Verify transformation into dataframe
     val h2oFrame = hc.asH2OFrame(df)
@@ -484,11 +489,14 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     val num = 2
     val values = (1 to num).map(x => PrimitiveC(Vectors.dense((1 to x).map(1.0 * _).toArray)))
     val df = sc.parallelize(values).toDF
-    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, df)
+
+    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
+    val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
+    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
 
     assert(expandedSchema === Vector(
-      (List(0), StructField("f0", DoubleType), 2),
-      (List(0), StructField("f1", DoubleType), 2)))
+      StructField("f0", DoubleType),
+      StructField("f1", DoubleType)))
 
     // Verify transformation into DataFrame
     val h2oFrame = hc.asH2OFrame(df)
@@ -507,15 +515,18 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     val num = 3
     val values = (0 until num).map(x =>
       PrimitiveC(
-        Vectors.sparse(num, (0 until num).map(i => if (i == x) (i, 1.0) else (i, 0.0)))
+        Vectors.sparse(num, Seq((x, 1.0)))
       ))
     val df = sc.parallelize(values).toDF()
-    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, df)
+
+    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
+    val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
+    val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
 
     assert(expandedSchema === Vector(
-      (List(0), StructField("f0", DoubleType), 2),
-      (List(0), StructField("f1", DoubleType), 2),
-      (List(0), StructField("f2", DoubleType), 2)))
+      StructField("f0", DoubleType),
+      StructField("f1", DoubleType),
+      StructField("f2", DoubleType)))
 
     // Verify transformation into DataFrame
     val h2oFrame = hc.asH2OFrame(df)
@@ -588,7 +599,7 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
 
   def assertH2OFrameInvariants(inputDF: DataFrame, df: H2OFrame): Unit = {
     assert(inputDF.count == df.numRows(), "Number of rows has to match")
-    assert(df.numCols() == flatSchema(inputDF.schema).length, "Number columns should match")
+    assert(df.numCols() == H2OSchemaUtils.flattenSchema(inputDF.schema).length, "Number columns should match")
   }
 
   def assertVectorIntValues(vec: water.fvec.Vec, values: Seq[Int]): Unit = {

--- a/core/src/test/scala/org/apache/spark/h2o/converters/SW516StandaloneApp.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/SW516StandaloneApp.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.h2o.converters
+
+import org.apache.spark.h2o.{H2OConf, H2OContext}
+import org.apache.spark.sql.SparkSession
+
+object SW516StandaloneApp {
+  val valuesCnt = 10
+  val partitions = 2
+  val cloudName = "SW516"
+}
+
+case class Data(f1: org.apache.spark.ml.linalg.Vector,
+                f2: org.apache.spark.ml.linalg.Vector)
+
+object SWApp {
+  import SW516StandaloneApp._
+
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("SW516")
+      .master("local[*]")
+      .config("spark.ext.h2o.external.read.confirmation.timeout", 240)
+      .getOrCreate()
+    
+    val h2oConf = new H2OConf(spark).setExternalClusterMode().useManualClusterStart().setCloudName(cloudName)
+    val hc = H2OContext.getOrCreate(spark, h2oConf)
+
+    val values = (0 until valuesCnt).map(x =>
+     Data(
+       org.apache.spark.ml.linalg.Vectors.sparse(valuesCnt, Seq((x, 1.0))),
+       org.apache.spark.ml.linalg.Vectors.dense(x.toDouble, 0.0, 1.0, 42.0)
+     ))
+
+    import spark.implicits._
+    println(s"Values to transfer: ${values.mkString("\n")}")
+    
+    // Create data in Spark
+    val df = spark.sparkContext.parallelize(values, partitions).toDF()
+    df.printSchema()
+
+    // Transfer data to H2O
+    val hf = hc.asH2OFrame(df)
+    println(hf.toString(0, 100))
+
+    spark.stop()
+  }
+}
+
+object H2OApp {
+  import SW516StandaloneApp._
+
+  def main(args: Array[String]): Unit = {
+    water.H2O.main(Array("-name", cloudName, "-md5skip"))
+  }
+
+}
+
+

--- a/core/src/test/scala/org/apache/spark/h2o/testdata/TestData.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/testdata/TestData.scala
@@ -48,7 +48,13 @@ case class ComposedWithTimestamp(a: PrimitiveA, v: TimestampField)
 
 case class PrimitiveB(f: Seq[Int])
 
-case class PrimitiveC(f: mllib.linalg.Vector)
+case class PrimitiveMllibFixture(f: mllib.linalg.Vector)
+
+case class PrimitiveMlFixture(f: org.apache.spark.ml.linalg.Vector)
+
+case class ComplexMlFixture(f1: org.apache.spark.ml.linalg.Vector,
+                            idx: Int,
+                            f2: org.apache.spark.ml.linalg.Vector)
 
 case class Prostate(ID: Option[Long],
                     CAPSULE: Option[Int],

--- a/core/src/test/scala/org/apache/spark/h2o/utils/ExternalBackendTestHelper.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/ExternalBackendTestHelper.scala
@@ -48,7 +48,7 @@ trait ExternalBackendTestHelper {
     // instead of extending h2o jar by another classes
     // The best solution would be to implement distributed classloading for H2O
     val jarList = List(h2oExtendedJar) ++ additionalCp.toList
-    val cmdToLaunch = Seq[String]("java", "-cp", jarList.mkString(":"), "water.H2OApp", "-md5skip", "-name", cloudName, "-ip", ip)
+    val cmdToLaunch = Seq[String]("java", "-ea", "-cp", jarList.mkString(":"), "water.H2OApp", "-md5skip", "-name", cloudName, "-ip", ip)
     Process(cmdToLaunch).run()
   }
 

--- a/core/src/test/scala/org/apache/spark/h2o/utils/H2OAsserts.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/H2OAsserts.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.h2o.utils
+
+import water.parser.BufferedString
+
+object H2OAsserts {
+  def assertVectorIntValues(vec: water.fvec.Vec, values: Seq[Int]): Unit = {
+    (0 until vec.length().toInt).foreach { rIdx =>
+      assert(if (vec.isNA(rIdx)) -1 == values(rIdx)
+             else vec.at8(rIdx) == values(rIdx), "Values stored in H2OFrame has to match specified values")
+    }
+  }
+
+  def assertVectorDoubleValues(vec: water.fvec.Vec, values: Seq[Double]): Unit = {
+    (0 until vec.length().toInt).foreach { rIdx =>
+      assert(if (vec.isNA(rIdx)) values(rIdx) == Double.NaN // this is Scala i can do NaN comparision
+             else vec.at(rIdx) == values(rIdx), "Values stored in H2OFrame has to match specified values")
+    }
+  }
+
+  def assertVectorEnumValues(vec: water.fvec.Vec, values: Seq[String]): Unit = {
+    val vecDom = vec.domain()
+    (0 until vec.length().toInt).foreach { rIdx =>
+      assert(vecDom(vec.at8(rIdx).asInstanceOf[Int]) == values(rIdx), "Values stored in H2OFrame has to match specified values")
+    }
+  }
+
+  def assertVectorStringValues(vec: water.fvec.Vec, values: Seq[String]): Unit = {
+    val valString = new BufferedString()
+    (0 until vec.length().toInt).foreach { rIdx =>
+      assert(
+        vec.isNA(rIdx) || {
+          vec.atStr(valString, rIdx)
+          valString.toSanitizedString == values(rIdx)
+        }, "Values stored in H2OFrame has to match specified values")
+    }
+  }
+
+  def assertDoubleFrameValues(f: water.fvec.Frame, rows: Seq[Array[Double]]): Unit = {
+    val ncol = f.numCols()
+    val rowsIdx = (0 until f.numRows().toInt)
+    val columns = (0 until ncol).map(cidx => rowsIdx.map(rows(_)(cidx)))
+    f.vecs().zipWithIndex.foreach { case (vec, idx: Int) =>
+      assertVectorDoubleValues(vec, columns(idx))
+    }
+  }
+}

--- a/examples/src/scriptsTest/scala/water/sparkling/scripts/ScriptsTestSuite.scala
+++ b/examples/src/scriptsTest/scala/water/sparkling/scripts/ScriptsTestSuite.scala
@@ -207,9 +207,9 @@ class ScriptPipelineHamOrSpam extends ScriptsTestHelper{
   }
   test("hamSpam.script.scala") {
     val inspections = new ScriptInspections()
-    inspections.addSnippet("val answer1 = isSpam(\"Michal, h2oworld party tonight in MV?\", modelOfLoadedPipeline, h2oContext)")
+    inspections.addSnippet("val answer1 = isSpam(\"Michal, h2oworld party tonight in MV?\", model, h2oContext)")
     inspections.addTermToCheck("answer1")
-    inspections.addSnippet("val answer2 = isSpam(\"We tried to contact you re your reply to our offer of a Video Handset? 750 anytime any networks mins? UNLIMITED TEXT?\", loadedModel, h2oContext)")
+    inspections.addSnippet("val answer2 = isSpam(\"We tried to contact you re your reply to our offer of a Video Handset? 750 anytime any networks mins? UNLIMITED TEXT?\", model, h2oContext)")
     inspections.addTermToCheck("answer2")
 
     val result = launchScript("hamOrSpam.script.scala", inspections, "pipelines")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,11 @@
 group=ai.h2o
 version=2.1.99999-SNAPSHOT
 # Major version of H2O release
-h2oMajorVersion=3.10.5
+h2oMajorVersion=3.14.0
 # Name of H2O major version
-h2oMajorName=vajda
+h2oMajorName=weierstrass
 # H2O Build version, defined here to be overriden by -P option
-h2oBuild=4
+h2oBuild=2
 # Spark version
 sparkVersion=2.1.1
 


### PR DESCRIPTION
SparkDataFrameConverter refactored. Now we first create flat dataframe in spark to simplify handling on sw side. 

The refactoring was needed in order to separate handling of vectors.

An improvement of this solution would be to drop the flag whether the vector is sparse or dense and make it part of the expected types

This change requires https://github.com/h2oai/h2o-3/pull/1348