### PR TITLE
[SW-505] Fix Java7 problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
 sudo: true
+dist: precise
 
 jdk:
   - oraclejdk7


### PR DESCRIPTION
Related issues:
  - https://github.com/travis-ci/travis-ci/issues/7476
  - https://github.com/travis-ci/travis-ci/issues/7884
  - cause by http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html