### PR TITLE
[SW-504] Provides uber Sparkling Water Spark package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,9 @@ The artifacts coordinates are:
 
 - ``ai.h2o:sparkling-water-core_{{scala_version}}:{{version}}`` - includes core of Sparkling Water.
 - ``ai.h2o:sparkling-water-examples_{{scala_version}}:{{version}}`` - includes example applications.
+- ``ai.h2o:sparkling-water-repl_{{scala_version}}:{{version}}`` - Spark REPL integration into H2O Flow UI
+- ``ai.h2o:sparkling-water-ml_{{scala_version}}:{{version}}`` - Extends Spark ML package by H2O-based transformations
+- ``ai.h2o:sparkling-water-package_{{scala_version}}:{{version}}`` - Uber Sparkling Water package referencing all available Sparkling Water modules. This is designed to use as Spark package via ``--packages`` option
 
    **Note:** The ``{{version}}`` references to a release version of Sparkling Water, the ``{{scala_version}}``
    references to Scala base version (``2.10`` or ``2.11``). For example:

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ Select right version
 ~~~~~~~~~~~~~~~~~~~~
 
 The Sparkling Water is developed in multiple parallel branches. Each
-branch corresponds to a Spark major release (e.g., branch **rel-2.1**
-provides implementation of Sparkling Water for Spark **2.1**).
+branch corresponds to a Spark major release (e.g., branch **rel-2.2**
+provides implementation of Sparkling Water for Spark **2.2**).
 
 Please, switch to the right branch:
 
@@ -60,14 +60,15 @@ Maven
 Each Sparkling Water release is published into Maven central. Published artifacts are provided with the following Scala
 versions:
 
+- Sparkling Water 2.2.x - Scala 2.11
 - Sparkling Water 2.1.x - Scala 2.11
 - Sparkling Water 2.0.x - Scala 2.11
 - Sparkling Water 1.6.x - Scala 2.10
 
 The artifacts coordinates are:
 
