### PR TITLE
[SW-407] Make Configuration consistent

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
@@ -27,109 +27,123 @@ trait SharedBackendConf {
 
   import SharedBackendConf._
 
-  def backendClusterMode = sparkConf.get(PROP_BACKEND_CLUSTER_MODE._1, PROP_BACKEND_CLUSTER_MODE._2)
+  /** Getters */
 
+  /** Generic parameters */
+  def backendClusterMode = sparkConf.get(PROP_BACKEND_CLUSTER_MODE._1, PROP_BACKEND_CLUSTER_MODE._2)
+  def cloudName = sparkConf.getOption(PROP_CLOUD_NAME._1)
+  def nthreads = sparkConf.getInt(PROP_NTHREADS._1, PROP_NTHREADS._2)
+  def disableGA = sparkConf.getBoolean(PROP_DISABLE_GA._1, PROP_DISABLE_GA._2)
+  def isH2OReplEnabled = sparkConf.getBoolean(PROP_REPL_ENABLED._1, PROP_REPL_ENABLED._2)
+  def scalaIntDefaultNum = sparkConf.getInt(PROP_SCALA_INT_DEFAULT_NUM._1, PROP_SCALA_INT_DEFAULT_NUM._2)
+  def isClusterTopologyListenerEnabled = sparkConf.getBoolean(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._2)
+  def isSparkVersionCheckEnabled = sparkConf.getBoolean(PROP_SPARK_VERSION_CHECK_ENABLED._1, PROP_SPARK_VERSION_CHECK_ENABLED._2)
+  def isFailOnUnsupportedSparkParamEnabled = sparkConf.getBoolean(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._2)
+  def jks = sparkConf.getOption(PROP_JKS._1)
+  def jksPass = sparkConf.getOption(PROP_JKS_PASS._1)
+  def hashLogin = sparkConf.getBoolean(PROP_HASH_LOGIN._1, PROP_HASH_LOGIN._2)
+  def ldapLogin = sparkConf.getBoolean(PROP_LDAP_LOGIN._1, PROP_LDAP_LOGIN._2)
+  def kerberosLogin = sparkConf.getBoolean(PROP_KERBEROS_LOGIN._1, PROP_KERBEROS_LOGIN._2)
+  def loginConf = sparkConf.getOption(PROP_LOGIN_CONF._1)
+  def userName = sparkConf.getOption(PROP_USER_NAME._1)
+  def sslConf = sparkConf.getOption(PROP_SSL_CONF._1)
+  def h2oNodeLogLevel = sparkConf.get(PROP_NODE_LOG_LEVEL._1, PROP_NODE_LOG_LEVEL._2)
+  def h2oNodeLogDir  = sparkConf.getOption(PROP_NODE_LOG_DIR._1)
+  def uiUpdateInterval = sparkConf.getInt(PROP_UI_UPDATE_INTERVAL._1, PROP_UI_UPDATE_INTERVAL._2)
+  def cloudTimeout = sparkConf.getInt(PROP_CLOUD_TIMEOUT._1, PROP_CLOUD_TIMEOUT._2)
+
+
+  /** H2O Client parameters */
+  def flowDir = sparkConf.getOption(PROP_FLOW_DIR._1)
   def clientIp      = sparkConf.getOption(PROP_CLIENT_IP._1)
-  def clientVerboseOutput = sparkConf.getBoolean(PROP_CLIENT_VERBOSE._1, PROP_CLIENT_VERBOSE._2)
-  def clientBasePort = sparkConf.getInt(PROP_CLIENT_PORT_BASE._1, PROP_CLIENT_PORT_BASE._2)
-  def cloudName     = sparkConf.getOption(PROP_CLOUD_NAME._1)
+  def clientIcedDir = sparkConf.getOption(PROP_CLIENT_ICED_DIR._1)
   def h2oClientLogLevel = sparkConf.get(PROP_CLIENT_LOG_LEVEL._1, PROP_CLIENT_LOG_LEVEL._2)
   def h2oClientLogDir = sparkConf.getOption(PROP_CLIENT_LOG_DIR._1)
-  def clientNetworkMask = sparkConf.getOption(PROP_CLIENT_NETWORK_MASK._1)
-  def nthreads      = sparkConf.getInt(PROP_NTHREADS._1, PROP_NTHREADS._2)
-  def disableGA     = sparkConf.getBoolean(PROP_DISABLE_GA._1, PROP_DISABLE_GA._2)
+  def clientBasePort = sparkConf.getInt(PROP_CLIENT_PORT_BASE._1, PROP_CLIENT_PORT_BASE._2)
   def clientWebPort = sparkConf.getInt(PROP_CLIENT_WEB_PORT._1, PROP_CLIENT_WEB_PORT._2)
-  def clientIcedDir = sparkConf.getOption(PROP_CLIENT_ICED_DIR._1)
-
-  def jks           = sparkConf.getOption(PROP_JKS._1)
-  def jksPass       = sparkConf.getOption(PROP_JKS_PASS._1)
-  def hashLogin     = sparkConf.getBoolean(PROP_HASH_LOGIN._1, PROP_HASH_LOGIN._2)
-  def ldapLogin     = sparkConf.getBoolean(PROP_LDAP_LOGIN._1, PROP_LDAP_LOGIN._2)
-  def kerberosLogin = sparkConf.getBoolean(PROP_KERBEROS_LOGIN._1, PROP_KERBEROS_LOGIN._2)
-  def loginConf     = sparkConf.getOption(PROP_LOGIN_CONF._1)
-  def userName      = sparkConf.getOption(PROP_USER_NAME._1)
-
-  def sslConf       = sparkConf.getOption(PROP_SSL_CONF._1)
-
-  def isFailOnUnsupportedSparkParamEnabled = sparkConf.getBoolean(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._2)
-  def scalaIntDefaultNum = sparkConf.getInt(PROP_SCALA_INT_DEFAULT_NUM._1, PROP_SCALA_INT_DEFAULT_NUM._2)
-  def isH2OReplEnabled = sparkConf.getBoolean(PROP_REPL_ENABLED._1, PROP_REPL_ENABLED._2)
-  def isClusterTopologyListenerEnabled = sparkConf.getBoolean(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._2)
-
-  def isSparkVersionCheckEnabled = sparkConf.getBoolean(PROP_SPARK_VERSION_CHECK_ENABLED._1, PROP_SPARK_VERSION_CHECK_ENABLED._2)
+  def clientVerboseOutput = sparkConf.getBoolean(PROP_CLIENT_VERBOSE._1, PROP_CLIENT_VERBOSE._2)
+  def clientNetworkMask = sparkConf.getOption(PROP_CLIENT_NETWORK_MASK._1)
 
   def runsInExternalClusterMode: Boolean = backendClusterMode.toLowerCase() == "external"
   def runsInInternalClusterMode: Boolean = !runsInExternalClusterMode
 
-  def h2oNodeLogLevel   = sparkConf.get(PROP_NODE_LOG_LEVEL._1, PROP_NODE_LOG_LEVEL._2)
-  def h2oNodeLogDir   = sparkConf.getOption(PROP_NODE_LOG_DIR._1)
+  /** Setters */
 
-  def uiUpdateInterval = sparkConf.getInt(PROP_UI_UPDATE_INTERVAL._1, PROP_UI_UPDATE_INTERVAL._2)
-  def flowDir = sparkConf.getOption(PROP_FLOW_DIR._1)
-
-  def setUiUpdateInterval(interval: Int): H2OConf = {
-    sparkConf.set(PROP_UI_UPDATE_INTERVAL._1, interval.toString)
-    self
+  /** Generic parameters */
+  def setInternalClusterMode() = {
+    if(runsInExternalClusterMode){
+      logWarning("Using internal cluster mode!")
+    }
+    setBackendClusterMode("internal")
   }
 
-  def setH2ONodeLogLevel(level: String): H2OConf = {
-    sparkConf.set(PROP_NODE_LOG_LEVEL._1, level)
-    self
+  def setExternalClusterMode() = {
+    if(runsInInternalClusterMode){
+      logWarning("Using external cluster mode!")
+    }
+    setBackendClusterMode("external")
   }
 
-  def setCloudName(cloudName: String): H2OConf = {
-    sparkConf.set(PROP_CLOUD_NAME._1, cloudName)
-    self
-  }
+  def setCloudName(cloudName: String) = set(PROP_CLOUD_NAME._1, cloudName)
+  def setNthreads(numThreads: Int) = set(PROP_NTHREADS._1, nthreads.toString)
 
-  private[this] def setBackendClusterMode(backendClusterMode: String): H2OConf = {
-    sparkConf.set(PROP_BACKEND_CLUSTER_MODE._1, backendClusterMode)
-    self
-  }
+  def setGAEnabled() = set(PROP_DISABLE_GA._1, true.toString)
+  def setGADisabled() = set(PROP_DISABLE_GA._1, false.toString)
 
-  def setInternalClusterMode(): H2OConf = setBackendClusterMode("internal")
+  def setReplEnabled() = set(PROP_REPL_ENABLED._1, true.toString)
+  def setReplDisabled() = set(PROP_REPL_ENABLED._1, false.toString)
 
-  def setReplDisabled(): H2OConf = {
-    sparkConf.set(PROP_REPL_ENABLED._1, false.toString)
-    self
-  }
-  def setReplEnabled(): H2OConf = {
-    sparkConf.set(PROP_REPL_ENABLED._1, true.toString)
-    self
-  }
+  def setDefaultNumReplSessions(numSessions: Int) = set(PROP_SCALA_INT_DEFAULT_NUM._1, numSessions.toString)
 
-  def setExternalClusterMode(): H2OConf = setBackendClusterMode("external")
+  def setClusterTopologyListenerEnabled() = set(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, true.toString)
+  def setClusterTopologyListenerDisabled() = set(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, false.toString)
 
-  def setClientIp(ip: String): H2OConf = {
-    sparkConf.set(PROP_CLIENT_IP._1, ip)
-    self
-  }
+  def setSparkVersionCheckEnable() = set(PROP_SPARK_VERSION_CHECK_ENABLED._1, true.toString)
+  def setSparkVersionCheckDisabled() = set(PROP_SPARK_VERSION_CHECK_ENABLED._1, false.toString)
 
-  def setH2OClientLogLevel(level: String): H2OConf = {
-    sparkConf.set(PROP_CLIENT_LOG_LEVEL._1, level)
-    self
-  }
+  def setFailOnUnsupportedSparkParamEnabled() = set(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, true.toString)
+  def setFailOnUnsupportedSparkParamDisabled() = set(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, false.toString)
 
-  def setH2OClientLogDir(dir: String): H2OConf = {
-    sparkConf.set(PROP_CLIENT_LOG_DIR._1, dir)
-    self
-  }
+  def setJks(path: String) = set(PROP_JKS._1, path)
+  def setJksPass(password: String) = set(PROP_JKS_PASS._1, password)
 
-  def setFlowDir(dir: String): H2OConf = {
-    sparkConf.set(PROP_FLOW_DIR._1, dir)
-    self
+  def setHashLoginEnabled() = set(PROP_HASH_LOGIN._1, true.toString)
+  def setHashLoginDisabled() = set(PROP_HASH_LOGIN._1, false.toString)
+
+  def setLdapLoginEnabled() = set(PROP_LDAP_LOGIN._1, true.toString)
+  def setLdapLoginDisabled() = set(PROP_LDAP_LOGIN._1, false.toString)
+
+  def setKerberosLoginEnabled() = set(PROP_KERBEROS_LOGIN._1, true.toString)
+  def setKerberosLoginDisabled() = set(PROP_KERBEROS_LOGIN._1, false.toString)
+
+  def setLoginConf(file: String) = set(PROP_LOGIN_CONF._1, file)
+  def setUserName(username: String) = set(PROP_USER_NAME._1, username)
+  def setSslConf(path: String) = set(PROP_SSL_CONF._1, path)
+  def setH2ONodeLogLevel(level: String) = set(PROP_NODE_LOG_LEVEL._1, level)
+  def setH2ONodeLogDir(dir: String) = set(PROP_NODE_LOG_DIR._1, dir)
+  def setUiUpdateInterval(interval: Int) = set(PROP_UI_UPDATE_INTERVAL._1, interval.toString)
+  def setCloudTimeout(timeout: Int) = set(PROP_CLOUD_TIMEOUT._1, timeout.toString)
+
+
+  /** H2O Client parameters */
+  def setFlowDir(dir: String) = set(PROP_FLOW_DIR._1, dir)
+  def setClientIp(ip: String) = set(PROP_CLIENT_IP._1, ip)
+  def setClientIcedDir(icedDir: String) = set(PROP_CLIENT_ICED_DIR._1, icedDir)
+  def setH2OClientLogLevel(level: String) = set(PROP_CLIENT_LOG_LEVEL._1, level)
+  def setH2OClientLogDir(dir: String) = set(PROP_CLIENT_LOG_DIR._1, dir)
+  def setClientPortBase(basePort: Int) = set(PROP_CLIENT_PORT_BASE._1, basePort.toString)
+
+  def setClientVerboseEnabled() = set(PROP_CLIENT_VERBOSE._1, true.toString)
+  def setClientVerboseDisabled() = set(PROP_CLIENT_VERBOSE._1, false.toString)
+
+  def setClientNetworkMask(mask: String) = set(PROP_CLIENT_NETWORK_MASK._1, mask)
+
+  private[this] def setBackendClusterMode(backendClusterMode: String) = {
+    set(PROP_BACKEND_CLUSTER_MODE._1, backendClusterMode)
   }
 }
 
 object SharedBackendConf {
-
-  /** Interval for updates of Spark UI in milliseconds */
-  val PROP_UI_UPDATE_INTERVAL = ("spark.ext.h2o.ui.update.interval", 10000)
-  /** H2O internal log level for launched remote nodes. */
-  val PROP_NODE_LOG_LEVEL = ("spark.ext.h2o.node.log.level", "INFO")
-
-  /** Location of log directory for remote nodes. */
-  val PROP_NODE_LOG_DIR = ("spark.ext.h2o.node.log.dir", None)
 
   /**
     * This option can be set either to "internal" or "external"
@@ -139,26 +153,8 @@ object SharedBackendConf {
     */
   val PROP_BACKEND_CLUSTER_MODE = ("spark.ext.h2o.backend.cluster.mode", "internal")
 
-  /** IP of H2O client node */
-  val PROP_CLIENT_IP = ("spark.ext.h2o.client.ip", None)
-
-  /** Print detailed messages to client stdout */
-  val PROP_CLIENT_VERBOSE = ("spark.ext.h2o.client.verbose", false)
-
-  /** Port on which H2O client publishes its API. If already occupied, the next odd port is tried and so on */
-  val PROP_CLIENT_PORT_BASE = ( "spark.ext.h2o.client.port.base", 54321 )
-
   /** Configuration property - name of H2O cloud */
   val PROP_CLOUD_NAME = ("spark.ext.h2o.cloud.name", None)
-
-  /** H2O log level for client running in Spark driver */
-  val PROP_CLIENT_LOG_LEVEL = ("spark.ext.h2o.client.log.level", "WARN")
-
-  /** Location of log directory for the driver instance. */
-  val PROP_CLIENT_LOG_DIR = ("spark.ext.h2o.client.log.dir", None)
-
-  /** Subnet selector for H2O client - if the mask is specified then Spark network setup is not discussed. */
-  val PROP_CLIENT_NETWORK_MASK = ("spark.ext.h2o.client.network.mask", None)
 
   /** Limit for number of threads used by H2O, default -1 means unlimited */
   val PROP_NTHREADS = ("spark.ext.h2o.nthreads", -1)
@@ -166,12 +162,20 @@ object SharedBackendConf {
   /** Disable GA tracking */
   val PROP_DISABLE_GA = ("spark.ext.h2o.disable.ga", true)
 
-  /** Exact client port to access web UI.
-    * The value `-1` means automatic search for free port starting at `spark.ext.h2o.port.base`. */
-  val PROP_CLIENT_WEB_PORT = ("spark.ext.h2o.client.web.port", -1)
+  /** Enable/Disable Sparkling-Water REPL **/
+  val PROP_REPL_ENABLED = ("spark.ext.h2o.repl.enabled", true)
 
-  /** Location of iced directory for the driver instance. */
-  val PROP_CLIENT_ICED_DIR = ("spark.ext.h2o.client.iced.dir", None)
+  /** Number of executors started at the start of h2o services, by default 1 */
+  val PROP_SCALA_INT_DEFAULT_NUM = ("spark.ext.scala.int.default.num", 1)
+
+  /** Enable/Disable listener which kills H2O when there is a change in underlying cluster's topology**/
+  val PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED = ("spark.ext.h2o.topology.change.listener.enabled", true)
+
+  /** Enable/Disable check for Spark version. */
+  val PROP_SPARK_VERSION_CHECK_ENABLED = ("spark.ext.h2o.spark.version.check.enabled", true)
+
+  /** Enable/Disable exit on unsupported Spark parameters. */
+  val PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM = ("spark.ext.h2o.fail.on.unsupported.spark.param", true)
 
   /** Path to Java KeyStore file. */
   val PROP_JKS = ("spark.ext.h2o.jks", None)
@@ -194,24 +198,46 @@ object SharedBackendConf {
   /** Override user name for cluster. */
   val PROP_USER_NAME = ("spark.ext.h2o.user.name", None)
 
-  /** Number of executors started at the start of h2o services, by default 1 */
-  val PROP_SCALA_INT_DEFAULT_NUM = ("spark.ext.scala.int.default.num", 1)
-
-  /** Enable/Disable Sparkling-Water REPL **/
-  val PROP_REPL_ENABLED = ("spark.ext.h2o.repl.enabled", true)
-
-  /** Enable/Disable listener which kills H2O when there is a change in underlying cluster's topology**/
-  val PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED = ("spark.ext.h2o.topology.change.listener.enabled", true)
-
-  /** Enable/Disable check for Spark version. */
-  val PROP_SPARK_VERSION_CHECK_ENABLED = ("spark.ext.h2o.spark.version.check.enabled", true)
-
-  /** Enable/Disable exit on unsupported Spark parameters. */
-  val PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM = ("spark.ext.h2o.fail.on.unsupported.spark.param", true)
-
   /** Path to Java KeyStore file. */
   val PROP_SSL_CONF = ("spark.ext.h2o.internal_security_conf", None)
 
+  /** H2O internal log level for launched remote nodes. */
+  val PROP_NODE_LOG_LEVEL = ("spark.ext.h2o.node.log.level", "INFO")
+
+  /** Location of log directory for remote nodes. */
+  val PROP_NODE_LOG_DIR = ("spark.ext.h2o.node.log.dir", None)
+
+  /** Interval for updates of Spark UI in milliseconds */
+  val PROP_UI_UPDATE_INTERVAL = ("spark.ext.h2o.ui.update.interval", 10000)
+
+  /** Configuration property - timeout for cloud up. */
+  val PROP_CLOUD_TIMEOUT = ("spark.ext.h2o.cloud.timeout", 60 * 1000)
+
   /** Path to flow dir. */
-  val PROP_FLOW_DIR=("spark.ext.h2o.client.flow.dir", None)
+  val PROP_FLOW_DIR = ("spark.ext.h2o.client.flow.dir", None)
+
+  /** IP of H2O client node */
+  val PROP_CLIENT_IP = ("spark.ext.h2o.client.ip", None)
+
+  /** Location of iced directory for the driver instance. */
+  val PROP_CLIENT_ICED_DIR = ("spark.ext.h2o.client.iced.dir", None)
+
+  /** H2O log level for client running in Spark driver */
+  val PROP_CLIENT_LOG_LEVEL = ("spark.ext.h2o.client.log.level", "WARN")
+
+  /** Location of log directory for the driver instance. */
+  val PROP_CLIENT_LOG_DIR = ("spark.ext.h2o.client.log.dir", None)
+
+  /** Port on which H2O client publishes its API. If already occupied, the next odd port is tried and so on */
+  val PROP_CLIENT_PORT_BASE = ("spark.ext.h2o.client.port.base", 54321)
+
+  /** Exact client port to access web UI.
+    * The value `-1` means automatic search for free port starting at `spark.ext.h2o.port.base`. */
+  val PROP_CLIENT_WEB_PORT = ("spark.ext.h2o.client.web.port", -1)
+
+  /** Print detailed messages to client stdout */
+  val PROP_CLIENT_VERBOSE = ("spark.ext.h2o.client.verbose", false)
+
+  /** Subnet selector for H2O client - if the mask is specified then Spark network setup is not discussed. */
+  val PROP_CLIENT_NETWORK_MASK = ("spark.ext.h2o.client.network.mask", None)
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -28,41 +28,30 @@ trait ExternalBackendConf extends SharedBackendConf {
 
   import ExternalBackendConf._
 
+  /** Getters */
+
   def h2oCluster = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1)
-  def YARNQueue = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_YARN_QUEUE._1)
-  def h2oDriverPath = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_DRIVER_PATH._1)
+  def h2oClusterHost = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1).map(_.split(":")(0))
+  def h2oClusterPort = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1).map(_.split(":")(1).toInt)
+
   def numOfExternalH2ONodes = sparkConf.getOption(PROP_EXTERNAL_H2O_NODES._1)
-  def HDFSOutputDir = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_HDFS_DIR._1)
-  def mapperXmx = sparkConf.get(PROP_EXTERNAL_H2O_MEMORY._1, PROP_EXTERNAL_H2O_MEMORY._2)
-  def clusterInfoFile = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_INFO_FILE._1)
-  def clusterStartMode = sparkConf.get(PROP_EXTERNAL_CLUSTER_START_MODE._1, PROP_EXTERNAL_CLUSTER_START_MODE._2)
-  def isAutoClusterStartUsed = clusterStartMode == "auto"
-  def isManualClusterStartUsed = !isAutoClusterStartUsed
-  def clusterStartTimeout = sparkConf.getInt(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, PROP_EXTERNAL_CLUSTER_START_TIMEOUT._2)
-  def clientConnectionTimeout = sparkConf.getInt(PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._1, PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._2)
   def clientCheckRetryTimeout = sparkConf.getInt(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._2)
