### PR TITLE
[SW-500] Warehouse dir does not have to be set in tests on Spark from…

### DIFF
--- a/core/src/test/scala/org/apache/spark/h2o/utils/SparkTestContext.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/SparkTestContext.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.h2o.utils
 
-import java.io.File
-
 import io.netty.util.internal.logging.{InternalLoggerFactory, Slf4JLoggerFactory}
 import org.apache.spark.h2o.backends.SharedBackendConf
 import org.apache.spark.h2o.{H2OConf, H2OContext}
@@ -67,8 +65,6 @@ trait SparkTestContext extends BeforeAndAfterEach with BeforeAndAfterAll {
       .set("spark.ext.h2o.backend.cluster.mode", sys.props.getOrElse("spark.ext.h2o.backend.cluster.mode", "internal"))
       .set("spark.ext.h2o.client.ip", sys.props.getOrElse("H2O_CLIENT_IP", NetworkInit.findInetAddressForSelf().getHostAddress))
       .set("spark.ext.h2o.external.start.mode", sys.props.getOrElse("spark.ext.h2o.external.start.mode", "manual"))
-      // set spark-warehouse manually because of https://issues.apache.org/jira/browse/SPARK-17810, fixed in 2.0.2
-      .set("spark.sql.warehouse.dir", s"file:${new File("spark-warehouse").getAbsolutePath}")
     conf
   })
 }

--- a/examples/src/integTest/scala/water/sparkling/itest/IntegTestHelper.scala
+++ b/examples/src/integTest/scala/water/sparkling/itest/IntegTestHelper.scala
@@ -49,8 +49,6 @@ trait IntegTestHelper extends BeforeAndAfterEach with BackendIndependentTestHelp
       // See: https://www.hackingnote.com/en/spark/trouble-shooting/NoClassDefFoundError-ClientConfig/
       Seq("--conf",  "spark.hadoop.yarn.timeline-service.enabled=false") ++
       Seq("--conf", s"spark.ext.h2o.external.start.mode=${sys.props.getOrElse("spark.ext.h2o.external.start.mode", "manual")}") ++
-      // set spark-warehouse manually because of https://issues.apache.org/jira/browse/SPARK-17810, fixed in 2.0.2
-      Seq("--conf", s"spark.sql.warehouse.dir=file:${new File("spark-warehouse").getAbsolutePath}") ++
       env.sparkConf.flatMap( p => Seq("--conf", s"${p._1}=${p._2}") ) ++
       Seq[String](env.itestJar)
 

--- a/examples/src/integTest/scala/water/sparkling/itest/IntegTestHelper.scala
+++ b/examples/src/integTest/scala/water/sparkling/itest/IntegTestHelper.scala
@@ -1,7 +1,5 @@
 package water.sparkling.itest
 
-import java.io.File
-
 import org.apache.spark.h2o.BackendIndependentTestHelper
 import org.apache.spark.h2o.backends.SharedBackendConf
 import org.apache.spark.h2o.backends.external.ExternalBackendConf

--- a/examples/src/scriptsTest/scala/water/sparkling/scripts/ScriptTestHelper.scala
+++ b/examples/src/scriptsTest/scala/water/sparkling/scripts/ScriptTestHelper.scala
@@ -65,8 +65,6 @@ trait ScriptsTestHelper extends FunSuiteWithLogging with BeforeAndAfterAll with 
       .set("spark.worker.timeout", "360") // Increase worker timeout if jenkins machines are busy
       .set("spark.ext.h2o.backend.cluster.mode", sys.props.getOrElse("spark.ext.h2o.backend.cluster.mode", "internal"))
       .set("spark.ext.h2o.external.start.mode", sys.props.getOrElse("spark.ext.h2o.external.start.mode", "manual"))
-      // set spark-warehouse manually because of https://issues.apache.org/jira/browse/SPARK-17810, fixed in 2.0.2
-      .set("spark.sql.warehouse.dir", s"file:${new File("spark-warehouse").getAbsolutePath}")
       .setJars(Array(assemblyJar))
     conf
   }

--- a/py/tests/integ_test_utils.py
+++ b/py/tests/integ_test_utils.py
@@ -90,7 +90,6 @@ class IntegTestSuite(unittest.TestCase):
         cmd_line.extend(["--conf", 'spark.scheduler.minRegisteredResourcesRatio=1'])
         cmd_line.extend(["--conf", 'spark.ext.h2o.repl.enabled=false']) #  disable repl in tests
         cmd_line.extend(["--conf", "spark.ext.h2o.external.start.mode=" + os.getenv("spark.ext.h2o.external.start.mode", "manual")])
-        cmd_line.extend(["--conf", "spark.sql.warehouse.dir=file:" + os.path.join(os.getcwd(), "spark-warehouse")])
         # Need to disable timeline service which requires Jersey libraries v1, but which are not available in Spark2.0
         # See: https://www.hackingnote.com/en/spark/trouble-shooting/NoClassDefFoundError-ClientConfig/
         cmd_line.extend(["--conf", 'spark.hadoop.yarn.timeline-service.enabled=false'])

--- a/py/tests/test_utils.py
+++ b/py/tests/test_utils.py
@@ -46,9 +46,7 @@ def get_default_spark_conf():
         set("spark.worker.timeout", "360"). \
         set("spark.ext.h2o.backend.cluster.mode", ExternalClusterTestHelper.cluster_mode()). \
         set("spark.ext.h2o.cloud.name", ExternalClusterTestHelper.unique_cloud_name("test")). \
-        set("spark.ext.h2o.external.start.mode", os.getenv("spark.ext.h2o.external.start.mode", "manual")) .\
-        set("spark.sql.warehouse.dir", "file:" + os.path.join(os.getcwd(), "spark-warehouse"))
-
+        set("spark.ext.h2o.external.start.mode", os.getenv("spark.ext.h2o.external.start.mode", "manual"))
 
     if ExternalClusterTestHelper.tests_in_external_mode():
         conf.set("spark.ext.h2o.client.ip", ExternalClusterTestHelper.local_ip())


### PR DESCRIPTION
… 2.1+

This is because https://issues.apache.org/jira/browse/SPARK-17810 was fixed in 2.1