-- ``ai.h2o:sparkling-water-core_{{scala_version}}:{{version}}`` - includes core of Sparkling Water.
-- ``ai.h2o:sparkling-water-examples_{{scala_version}}:{{version}}`` - includes example applications.
+- ``ai.h2o:sparkling-water-core_{{scala_version}}:{{version}}`` - Includes core of Sparkling Water
+- ``ai.h2o:sparkling-water-examples_{{scala_version}}:{{version}}`` - Includes example applications
 - ``ai.h2o:sparkling-water-repl_{{scala_version}}:{{version}}`` - Spark REPL integration into H2O Flow UI
 - ``ai.h2o:sparkling-water-ml_{{scala_version}}:{{version}}`` - Extends Spark ML package by H2O-based transformations
 - ``ai.h2o:sparkling-water-package_{{scala_version}}:{{version}}`` - Uber Sparkling Water package referencing all available Sparkling Water modules. This is designed to use as Spark package via ``--packages`` option

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,8 @@ ext {
       project(':sparkling-water-repl'),
       project(':sparkling-water-core'),
       project(':sparkling-water-examples'),
-      project(':sparkling-water-ml')
+      project(':sparkling-water-ml'),
+      project(':sparkling-water-package')
     ]
     // Project with integration tests
     integTestProjects = [
@@ -51,7 +52,8 @@ ext {
       project(':sparkling-water-core'),
       project(':sparkling-water-examples'),
       project(':sparkling-water-ml'),
-      project(':sparkling-water-app-streaming')
+      project(':sparkling-water-app-streaming'),
+      project(':sparkling-water-package')
     ]
     // Python projects
     pythonProjects = [
@@ -157,5 +159,6 @@ clean.doFirst {
   delete file("build/")
   delete file("h2ologs/")
   delete file("null/")
+  delete file("metastore_db/")
 }
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -781,7 +781,7 @@
             <p>1. Ensure that Spark is installed, and MASTER and SPARK_HOME environmental variables are properly set.</p>
             <p>2. Start Spark and point to maven coordinates of Sparkling Water:</p>
             <p class="terminal">
-              $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-core_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION
+              $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-package_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION
             </p>
 
             <p>3. Create an H<sub>2</sub>O cloud inside the Spark cluster:</p>

--- a/doc/tutorials/use_as_spark_package.rst
+++ b/doc/tutorials/use_as_spark_package.rst
@@ -2,16 +2,18 @@ Use Sparkling Water via Spark Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sparkling Water is also published as a Spark package. You can use it
-directly from your Spark distribution.
+directly from your Spark distribution. The name of published package is `ai.h2o:sparkling-water-package`
+and it references all published Sparkling Water modules. Moreover, each
+module can be used as Spark package if necessary.
 
-For example, if you have Spark version 2.0 and would like to use
-Sparkling Water version 2.0.0 and launch example
+For example, if you have Spark version 2.1 and would like to use
+Sparkling Water version 2.1.12 and launch example
 ``CraigslistJobTitlesStreamingApp``, then you can use the following
 command:
 
 .. code:: bash
 
-    $SPARK_HOME/bin/spark-submit --packages no.priv.garshol.duke:duke:1.2,ai.h2o:sparkling-water-core_2.11:2.1.0,ai.h2o:sparkling-water-examples_2.11:2.1.0 --class org.apache.spark.examples.h2o.CraigslistJobTitlesStreamingApp /dev/null
+    $SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-package_2.11:2.1.12 --class org.apache.spark.examples.h2o.CraigslistJobTitlesStreamingApp /dev/null
 
 The Spark option ``--packages`` points to Duke package and published Sparkling Water
 packages in Maven repository.
@@ -20,21 +22,15 @@ The similar command works for ``spark-shell``:
 
 .. code:: bash
 
-    $SPARK_HOME/bin/spark-shell --packages no.priv.garshol.duke:duke:1.2,ai.h2o:sparkling-water-core_2.11:2.1.0,ai.h2o:sparkling-water-examples_2.11:2.1.0
+    $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-package_2.11:2.1.12
 
 The same command works for Python programs:
 
 .. code:: bash
 
-    $SPARK_HOME/bin/spark-submit --packages no.priv.garshol.duke:duke:1.2,ai.h2o:sparkling-water-core_2.11:2.1.0,ai.h2o:sparkling-water-examples_2.11:2.1.0 example.py
+    $SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-package_2.11:2.1.12 example.py
 
 
 Note 1: When you are using Spark packages you do not need to download Sparkling Water distribution! Spark installation is sufficient!
-
-Note 2: The ``no.priv.garshol.duke:duke:1.2`` dependency has to be explicitly configured in order to use Sparkling
-Water as Spark package due to a bug in dependency resolutions in Spark.
-
-
-
 
 

--- a/doc/tutorials/use_as_spark_package.rst
+++ b/doc/tutorials/use_as_spark_package.rst
@@ -6,14 +6,14 @@ directly from your Spark distribution. The name of published package is `ai.h2o:
 and it references all published Sparkling Water modules. Moreover, each
 module can be used as Spark package if necessary.
 
-For example, if you have Spark version 2.1 and would like to use
-Sparkling Water version 2.1.12 and launch example
+For example, if you have Spark version 2.2 and would like to use
+Sparkling Water version 2.2.2 and launch example
 ``CraigslistJobTitlesStreamingApp``, then you can use the following
 command:
 
 .. code:: bash
 
-    $SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-package_2.11:2.1.12 --class org.apache.spark.examples.h2o.CraigslistJobTitlesStreamingApp /dev/null
+    $SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-package_2.11:2.2.2 --class org.apache.spark.examples.h2o.CraigslistJobTitlesStreamingApp /dev/null
 
 The Spark option ``--packages`` points to Duke package and published Sparkling Water
 packages in Maven repository.
@@ -22,13 +22,13 @@ The similar command works for ``spark-shell``:
 
 .. code:: bash
 
-    $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-package_2.11:2.1.12
+    $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-package_2.11:2.2.2
 
 The same command works for Python programs:
 
 .. code:: bash
 
-    $SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-package_2.11:2.1.12 example.py
+    $SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-package_2.11:2.2.2 example.py
 
 
 Note 1: When you are using Spark packages you do not need to download Sparkling Water distribution! Spark installation is sufficient!

--- a/package/build.gradle
+++ b/package/build.gradle
@@ -1,0 +1,27 @@
+description = 'Sparkling Water Spark Package'
+
+apply plugin: 'com.github.johnrengelman.shadow'
+
+dependencies {
+    // hack to go around Spark Ivy resolver
+    compileOnly "no.priv.garshol.duke:duke:1.2"
+
+    compile project(':sparkling-water-core')
+    compile project(":sparkling-water-examples")
+    compile project(":sparkling-water-ml")
+    compile project(":sparkling-water-repl")
+}
+
+jar {
+    enabled = true
+}
+
+shadowJar {
+    archiveName = jar.archiveName
+    //classifier = ''
+    dependencies {
+        configurations = [project.configurations.compileOnly]
+    }
+}
+
+jar.finalizedBy shadowJar

--- a/package/build.gradle
+++ b/package/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
     // hack to go around Spark Ivy resolver
-    compileOnly "no.priv.garshol.duke:duke:1.2"
+    compile "no.priv.garshol.duke:duke:1.2"
 
     compile project(':sparkling-water-core')
     compile project(":sparkling-water-examples")

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ include 'py'
 include 'repl'
 include 'docker'
 include 'app-streaming'
+include 'package'
 
 // Prefix all projects with sparkling-water name
 rootProject.children.each { project ->


### PR DESCRIPTION
The motivation for this is to improve user experience. Right now, SW provides 4 modules with complex dependencies which need to be often hot-fixed (like  SW-475).
The goal of this improvement is to provide a single uber Sparkling Water package which can be used as input for Spark submit option `--packages`.

This package is being published into maven central and can be used with Spark submit:
```
$SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-package_2.11:2.1.12 --class org.apache.spark.examples.h2o.CraigslistJobTitlesStreamingApp /dev/null
```

Note: right now it also provides a fixed for [SW-475]