+  def clientConnectionTimeout = sparkConf.getInt(PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._1, PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._2)
   def externalReadConfirmationTimeout = sparkConf.getInt(PROP_EXTERNAL_READ_TIMEOUT._1, PROP_EXTERNAL_READ_TIMEOUT._2)
   def externalWriteConfirmationTimeout = sparkConf.getInt(PROP_EXTERNAL_WRITE_TIMEOUT._1, PROP_EXTERNAL_WRITE_TIMEOUT._2)
+  def clusterStartTimeout = sparkConf.getInt(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, PROP_EXTERNAL_CLUSTER_START_TIMEOUT._2)
+  def clusterInfoFile = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_INFO_FILE._1)
+  def mapperXmx = sparkConf.get(PROP_EXTERNAL_H2O_MEMORY._1, PROP_EXTERNAL_H2O_MEMORY._2)
+  def HDFSOutputDir = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_HDFS_DIR._1)
 
-  def setClientConnectionTimeout(timeout: Int): H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._1, timeout.toString)
-    self
-  }
+  def isAutoClusterStartUsed = clusterStartMode == "auto"
+  def isManualClusterStartUsed = !isAutoClusterStartUsed
 
-  def setClientCheckRetryTimeout(timeout: Int): H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, timeout.toString)
-    self
-  }
+  def clusterStartMode = sparkConf.get(PROP_EXTERNAL_CLUSTER_START_MODE._1, PROP_EXTERNAL_CLUSTER_START_MODE._2)
+  def h2oDriverPath = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_DRIVER_PATH._1)
+  def YARNQueue = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_YARN_QUEUE._1)
 
