### PR TITLE
[SW-501] Propagate all security related files.

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -52,6 +52,11 @@ class H2OConf(val sparkConf: SparkConf) extends Logging with InternalBackendConf
     this
   }
 
+  def set(key: String, value: Boolean): H2OConf = {
+    sparkConf.set(key, value.toString)
+    this
+  }
+
   /** Remove a parameter from the configuration */
   def remove(key: String): H2OConf = {
     sparkConf.remove(key)

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
@@ -87,34 +87,34 @@ trait SharedBackendConf {
   def setCloudName(cloudName: String) = set(PROP_CLOUD_NAME._1, cloudName)
   def setNthreads(numThreads: Int) = set(PROP_NTHREADS._1, nthreads.toString)
 
-  def setGAEnabled() = set(PROP_DISABLE_GA._1, true.toString)
-  def setGADisabled() = set(PROP_DISABLE_GA._1, false.toString)
+  def setGAEnabled() = set(PROP_DISABLE_GA._1, true)
+  def setGADisabled() = set(PROP_DISABLE_GA._1, false)
 
-  def setReplEnabled() = set(PROP_REPL_ENABLED._1, true.toString)
-  def setReplDisabled() = set(PROP_REPL_ENABLED._1, false.toString)
+  def setReplEnabled() = set(PROP_REPL_ENABLED._1, true)
+  def setReplDisabled() = set(PROP_REPL_ENABLED._1, false)
 
   def setDefaultNumReplSessions(numSessions: Int) = set(PROP_SCALA_INT_DEFAULT_NUM._1, numSessions.toString)
 
-  def setClusterTopologyListenerEnabled() = set(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, true.toString)
-  def setClusterTopologyListenerDisabled() = set(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, false.toString)
+  def setClusterTopologyListenerEnabled() = set(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, true)
+  def setClusterTopologyListenerDisabled() = set(PROP_CLUSTER_TOPOLOGY_LISTENER_ENABLED._1, false)
 
-  def setSparkVersionCheckEnable() = set(PROP_SPARK_VERSION_CHECK_ENABLED._1, true.toString)
-  def setSparkVersionCheckDisabled() = set(PROP_SPARK_VERSION_CHECK_ENABLED._1, false.toString)
+  def setSparkVersionCheckEnable() = set(PROP_SPARK_VERSION_CHECK_ENABLED._1, true)
+  def setSparkVersionCheckDisabled() = set(PROP_SPARK_VERSION_CHECK_ENABLED._1, false)
 
-  def setFailOnUnsupportedSparkParamEnabled() = set(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, true.toString)
-  def setFailOnUnsupportedSparkParamDisabled() = set(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, false.toString)
+  def setFailOnUnsupportedSparkParamEnabled() = set(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, true)
+  def setFailOnUnsupportedSparkParamDisabled() = set(PROP_FAIL_ON_UNSUPPORTED_SPARK_PARAM._1, false)
 
   def setJks(path: String) = set(PROP_JKS._1, path)
   def setJksPass(password: String) = set(PROP_JKS_PASS._1, password)
 
-  def setHashLoginEnabled() = set(PROP_HASH_LOGIN._1, true.toString)
-  def setHashLoginDisabled() = set(PROP_HASH_LOGIN._1, false.toString)
+  def setHashLoginEnabled() = set(PROP_HASH_LOGIN._1, true)
+  def setHashLoginDisabled() = set(PROP_HASH_LOGIN._1, false)
 
-  def setLdapLoginEnabled() = set(PROP_LDAP_LOGIN._1, true.toString)
-  def setLdapLoginDisabled() = set(PROP_LDAP_LOGIN._1, false.toString)
+  def setLdapLoginEnabled() = set(PROP_LDAP_LOGIN._1, true)
+  def setLdapLoginDisabled() = set(PROP_LDAP_LOGIN._1, false)
 
-  def setKerberosLoginEnabled() = set(PROP_KERBEROS_LOGIN._1, true.toString)
-  def setKerberosLoginDisabled() = set(PROP_KERBEROS_LOGIN._1, false.toString)
+  def setKerberosLoginEnabled() = set(PROP_KERBEROS_LOGIN._1, true)
+  def setKerberosLoginDisabled() = set(PROP_KERBEROS_LOGIN._1, false)
 
   def setLoginConf(file: String) = set(PROP_LOGIN_CONF._1, file)
   def setUserName(username: String) = set(PROP_USER_NAME._1, username)
@@ -133,8 +133,8 @@ trait SharedBackendConf {
   def setH2OClientLogDir(dir: String) = set(PROP_CLIENT_LOG_DIR._1, dir)
   def setClientPortBase(basePort: Int) = set(PROP_CLIENT_PORT_BASE._1, basePort.toString)
 
-  def setClientVerboseEnabled() = set(PROP_CLIENT_VERBOSE._1, true.toString)
-  def setClientVerboseDisabled() = set(PROP_CLIENT_VERBOSE._1, false.toString)
+  def setClientVerboseEnabled() = set(PROP_CLIENT_VERBOSE._1, true)
+  def setClientVerboseDisabled() = set(PROP_CLIENT_VERBOSE._1, false)
 
   def setClientNetworkMask(mask: String) = set(PROP_CLIENT_NETWORK_MASK._1, mask)
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendConf.scala
@@ -46,8 +46,8 @@ trait InternalBackendConf extends SharedBackendConf {
 
   /** Setters */
 
-  def setFlatFileEnabled() = set(PROP_USE_FLATFILE._1, true.toString)
-  def setFlatFileDisabled() = set(PROP_USE_FLATFILE._1, false.toString)
+  def setFlatFileEnabled() = set(PROP_USE_FLATFILE._1, true)
+  def setFlatFileDisabled() = set(PROP_USE_FLATFILE._1, false)
 
   def setNumH2OWorkers(numWorkers: Int) = set(PROP_CLUSTER_SIZE._1, numWorkers.toString)
   def setDrddMulFactor(factor: Int) = set(PROP_DUMMY_RDD_MUL_FACTOR._1, factor.toString)
@@ -58,7 +58,10 @@ trait InternalBackendConf extends SharedBackendConf {
   def setNodeBasePort(port: Int) = set(PROP_NODE_PORT_BASE._1, port.toString)
   def setNodeIcedDir(dir: String) = set(PROP_NODE_ICED_DIR._1, dir)
   def setNodeNetworkMask(mask: String) = set(PROP_NODE_NETWORK_MASK._1, mask)
-  def setInternalSecureConnectionsEnabled(flag: Boolean) = set(PROP_INTERNAL_SECURE_CONNECTIONS._1, flag)
+
+  def setInternalSecureConnectionsEnabled() = set(PROP_INTERNAL_SECURE_CONNECTIONS._1, true)
+  def setInternalSecureConnectionsDisabled() = set(PROP_INTERNAL_SECURE_CONNECTIONS._1, false)
+
 
   def internalConfString: String =
     s"""Sparkling Water configuration:

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendConf.scala
@@ -41,6 +41,9 @@ trait InternalBackendConf extends SharedBackendConf {
   def nodeIcedDir = sparkConf.getOption(PROP_NODE_ICED_DIR._1)
   def nodeNetworkMask = sparkConf.getOption(PROP_NODE_NETWORK_MASK._1)
 
+  def isInternalSecureConnectionsEnabled = sparkConf.getBoolean(PROP_INTERNAL_SECURE_CONNECTIONS._1,
+                                                                PROP_INTERNAL_SECURE_CONNECTIONS._2)
+
   /** Setters */
 
   def setFlatFileEnabled() = set(PROP_USE_FLATFILE._1, true.toString)
@@ -55,6 +58,7 @@ trait InternalBackendConf extends SharedBackendConf {
   def setNodeBasePort(port: Int) = set(PROP_NODE_PORT_BASE._1, port.toString)
   def setNodeIcedDir(dir: String) = set(PROP_NODE_ICED_DIR._1, dir)
   def setNodeNetworkMask(mask: String) = set(PROP_NODE_NETWORK_MASK._1, mask)
+  def setInternalSecureConnectionsEnabled(flag: Boolean) = set(PROP_INTERNAL_SECURE_CONNECTIONS._1, flag)
 
   def internalConfString: String =
     s"""Sparkling Water configuration:
@@ -103,5 +107,8 @@ object InternalBackendConf {
 
   /** Subnet selector for H2O nodes running inside executors - if the mask is specified then Spark network setup is not discussed. */
   val PROP_NODE_NETWORK_MASK = ("spark.ext.h2o.node.network.mask", None)
+
+  /** Secure internal connections by automatically generated credentials */
+  val PROP_INTERNAL_SECURE_CONNECTIONS = ("spark.ext.h2o.internal_secure_connections", false)
 
 }

--- a/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterInfoPage.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterInfoPage.scala
@@ -210,6 +210,9 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
             <strong>Health:</strong>{if (listener.cloudHealthy) "\u2714" else "\u2716"}
           </li>
           <li>
+            <strong>Secured communication:</strong>{listener.h2oCloudInfo.map(p => if (p.cloudSecured) "\u2714" else "\u2716").getOrElse("\u2754")}
+          </li>
+          <li>
             <strong>Nodes:</strong>{listener.h2oCloudInfo.get.cloudNodes.length}
           </li>
           <li>

--- a/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterListener.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterListener.scala
@@ -103,6 +103,7 @@ class SparklingWaterHistoryListener(conf: SparkConf, sparkUI: SparkUI)
 case class H2OCloudInfo(
                           localClientIpPort: String,
                           cloudHealthy: Boolean,
+                          cloudSecured: Boolean,
                           cloudNodes: Array[String],
                           extraBackendInfo: Seq[(String, String)],
                           h2oStartTime: Long)

--- a/core/src/main/scala/org/apache/spark/network/Security.scala
+++ b/core/src/main/scala/org/apache/spark/network/Security.scala
@@ -30,12 +30,8 @@ object Security extends Logging {
   def enableSSL(spark: SparkSession, conf: SparkConf): Unit = {
     val sslPair = SecurityUtils.generateSSLPair()
     val config = SecurityUtils.generateSSLConfig(sslPair)
-    if(SparkHadoopUtil.get.isYarnMode) {
-      conf.set("spark.yarn.dist.files", s"${sslPair.jks.path},$config")
-    } else {
-      spark.sparkContext.addFile(if (sslPair.jks.path.isEmpty) sslPair.jks.name else sslPair.jks.path + File.separator + sslPair.jks.name)
-      spark.sparkContext.addFile(config)
-    }
+    spark.sparkContext.addFile(if (sslPair.jks.path.isEmpty) sslPair.jks.name else sslPair.jks.path + File.separator + sslPair.jks.name)
+    spark.sparkContext.addFile(config)
     conf.set("spark.ext.h2o.internal_security_conf", config)
     logInfo(s"Added spark.ext.h2o.internal_security_conf configuration set to $config")
   }

--- a/doc/configuration/configuration_properties.rst
+++ b/doc/configuration/configuration_properties.rst
@@ -167,7 +167,7 @@ Internal backend configuration properties
 |                                                    |                | in `H2O Hadoop deployments             |
 |                                                    |                | <https://github.com/h2oai/h2o-3/blob/  |
 |                                                    |                | master/h2o-docs/src/product/           |
-|                                                    |                | security.rst#hadoop>`.                 |
+|                                                    |                | security.rst#hadoop>`_.                |
 +----------------------------------------------------+----------------+----------------------------------------+
 | **H2O nodes parameters**                           |                |                                        |
 +----------------------------------------------------+----------------+----------------------------------------+

--- a/doc/configuration/configuration_properties.rst
+++ b/doc/configuration/configuration_properties.rst
@@ -159,6 +159,16 @@ Internal backend configuration properties
 |                                                    |                | out size of Spark cluster, which are   |
 |                                                    |                | producing the same number of nodes.    |
 +----------------------------------------------------+----------------+----------------------------------------+
+| ``spark.ext.h2o.internal_secure_connections``      | ``false``      | Enables secure communications among    |
+|                                                    |                | H2O nodes. The security is based on    |
+|                                                    |                | automatically generated keystore       |
+|                                                    |                | and truststore. This is equivalent for |
+|                                                    |                | ``-internal_secure_conections`` option |
+|                                                    |                | in `H2O Hadoop deployments             |
+|                                                    |                | <https://github.com/h2oai/h2o-3/blob/  |
+|                                                    |                | master/h2o-docs/src/product/           |
+|                                                    |                | security.rst#hadoop>`.                 |
++----------------------------------------------------+----------------+----------------------------------------+
 | **H2O nodes parameters**                           |                |                                        |
 +----------------------------------------------------+----------------+----------------------------------------+
 | ``spark.ext.h2o.node.port.base``                   | ``54321``      | Base port used for individual H2O      |

--- a/doc/tutorials/security.rst
+++ b/doc/tutorials/security.rst
@@ -16,7 +16,7 @@ Security for data exchanged between H2O instances can be enabled
 manually by generating all necessary files and distributing them to all
 worker nodes as described in `H2O's
 documentation <https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/security.rst#ssl-internode-security>`__
-and passing the ``spark.ext.h2o.internal_security_conf`` to spark
+and passing the ``spark.ext.h2o.internal_security_conf`` to Spark
 submit:
 
 .. code:: shell
@@ -24,7 +24,15 @@ submit:
     bin/sparkling-shell --conf "spark.ext.h2o.internal_security_conf=ssl.properties"
 
 We also provide utility methods which automatically generate all
-necessary files and enable security on all H2O nodes:
+necessary files and enable security on all H2O nodes by passing the 
+option ``spark.ext.h2o.internal_secure_connections=true`` to Spark job submit:
+
+.. code:: shell
+
+    bin/sparkling-shell --conf "spark.ext.h2o.internal_secure_connections=true"
+
+This can be also achieved in programmatic way in Scala using the utility class
+``org.apache.spark.network.Security``:
 
 .. code:: scala
 

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -234,6 +234,15 @@ class H2OConf(object):
         self._jconf.setNodeNetworkMask(mask)
         return self
 
+    def set_internal_secure_connections_enabled(self):
+        self._jconf.setInternalSecureConnectionsEnabled()
+        return self
+
+    def set_internal_secure_connections_disabled(self):
+        self._jconf.setInternalSecureConnectionsDisabled()
+        return self
+
+
     # setters for external backend
 
     def set_h2o_cluster(self, ip, port):
@@ -439,6 +448,9 @@ class H2OConf(object):
 
     def node_network_mask(self):
         return self._get_option(self._jconf.nodeNetworkMask())
+
+    def is_internal_secure_connections_enabled(self):
+        return self._jconf.isInternalSecureConnectionsEnabled()
 
     # Getters for external backend
 


### PR DESCRIPTION
Propagate ssl.properties and ssl key files through Spark mechanisms instead of YARN.

To try:

1) run master branch to make sure it fails, `sparkling-shell --master yarn`

```
import org.apache.spark.network.Security
import org.apache.spark.h2o._
Security.enableSSL(spark)
val hc = H2OContext.getOrCreate(spark)
```

Should fail complaining about no `ssl.properties` file.

2) Run the above with this branch. H2O cluster should start, there should be mentions of `ssl.properties` in H2O logs and `ssl.properties` and `h2o-internal.jks` should be in temp files of each container (location can be found at the beginning of H2O logs).