-  def setExternalReadConfirmationTimeout(timeout: Int): H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_READ_TIMEOUT._1, timeout.toString)
-    self
-  }
-
-  def setExternalWriteConfirmationTimeout(timeout: Int): H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_WRITE_TIMEOUT._1, timeout.toString)
-    self
-  }
+  /** Setters */
 
   /**
     * Sets node and port representing H2O Cluster to which should H2O connect when started in external mode.
@@ -72,78 +61,42 @@ trait ExternalBackendConf extends SharedBackendConf {
     * @param port port representing the cluster
     * @return H2O Configuration
     */
-  def setH2OCluster(host: String, port: Int): H2OConf = {
+  def setH2OCluster(host: String, port: Int) = {
     setExternalClusterMode()
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, host + ":" + port)
-    self
+    set(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, host + ":" + port)
   }
 
-  def setClusterStartTimeout(clusterStartTimeout: Int): H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, clusterStartTimeout.toString)
-    self
-  }
-
-  def setH2OCluster(hostPort: String): H2OConf = {
+  def setH2OCluster(hostPort: String) = {
     setExternalClusterMode()
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, hostPort)
-    self
+    set(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, hostPort)
   }
 
-  def h2oClusterHost = {
-    sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1).map(_.split(":")(0))
-  }
+  def setNumOfExternalH2ONodes(numOfExternalH2ONodes: Int) = set(PROP_EXTERNAL_H2O_NODES._1, numOfExternalH2ONodes.toString)
+  def setClientCheckRetryTimeout(timeout: Int) = set(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, timeout.toString)
+  def setClientConnectionTimeout(timeout: Int) = set(PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT._1, timeout.toString)
+  def setExternalReadConfirmationTimeout(timeout: Int) = set(PROP_EXTERNAL_READ_TIMEOUT._1, timeout.toString)
+  def setExternalWriteConfirmationTimeout(timeout: Int) = set(PROP_EXTERNAL_WRITE_TIMEOUT._1, timeout.toString)
+  def setClusterStartTimeout(clusterStartTimeout: Int) = set(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, clusterStartTimeout.toString)
+  def setClusterConfigFile(path: String) = set(PROP_EXTERNAL_CLUSTER_INFO_FILE._1, path)
+  def setMapperXmx(mem: String) = set(PROP_EXTERNAL_H2O_MEMORY._1, mem)
+  def setHDFSOutputDir(dir: String) = set(PROP_EXTERNAL_CLUSTER_HDFS_DIR._1, dir)
 
-  def h2oClusterPort = {
-    sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1).map(_.split(":")(1))
-  }
-
-
-  def setYARNQueue(queueName: String) : H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_YARN_QUEUE._1, queueName)
-    self
-  }
-
-  def setH2ODriverPath(path: String): H2OConf = {
+  def useAutoClusterStart() = {
     setExternalClusterMode()
-    logWarning("Using external cluster mode!")
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_DRIVER_PATH._1, path)
-    self
+    set(PROP_EXTERNAL_CLUSTER_START_MODE._1, "auto")
   }
 
-  def setNumOfExternalH2ONodes(numOfExternalH2ONodes: Int): H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_H2O_NODES._1, numOfExternalH2ONodes.toString)
-    self
-  }
-
-  def setHDFSOutputDir(dir: String): H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_HDFS_DIR._1, dir)
-    self
-  }
-
-
-  def setMapperXmx(mem: String): H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_H2O_MEMORY._1, mem)
-    self
-  }
-
-  def setClusterConfigFile(path: String) : H2OConf = {
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_INFO_FILE._1, path)
-    self
-  }
-
-  def useAutoClusterStart() : H2OConf = {
+  def useManualClusterStart()  = {
     setExternalClusterMode()
-    logWarning("Using external cluster mode!")
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_START_MODE._1, "auto")
-    self
+    set(PROP_EXTERNAL_CLUSTER_START_MODE._1, "manual")
   }
 
-  def useManualClusterStart() : H2OConf = {
+  def setH2ODriverPath(path: String) = {
     setExternalClusterMode()
-    logWarning("Using external cluster mode!")
-    sparkConf.set(PROP_EXTERNAL_CLUSTER_START_MODE._1, "manual")
-    self
+    set(PROP_EXTERNAL_CLUSTER_DRIVER_PATH._1, path)
   }
+
+  def setYARNQueue(queueName: String) = set(PROP_EXTERNAL_CLUSTER_YARN_QUEUE._1, queueName)
 
 
   def externalConfString: String =
@@ -159,8 +112,19 @@ trait ExternalBackendConf extends SharedBackendConf {
 
 object ExternalBackendConf {
 
+  /** ip:port of arbitrary h2o node to identify external h2o cluster */
+  val PROP_EXTERNAL_CLUSTER_REPRESENTATIVE = ("spark.ext.h2o.cloud.representative", None)
+
+  /** Number of nodes to wait for when connecting to external H2O cluster in manual mode. In auto mode, number
+    * of nodes to be started. */
+  val PROP_EXTERNAL_H2O_NODES = ("spark.ext.h2o.external.cluster.num.h2o.nodes", None)
+
   /** Timeout in milliseconds specifying how often the check for connected watchdog client is done */
   val PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT = ("spark.ext.h2o.cluster.client.retry.timeout", 10000)
+
+  /** Timeout in milliseconds for watchdog client connection. If client is not connected
+    * to the external cluster in the given time, the cluster is killed */
+  val PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT = ("spark.ext.h2o.cluster.client.connect.timeout", 120000 + 10000)
 
   /** Timeout for confirmation of read operation ( h2o frame => spark frame) on external cluster. */
   val PROP_EXTERNAL_READ_TIMEOUT = ("spark.ext.h2o.external.read.confirmation.timeout", 20)
@@ -171,14 +135,13 @@ object ExternalBackendConf {
   /** Timeout in seconds for starting h2o external cluster */
   val PROP_EXTERNAL_CLUSTER_START_TIMEOUT = ("spark.ext.h2o.cluster.start.timeout", 120)
 
-  /** Timeout in milliseconds for watchdog client connection. If client is not connected
-    * to the external cluster in the given time, the cluster is killed */
-  val PROP_EXTERNAL_CLIENT_CONNECTION_TIMEOUT = ("spark.ext.h2o.cluster.client.connect.timeout", 120000 + 10000)
-
+  /** Path to a file used as cluster notification file */
   val PROP_EXTERNAL_CLUSTER_INFO_FILE = ("spark.ext.h2o.cluster.info.name", None)
 
+  /** Number of memory assigned to each external h2o node when starting in auto mode */
   val PROP_EXTERNAL_H2O_MEMORY = ("spark.ext.h2o.hadoop.memory", "6g")
 
+  /** HDFS dir for external h2o nodes when starting in auto mode */
   val PROP_EXTERNAL_CLUSTER_HDFS_DIR = ("spark.ext.h2o.external.hdfs.dir", None)
 
   /**
@@ -187,17 +150,13 @@ object ExternalBackendConf {
     */
   val PROP_EXTERNAL_CLUSTER_START_MODE = ("spark.ext.h2o.external.start.mode", "manual")
 
-  /**
-    * Path to h2o driver
-    */
+  /** Path to h2o driver */
   val PROP_EXTERNAL_CLUSTER_DRIVER_PATH = ("spark.ext.h2o.external.h2o.driver", None)
 
   /** Yarn queue on which external cluster should be started */
   val PROP_EXTERNAL_CLUSTER_YARN_QUEUE = ("spark.ext.h2o.external.yarn.queue", None)
 
-  /** ip:port of arbitrary h2o node to identify external h2o cluster */
-  val PROP_EXTERNAL_CLUSTER_REPRESENTATIVE = ("spark.ext.h2o.cloud.representative", None)
 
-  /** Number of nodes to wait for when connecting to external H2O cluster */
-  val PROP_EXTERNAL_H2O_NODES = ("spark.ext.h2o.external.cluster.num.h2o.nodes", None)
+
+
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendConf.scala
@@ -27,16 +27,34 @@ trait InternalBackendConf extends SharedBackendConf {
   self: H2OConf =>
 
   import InternalBackendConf._
+
+  /** Getters */
+
+  def useFlatFile = sparkConf.getBoolean(PROP_USE_FLATFILE._1, PROP_USE_FLATFILE._2)
   def numH2OWorkers = sparkConf.getOption(PROP_CLUSTER_SIZE._1).map(_.toInt)
-  def useFlatFile   = sparkConf.getBoolean(PROP_USE_FLATFILE._1, PROP_USE_FLATFILE._2)
-  def nodeBasePort  = sparkConf.getInt(PROP_NODE_PORT_BASE._1, PROP_NODE_PORT_BASE._2)
-  def cloudTimeout  = sparkConf.getInt(PROP_CLOUD_TIMEOUT._1, PROP_CLOUD_TIMEOUT._2)
   def drddMulFactor = sparkConf.getInt(PROP_DUMMY_RDD_MUL_FACTOR._1, PROP_DUMMY_RDD_MUL_FACTOR._2)
   def numRddRetries = sparkConf.getInt(PROP_SPREADRDD_RETRIES._1, PROP_SPREADRDD_RETRIES._2)
   def defaultCloudSize  = sparkConf.getInt(PROP_DEFAULT_CLUSTER_SIZE._1, PROP_DEFAULT_CLUSTER_SIZE._2)
-  def nodeNetworkMask   = sparkConf.getOption(PROP_NODE_NETWORK_MASK._1)
-  def nodeIcedDir   = sparkConf.getOption(PROP_NODE_ICED_DIR._1)
   def subseqTries  = sparkConf.getInt(PROP_SUBSEQ_TRIES._1, PROP_SUBSEQ_TRIES._2)
+
+  def nodeBasePort  = sparkConf.getInt(PROP_NODE_PORT_BASE._1, PROP_NODE_PORT_BASE._2)
+  def nodeIcedDir   = sparkConf.getOption(PROP_NODE_ICED_DIR._1)
+  def nodeNetworkMask   = sparkConf.getOption(PROP_NODE_NETWORK_MASK._1)
+
+  /** Setters */
+
+  def setFlatFileEnabled() = set(PROP_USE_FLATFILE._1, true.toString)
+  def setFlatFileDisabled() = set(PROP_USE_FLATFILE._1, false.toString)
+
+  def setNumH2OWorkers(numWorkers: Int) = set(PROP_CLUSTER_SIZE._1, numWorkers.toString)
+  def setDrddMulFactor(factor: Int) = set(PROP_DUMMY_RDD_MUL_FACTOR._1,factor.toString)
+  def setNumRddRetries(retries: Int) = set(PROP_SPREADRDD_RETRIES._1, retries.toString)
+  def setDefaultCloudSize(defaultClusterSize: Int) = set(PROP_DEFAULT_CLUSTER_SIZE._1, defaultClusterSize.toString)
+  def setSubseqTries(subseqTriesNum: Int) = set(PROP_SUBSEQ_TRIES._1, subseqTriesNum.toString)
+
+  def setNodeBasePort(port: Int) = set(PROP_NODE_PORT_BASE._1, port.toString)
+  def setNodeIcedDir(dir: String) = set(PROP_NODE_ICED_DIR._1, dir)
+  def setNodeNetworkMask(mask: String) = set(PROP_NODE_NETWORK_MASK._1, mask)
 
   def internalConfString: String =
     s"""Sparkling Water configuration:
@@ -55,19 +73,14 @@ trait InternalBackendConf extends SharedBackendConf {
 }
 
 object InternalBackendConf {
-  /** Configuration property - expected number of workers of H2O cloud.
-    * Value None means automatic detection of cluster size.
-    */
-  val PROP_CLUSTER_SIZE = ("spark.ext.h2o.cluster.size", None)
 
   /** Configuration property - use flatfile for H2O cloud formation. */
   val PROP_USE_FLATFILE = ("spark.ext.h2o.flatfile", true)
 
-  /** Configuration property - base port used for individual H2O nodes configuration. */
-  val PROP_NODE_PORT_BASE = ( "spark.ext.h2o.node.port.base", 54321)
-
-  /** Configuration property - timeout for cloud up. */
-  val PROP_CLOUD_TIMEOUT = ("spark.ext.h2o.cloud.timeout", 60*1000)
+  /** Configuration property - expected number of workers of H2O cloud.
+    * Value None means automatic detection of cluster size.
+    */
+  val PROP_CLUSTER_SIZE = ("spark.ext.h2o.cluster.size", None)
 
   /** Configuration property - multiplication factor for dummy RDD generation.
     * Size of dummy RDD is PROP_CLUSTER_SIZE*PROP_DUMMY_RDD_MUL_FACTOR */
@@ -79,12 +92,16 @@ object InternalBackendConf {
   /** Starting size of cluster in case that size is not explicitly passed */
   val PROP_DEFAULT_CLUSTER_SIZE = ("spark.ext.h2o.default.cluster.size", 20)
 
-  /** Subnet selector for H2O nodes running inside executors - if the mask is specified then Spark network setup is not discussed. */
-  val PROP_NODE_NETWORK_MASK = ("spark.ext.h2o.node.network.mask", None)
+  /** Subsequent successful tries to figure out size of Spark cluster which are producing same number of nodes. */
+  val PROP_SUBSEQ_TRIES = ("spark.ext.h2o.subseq.tries", 5)
+
+  /** Configuration property - base port used for individual H2O nodes configuration. */
+  val PROP_NODE_PORT_BASE = ( "spark.ext.h2o.node.port.base", 54321)
 
   /** Location of iced directory for Spark nodes */
   val PROP_NODE_ICED_DIR = ("spark.ext.h2o.node.iced.dir", None)
 
-  /** Subsequent successful tries to figure out size of Spark cluster which are producing same number of nodes. */
-  val PROP_SUBSEQ_TRIES = ("spark.ext.h2o.subseq.tries", 5)
+  /** Subnet selector for H2O nodes running inside executors - if the mask is specified then Spark network setup is not discussed. */
+  val PROP_NODE_NETWORK_MASK = ("spark.ext.h2o.node.network.mask", None)
+
 }

--- a/doc/configuration/configuration_properties.rst
+++ b/doc/configuration/configuration_properties.rst
@@ -74,14 +74,17 @@ Configuration properties independent on selected backend
 | ``spark.ext.h2o.node.log.level``                   | ``INFO``       | H2O internal log level used for H2O    |
 |                                                    |                | nodes except the client.               |
 +----------------------------------------------------+----------------+----------------------------------------+
-| ``spark.ext.h2o.ui.update.interval``               | ``10000ms``    | Interval for updates of the Spark UI   |
-|                                                    |                | and History server in milliseconds     |
-+----------------------------------------------------+----------------+----------------------------------------+
 | ``spark.ext.h2o.node.log.dir``                     | ``{user.dir}/h | Location of H2O logs on H2O nodes      |
 |                                                    | 2ologs/{SparkA | except on the client.                  |
 |                                                    | ppId}``        |                                        |
 |                                                    | or YARN        |                                        |
 |                                                    | container dir  |                                        |
++----------------------------------------------------+----------------+----------------------------------------+
+| ``spark.ext.h2o.ui.update.interval``               | ``10000ms``    | Interval for updates of the Spark UI   |
+|                                                    |                | and History server in milliseconds     |
++----------------------------------------------------+----------------+----------------------------------------+
+| ``spark.ext.h2o.cloud.timeout``                    | ``60*1000``    | Timeout (in msec) for cluster          |
+|                                                    |                | formation.                             |
 +----------------------------------------------------+----------------+----------------------------------------+
 | **H2O client parameters**                          |                |                                        |
 +----------------------------------------------------+----------------+----------------------------------------+
@@ -138,9 +141,6 @@ Internal backend configuration properties
 |                                                    |                | detection of cluster size. This number |
 |                                                    |                | must be equal to number of Spark       |
 |                                                    |                | executors.                             |
-+----------------------------------------------------+----------------+----------------------------------------+
-| ``spark.ext.h2o.cloud.timeout``                    | ``60*1000``    | Timeout (in msec) for cluster          |
-|                                                    |                | formation.                             |
 +----------------------------------------------------+----------------+----------------------------------------+
 | ``spark.ext.h2o.dummy.rdd.mul.factor``             | ``10``         | Multiplication factor for dummy RDD    |
 |                                                    |                | generation. Size of dummy RDD is       |

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -33,21 +33,8 @@ class H2OConf(object):
         else:
             return None
 
-    def runs_in_external_cluster_mode(self):
-        return self._jconf.runsInExternalClusterMode()
 
-    def runs_in_internal_cluster_mode(self):
-        return self._jconf.runsInInternalClusterMode()
-
-    # setters for most common properties
-    # TODO: Create setters and getters for all properties
-    def set_cloud_name(self, cloud_name):
-        self._jconf.setCloudName(cloud_name)
-        return self
-
-    def set_num_of_external_h2o_nodes(self, num_of_external_h2o_nodes):
-        self._jconf.setNumOfExternalH2ONodes(num_of_external_h2o_nodes)
-        return self
+    # setters independent on selected backend
 
     def set_internal_cluster_mode(self):
         self._jconf.setInternalClusterMode()
@@ -57,71 +44,214 @@ class H2OConf(object):
         self._jconf.setExternalClusterMode()
         return self
 
-    def set_client_ip(self, ip):
-        self._jconf.setClientIp(ip)
+    def set_cloud_name(self, cloud_name):
+        self._jconf.setCloudName(cloud_name)
         return self
 
-    def set_client_network_mask(self, mask):
-        self._jconf.setClientNetworkMask(mask)
+    def set_nthreads(self, nthreads):
+        self._jconf.setNthreads(nthreads)
         return self
 
-    def set_flatfile_path(self, flatfile_path):
-        self._jconf.setFlatFilePath(flatfile_path)
+    def set_ga_enabled(self):
+        self._jconf.setGAEnabled()
         return self
 
-    def set_h2o_cluster(self, ip, port):
-        self._jconf.setH2OCluster(ip, port)
+    def set_ga_disabled(self):
+        self._jconf.setGADisabled()
         return self
 
-    def set_yarn_queue(self, queue_name):
-        self._jconf.setYARNQueue(queue_name)
+    def set_repl_enabled(self):
+        self._jconf.setReplEnabled()
         return self
 
-    def set_h2o_driver_path(self, driver_path):
-        self._jconf.setH2ODriverPath(driver_path)
+    def set_repl_disabled(self):
+        self._jconf.setReplDisabled()
         return self
 
-    def set_hdfs_output_dir(self, hdfs_output_dir):
-        self._jconf.setHDFSOutputDir(hdfs_output_dir)
+    def set_default_num_repl_sessions(self, num_sessions):
+        self._jconf.setDefaultNumReplSessions(num_sessions)
         return self
 
-    def set_mapper_xmx(self, mem):
-        self._jconf.setMapperXmx(mem)
+    def set_cluster_topology_listener_enabled(self):
+        self._jconf.setClusterTopologyListenerEnabled()
         return self
 
-    def set_cluster_config_file(self, path):
-        self._jconf.setClusterConfigFile(path)
+    def set_cluster_topology_listener_disabled(self):
+        self._jconf.setClusterTopologyListenerDisabled()
         return self
 
-    def use_auto_cluster_start(self):
-        self._jconf.useAutoClusterStart()
+    def set_spark_version_check_enabled(self):
+        self._jconf.setSparkVersionCheckEnabled()
         return self
 
-    def use_manual_cluster_start(self):
-        self._jconf.useManualClusterStart()
+    def set_spark_version_check_disabled(self):
+        self._jconf.setSparkVersionCheckDisabled()
+        return self
+
+    def set_fail_on_unsupported_spark_param_enabled(self):
+        self._jconf.setFailOnUnsupportedSparkParamEnabled()
+        return self
+
+    def set_fail_on_unsupported_spark_param_disabled(self):
+        self._jconf.setFailOnUnsupportedSparkParamDisabled()
+        return self
+
+    def set_jks(self, path):
+        self._jconf.setJks(path)
+        return self
+
+    def set_jks_pass(self, password):
+        self._jconf.setJksPass(password)
+        return self
+
+    def set_hash_login_enabled(self):
+        self._jconf.setHashLoginEnabled()
+        return self
+
+    def set_hash_login_disabled(self):
+        self._jconf.setHashLoginDisabled()
+        return self
+
+    def set_ldap_login_enabled(self):
+        self._jconf.setLdapLoginEnabled()
+        return self
+
+    def set_ldap_login_disabled(self):
+        self._jconf.setLdapLoginDisabled()
+        return self
+
+    def set_kerberos_login_enabled(self):
+        self._jconf.setKerberosLoginEnabled()
+        return self
+
+    def set_kerberos_login_disabled(self):
+        self._jconf.setKerberosLoginDisabled()
+        return self
+
+    def set_login_conf(self, file):
+        self._jconf.setLoginConf(file)
+        return self
+
+    def set_user_name(self, username):
+        self._jconf.setUserName(username)
+        return self
+
+    def set_ssl_conf(self, path):
+        self._jconf.setSslConf(path)
         return self
 
     def set_h2o_node_log_level(self, level):
         self._jconf.setH2ONodeLogLevel(level)
         return self
 
-    def set_cluster_start_timeout(self, timeout):
-        """Set timeout for start of external cluster. If the cluster is not able to cloud within the timeout the
-        the exception is thrown.
+    def set_h2o_node_log_dir(self, dir):
+        self._jconf.setH2ONodeLogDir(dir)
+        return self
 
-        Arguments:
-        timeout -- timeout in seconds
-        
-        """
-        self._jconf.setClusterStartTimeout(timeout)
+    def set_ui_update_interval(self, interval):
+        self._jconf.setUiUpdateInterval(interval)
+        return self
+
+    def set_cloud_timeout(self, timeout):
+        self._jconf.setCloudTimeout(timeout)
+        return self
+
+    def set_flow_dir(self, dir):
+        self._jconf.setFlowDir(dir)
+        return self
+
+    def set_client_ip(self, ip):
+        self._jconf.setClientIp(ip)
+        return self
+
+    def set_client_iced_dir(self, iced_dir):
+        self._jconf.setClientIcedDir(iced_dir)
         return self
 
     def set_h2o_client_log_level(self, level):
         self._jconf.setH2OClientLogLevel(level)
         return self
 
-    def set_h2o_client_log_dir(self, log_dir):
-        self._jconf.setH2OClientLogDir(log_dir)
+    def set_h2o_client_log_dir(self, dir):
+        self._jconf.setH2OClientLogDir(dir)
+        return self
+
+    def set_client_port_base(self, baseport):
+        self._jconf.setClientPortBase(baseport)
+        return self
+
+    def set_client_verbose_enabled(self):
+        self._jconf.setClientVerboseEnabled()
+        return self
+
+    def set_client_verbose_disabled(self):
+        self._jconf.setClientVerboseDisabled()
+        return self
+
+    def set_client_network_mask(self, mask):
+        self._jconf.setClientNetworkMask(mask)
+        return self
+
+    # setters for internal backend
+
+    def set_flatfile_enabled(self):
+        self._jconf.setFlatFileEnabled()
+        return self
+
+    def set_flatfile_disabled(self):
+        self._jconf.setFlatFileDisabled()
+        return self
+
+    def set_num_h2o_workers(self, num_workers):
+        self._jconf.setNumH2OWorkers(num_workers)
+        return self
+
+    def set_drdd_mul_factor(self, factor):
+        self._jconf.setDrddMulFactor(factor)
+        return self
+
+    def set_num_rdd_retries(self, retries):
+        self._jconf.setNumRddRetries(retries)
+        return self
+
+    def set_default_cloud_size(self, size):
+        self._jconf.setDefaultCloudSize(size)
+        return self
+
+    def set_subseq_tries(self, subseq_tries_num):
+        self._jconf.setSubseqTries(subseq_tries_num)
+        return self
+
+    def set_node_base_port(self, port):
+        self._jconf.setNodeBasePort(port)
+        return self
+
+    def set_node_iced_dir(self, dir):
+        self._jconf.setNodeIcedDir(dir)
+        return self
+
+    def set_node_network_mask(self, mask):
+        self._jconf.setNodeNetworkMask(mask)
+        return self
+
+    # setters for external backend
+
+    def set_h2o_cluster(self, ip, port):
+        self._jconf.setH2OCluster(ip, port)
+        return self
+
+    def set_num_of_external_h2o_nodes(self, num_of_external_h2o_nodes):
+        self._jconf.setNumOfExternalH2ONodes(num_of_external_h2o_nodes)
+        return self
+
+    def set_client_check_retry_timeout(self, timeout):
+        """Set retry interval how often nodes in the external cluster mode check for the presence of the h2o client.
+
+        Arguments:
+        timeout -- timeout in milliseconds
+
+        """
+        self._jconf.setClientCheckRetryTimeout(timeout)
         return self
 
     def set_client_connection_timeout(self, timeout):
@@ -130,19 +260,9 @@ class H2OConf(object):
 
         Arguments:
         timeout -- timeout in milliseconds
-        
+
         """
         self._jconf.setClientConnectionTimeout(timeout)
-        return self
-
-    def set_client_check_retry_timeout(self, timeout):
-        """Set retry interval how often nodes in the external cluster mode check for the presence of the h2o client.
-        
-        Arguments:
-        timeout -- timeout in milliseconds
-        
-        """
-        self._jconf.setClientCheckRetryTimeout(timeout)
         return self
 
     def set_external_read_confirmation_timeout(self, timeout):
@@ -153,126 +273,59 @@ class H2OConf(object):
         self._jconf.setExternalWriteConfirmationTimeout(timeout)
         return self
 
-    def set_ui_update_interval(self, interval):
-        self._jconf.setUiUpdateInterval(interval)
+    def set_cluster_start_timeout(self, timeout):
+        """Set timeout for start of external cluster. If the cluster is not able to cloud within the timeout the
+        the exception is thrown.
+
+        Arguments:
+        timeout -- timeout in seconds
+
+        """
+        self._jconf.setClusterStartTimeout(timeout)
         return self
 
-    def set_flow_dir(self, dir):
-        self._jconf.setFlowDir(dir)
+
+    def set_cluster_config_file(self, path):
+        self._jconf.setClusterConfigFile(path)
         return self
 
-    # getters
+    def set_mapper_xmx(self, mem):
+        self._jconf.setMapperXmx(mem)
+        return self
 
-    def flow_dir(self):
-        return self._get_option(self._jconf.flowDir())
+    def set_hdfs_output_dir(self, hdfs_output_dir):
+        self._jconf.setHDFSOutputDir(hdfs_output_dir)
+        return self
 
-    def ui_update_interval(self):
-        return self._jconf.uiUpdateInterval()
+    def use_auto_cluster_start(self):
+        self._jconf.useAutoClusterStart()
+        return self
 
-    def client_connection_timeout(self):
-        return self._jconf.clientConnectionTimeout()
+    def use_manual_cluster_start(self):
+        self._jconf.useManualClusterStart()
+        return self
 
-    def client_check_retry_timeout(self):
-        return self._jconf.clientCheckRetryTimeout()
+    def set_h2o_driver_path(self, driver_path):
+        self._jconf.setH2ODriverPath(driver_path)
+        return self
 
-    def external_read_confirmation_timeout(self):
-        return self._jconf.externalReadConfirmationTimeout()
+    def set_yarn_queue(self, queue_name):
+        self._jconf.setYARNQueue(queue_name)
+        return self
 
-    def external_write_confirmation_timeout(self):
-        return self._jconf.externalWriteConfirmationTimeout()
-
-    def cluster_start_timeout(self):
-        return self._jconf.clusterStartTimeout()
-
-    def h2o_cluster(self):
-        return self._get_option(self._jconf.h2oCluster())
-
-    def yarn_queue(self):
-        return self._get_option(self._jconf.YARNQueue())
-
-    def h2o_driver_path(self):
-        return self._get_option(self._jconf.h2oDriverPath())
-
-    def hdfs_output_dir(self):
-        return self._get_option(self._jconf.HDFSOutputDir())
-
-    def mapper_xmx(self):
-        return self._jconf.mapperXmx()
-
-    def cluster_config_file(self):
-        return self._get_option(self._jconf.clusterInfoFile())
-
-    def cluster_start_mode(self):
-        return self._jconf.clusterStartMode()
-
-    def is_auto_cluster_start_used(self):
-        return self._jconf.isAutoClusterStartUsed()
-
-    def is_manual_cluster_start_used(self):
-        return self._jconf.isManualClusterStartUsed()
-
-    def cloud_name(self):
-        return self._get_option(self._jconf.cloudName())
-
-    def num_of_external_h2o_nodes(self):
-        return self._get_option(self._jconf.numOfExternalH2ONodes())
-
-    def flatfile_path(self):
-        return self._get_option(self._jconf.flatFilePath())
-
-    def num_h2o_workers(self):
-        return self._get_option(self._jconf.numH2OWorkers())
-
-    def use_flatfile(self):
-        return self._jconf.useFlatFile()
-
-    def node_base_port(self):
-        return self._jconf.nodeBasePort()
-
-    def cloud_timeout(self):
-        return self._jconf.cloudTimeout()
-
-    def drdd_mul_factor(self):
-        return self._jconf.drddMulFactor()
-
-    def num_rdd_retries(self):
-        return self._jconf.numRddRetries()
-
-    def default_cloud_size(self):
-        return self._jconf.defaultCloudSize()
-
-    def h2o_node_log_level(self):
-        return self._jconf.h2oNodeLogLevel()
-
-    def h2o_node_log_dir(self):
-        return self._jconf.h2oNodeLogDir()
-
-    def node_iced_dir(self):
-        return self._get_option(self._jconf.nodeIcedDir())
-
-    def subseq_tries(self):
-        return self._jconf.subseqTries()
+    # getters independent on backend
 
     def backend_cluster_mode(self):
         return self._jconf.backendClusterMode()
 
-    def client_ip(self):
-        return self._get_option(self._jconf.clientIp())
+    def runs_in_external_cluster_mode(self):
+        return self._jconf.runsInExternalClusterMode()
 
-    def client_base_port(self):
-        return self._jconf.clientBasePort()
+    def runs_in_internal_cluster_mode(self):
+        return self._jconf.runsInInternalClusterMode()
 
-    def h2o_client_log_level(self):
-        return self._jconf.h2oClientLogLevel()
-
-    def h2o_client_log_dir(self):
-        return self._get_option(self._jconf.h2oClientLogDir())
-
-    def client_network_mask(self):
-        return self._get_option(self._jconf.clientNetworkMask())
-
-    def node_network_mask(self):
-        return self._get_option(self._jconf.nodeNetworkMask())
+    def cloud_name(self):
+        return self._get_option(self._jconf.cloudName())
 
     def nthreads(self):
         return self._jconf.nthreads()
@@ -280,11 +333,20 @@ class H2OConf(object):
     def disable_ga(self):
         return self._jconf.disableGA()
 
-    def client_web_port(self):
-        return self._jconf.clientWebPort()
+    def is_h2o_repl_enabled(self):
+        return self._jconf.isH2OReplEnabled()
 
-    def client_iced_dir(self):
-        return self._get_option(self._jconf.clientIcedDir())
+    def scala_int_default_num(self):
+        return self._jconf.scalaIntDefaultNum()
+
+    def is_cluster_topology_listener_enabled(self):
+        return self._jconf.isClusterTopologyListenerEnabled()
+
+    def is_spark_version_check_enabled(self):
+        return self._jconf.isSparkVersionCheckEnabled()
+
+    def is_fail_on_unsupported_spark_param_enabled(self):
+        return self._jconf.isFailOnUnsupportedSparkParamEnabled()
 
     def jks(self):
         return self._get_option(self._jconf.jks())
@@ -298,23 +360,140 @@ class H2OConf(object):
     def ldap_login(self):
         return self._jconf.ldapLogin()
 
+    def kerberos_login(self):
+        return self._jconf.kerberosLogin()
+
     def login_conf(self):
         return self._get_option(self._jconf.loginConf())
 
     def user_name(self):
         return self._get_option(self._jconf.userName())
 
-    def scala_int_default_num(self):
-        return self._jconf.scalaIntDefaultNum()
+    def ssl_conf(self):
+        return self._get_option(self._jconf.sslConf())
 
-    def is_h2o_repl_enabled(self):
-        return self._jconf.isH2OReplEnabled()
+    def h2o_node_log_level(self):
+        return self._jconf.h2oNodeLogLevel()
 
-    def is_cluster_topology_listener_enabled(self):
-        return self._jconf.isClusterTopologyListenerEnabled()
+    def h2o_node_log_dir(self):
+        return self._jconf.h2oNodeLogDir()
 
-    def is_spark_version_check_enabled(self):
-        return self._jconf.isSparkVersionCheckEnabled()
+    def ui_update_interval(self):
+        return self._jconf.uiUpdateInterval()
+
+    def cloud_timeout(self):
+        return self._jconf.cloudTimeout()
+
+    def flow_dir(self):
+        return self._get_option(self._jconf.flowDir())
+
+    def client_ip(self):
+        return self._get_option(self._jconf.clientIp())
+
+    def client_iced_dir(self):
+        return self._get_option(self._jconf.clientIcedDir())
+
+    def h2o_client_log_level(self):
+        return self._jconf.h2oClientLogLevel()
+
+    def h2o_client_log_dir(self):
+        return self._get_option(self._jconf.h2oClientLogDir())
+
+    def client_base_port(self):
+        return self._jconf.clientBasePort()
+
+    def client_web_port(self):
+        return self._jconf.clientWebPort()
+
+    def client_verbose_output(self):
+        return self._jconf.clientVerboseOutput()
+
+    def client_network_mask(self):
+        return self._get_option(self._jconf.clientNetworkMask())
+
+    # Getters for internal backend
+
+    def use_flatfile(self):
+        return self._jconf.useFlatFile()
+
+    def num_h2o_workers(self):
+        return self._get_option(self._jconf.numH2OWorkers())
+
+    def drdd_mul_factor(self):
+        return self._jconf.drddMulFactor()
+
+    def num_rdd_retries(self):
+        return self._jconf.numRddRetries()
+
+    def default_cloud_size(self):
+        return self._jconf.defaultCloudSize()
+
+    def subseq_tries(self):
+        return self._jconf.subseqTries()
+
+    def node_base_port(self):
+        return self._jconf.nodeBasePort()
+
+    def node_iced_dir(self):
+        return self._get_option(self._jconf.nodeIcedDir())
+
+    def node_network_mask(self):
+        return self._get_option(self._jconf.nodeNetworkMask())
+
+    # Getters for external backend
+
+    def h2o_cluster(self):
+        return self._get_option(self._jconf.h2oCluster())
+
+    def h2o_cluster_host(self):
+        return self._get_option(self._jconf.h2oClusterHost())
+
+    def h2o_cluster_port(self):
+        return self._get_option(self._jconf.h2oClusterPort())
+
+    def num_of_external_h2o_nodes(self):
+        return self._get_option(self._jconf.numOfExternalH2ONodes())
+
+    def client_check_retry_timeout(self):
+        return self._jconf.clientCheckRetryTimeout()
+
+    def client_connection_timeout(self):
+        return self._jconf.clientConnectionTimeout()
+
+    def external_read_confirmation_timeout(self):
+        return self._jconf.externalReadConfirmationTimeout()
+
+    def external_write_confirmation_timeout(self):
+        return self._jconf.externalWriteConfirmationTimeout()
+
+    def cluster_start_timeout(self):
+        return self._jconf.clusterStartTimeout()
+
+    def cluster_config_file(self):
+        return self._get_option(self._jconf.clusterInfoFile())
+
+    def mapper_xmx(self):
+        return self._jconf.mapperXmx()
+
+    def hdfs_output_dir(self):
+        return self._get_option(self._jconf.HDFSOutputDir())
+
+    def cluster_start_mode(self):
+        return self._jconf.clusterStartMode()
+
+    def is_auto_cluster_start_used(self):
+        return self._jconf.isAutoClusterStartUsed()
+
+    def is_manual_cluster_start_used(self):
+        return self._jconf.isManualClusterStartUsed()
+
+    def h2o_driver_path(self):
+        return self._get_option(self._jconf.h2oDriverPath())
+
+    def yarn_queue(self):
+        return self._get_option(self._jconf.YARNQueue())
+
+
 
     def set(self, key, value):
         self._jconf.set(key, value)


### PR DESCRIPTION
This is just technical task which brings nothing new, just makes all the setters and getters consistent amongst scala and python

- allow to get and set all properties at run-time at Scala API
- allow to get and set all properties at run-time at Python API
- remove set_flatfile option in python which isn't defined anywhere in Scala backend
- sort definition of configuration properties everywhere in the same order

- This change does not change names of existing configuration so all existing configuration works just fine