### PR TITLE
[SW-532] Make auto mode in external cluster default for tests in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,21 +39,16 @@ pipeline{
                 name: 'backendMode')
 
         choice(
-                choices: 'manual\nauto',
-                description: 'Start mode of H2O cluster in external backend',
-                name: 'externalBackendStartMode')
-
-        choice(
                 choices: 'hdp2.2\nhdp2.3\nhdp2.4\nhdp2.5\nhdp2.6\ncdh5.4\ncdh5.5\ncdh5.6\ncdh5.7\ncdh5.8\ncdh5.10\nmapr4.0\nmapr5.0\nmapr5.1\nmapr5.2\niop4.2',
                 description: 'Hadoop version for which H2O driver is obtained',
                 name: 'driverHadoopVersion')
 
-        string(name: 'hdpVersion', defaultValue: 'current', description: 'HDP version to pass to Spark configuration - for example, 2.2.0.0-2041, or 2.6.0.2.2, or current. When running external tests on yarn, the current will not do since it is not automatically expanded -> so please set 2.2.6.3-1')
+        string(name: 'hdpVersion', defaultValue: '2.2.6.3-1', description: 'HDP version to pass to Spark configuration - for example, 2.2.0.0-2041, or 2.6.0.2.2, or current. When running external tests on yarn, the current will not do since it is not automatically expanded -> so please set 2.2.6.3-1')
 
     }
 
     environment {
-        HADOOP_VERSION  = "2.6" 
+        HADOOP_VERSION  = "2.6"
         SPARK           = "spark-${params.sparkVersion}-bin-hadoop${HADOOP_VERSION}"
         SPARK_HOME      = "${env.WORKSPACE}/spark"
         HADOOP_CONF_DIR = "/etc/hadoop/conf"
@@ -113,7 +108,8 @@ pipeline{
                     # and export variable H2O_PYTHON_WHEEL driving building of pysparkling package
                     mkdir -p ${env.WORKSPACE}/private/
                     curl -s `./gradlew -q printH2OWheelPackage` > ${env.WORKSPACE}/private/h2o.whl
-                    ./gradlew -q extendJar -PdownloadH2O=${params.driverHadoopVersion}
+                    ./gradlew cleanH2OJars cleanExtendedH2OJars
+                    cp `./gradlew -q extendJar -PdownloadH2O=${params.driverHadoopVersion}` $H2O_EXTENDED_JAR
                    """
             }
         }
@@ -134,7 +130,7 @@ pipeline{
             steps {
                 sh  """
                     # Build, run regular tests
-                    ${env.WORKSPACE}/gradlew test -x integTest -PbackendMode=${params.backendMode} -PexternalBackendStartMode=${params.externalBackendStartMode}
+                    ${env.WORKSPACE}/gradlew test -x integTest -PbackendMode=${params.backendMode} -PexternalBackendStartMode=auto
                     """
             }
 
@@ -156,7 +152,7 @@ pipeline{
             steps {
                 sh  """
                     # Build, run regular tests
-                    ${env.WORKSPACE}/gradlew integTest -PsparkHome=${env.SPARK_HOME} -PbackendMode=${params.backendMode} -PexternalBackendStartMode=${params.externalBackendStartMode}
+                    ${env.WORKSPACE}/gradlew integTest -PsparkHome=${env.SPARK_HOME} -PbackendMode=${params.backendMode} -PexternalBackendStartMode=auto
                     """
             }
 
@@ -177,7 +173,7 @@ pipeline{
             steps {
                 sh """
                 # Run scripts tests
-                ${env.WORKSPACE}/gradlew scriptTest -PbackendMode=${params.backendMode} -PexternalBackendStartMode=${params.externalBackendStartMode}
+                ${env.WORKSPACE}/gradlew scriptTest -PbackendMode=${params.backendMode} -PexternalBackendStartMode=auto
                 """
 		    }
 			post {
@@ -195,7 +191,7 @@ pipeline{
             }
             steps {
                 sh """
-                    ${env.WORKSPACE}/gradlew integTest -PbackendMode=${params.backendMode} -PexternalBackendStartMode=${params.externalBackendStartMode} -PsparklingTestEnv=${params.sparklingTestEnv} -PsparkMaster=${env.MASTER} -PsparkHome=${env.SPARK_HOME} -x check -x :sparkling-water-py:integTest
+                    ${env.WORKSPACE}/gradlew integTest -PbackendMode=${params.backendMode} -PexternalBackendStartMode=auto -PsparklingTestEnv=${params.sparklingTestEnv} -PsparkMaster=${env.MASTER} -PsparkHome=${env.SPARK_HOME} -x check -x :sparkling-water-py:integTest
                      #  echo 'Archiving artifacts after Integration test'
                  """
             }
@@ -215,7 +211,7 @@ pipeline{
             }
             steps {
                 sh  """
-                    ${env.WORKSPACE}/gradlew integTestPython -PbackendMode=${params.backendMode} -PexternalBackendStartMode=${params.externalBackendStartMode} -PsparklingTestEnv=${params.sparklingTestEnv} -PsparkMaster=${env.MASTER} -PsparkHome=${env.SPARK_HOME} -x check
+                    ${env.WORKSPACE}/gradlew integTestPython -PbackendMode=${params.backendMode} -PexternalBackendStartMode=auto -PsparklingTestEnv=${params.sparklingTestEnv} -PsparkMaster=${env.MASTER} -PsparkHome=${env.SPARK_HOME} -x check
                     #  echo 'Archiving artifacts after PySparkling Integration test'
                     """
             }

--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -88,6 +88,11 @@ dependencies {
         exclude group: "org.spire-math", module: "spire_${scalaBaseVersion}"
     }
 
+    artifactsToMerge("joda-time:joda-time:2.3")
+    artifactsToMerge(project(':sparkling-water-examples')){
+        transitive = false
+    }
+
     originalJar = getOrDownloadOriginalJar()
     if (originalJar != null) {
         artifactsToMerge files(originalJar)
@@ -105,6 +110,9 @@ task cleanH2OJars(type: Delete){
     delete(file("private/downloaded"))
 }
 
+task cleanExtendedH2OJars(type: Delete){
+    delete(file("private/extended"))
+}
 
 task extendJar(type: ShadowJar, dependsOn:[":sparkling-water-ml:jar", ":sparkling-water-core:jar"]) {
     doFirst {
@@ -136,7 +144,9 @@ task printHadoopDistributions(){
 
 def static String h2oJarFileName(String pathToH2OJar){
     if(pathToH2OJar != null) {
-        return "h2odriver-extended"
+        def fileName = Paths.get(pathToH2OJar).last().toString()
+        def fileNameNoExtension = fileName.substring(0, fileName.length() - 4)
+        return fileNameNoExtension + "-extended"
     }else{
         return null
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -103,4 +103,6 @@ integTest {
     // Pass list of jars required for testing
     systemProperty "sparkling.assembly.jar", "${project(":sparkling-water-assembly").configurations.shadow.artifacts.file.join(',')}"
     systemProperty "sparkling.itest.jar", "${integTestJar.archivePath}"
+
+    // testLogging.showStandardStreams = true
 }

--- a/core/src/integTest/scala/water/sparkling/itest/local/H2OContextLocalSuite.scala
+++ b/core/src/integTest/scala/water/sparkling/itest/local/H2OContextLocalSuite.scala
@@ -35,7 +35,7 @@ class H2OContextLocalSuite extends FunSuite
   test("verify H2O cloud building on local JVM") {
     sc = new SparkContext("local[*]", "test-local", defaultSparkConf)
     
-    // start h2o cloud in case of external cluster mode
+    // This call also starts H2O cloud in case of external cluster mode
     hc = createH2OContext(sc, 1)
 
     // Number of nodes should be on

--- a/core/src/test/scala/org/apache/spark/h2o/H2OConfTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/H2OConfTestSuite.scala
@@ -56,7 +56,7 @@ class H2OConfTestSuite extends FunSuite
     // and getOrCreate methods automatically start H2OContext, we use a little bit of reflection
     val ctor = classOf[H2OContext].getDeclaredConstructor(classOf[SparkSession], classOf[H2OConf])
     ctor.setAccessible(true)
-    hc = ctor.newInstance(spark, new H2OConf(spark))
+    hc = ctor.newInstance(spark, new H2OConf(spark).setNumOfExternalH2ONodes(1))
     val conf = hc.getConf
 
     // Test passed values

--- a/core/src/test/scala/org/apache/spark/h2o/KnownSparkIssues.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/KnownSparkIssues.scala
@@ -17,23 +17,20 @@
 package org.apache.spark.h2o
 
 import org.apache.spark.SparkContext
-import org.apache.spark.h2o.utils.{SharedSparkTestContext, SparkTestContext}
+import org.apache.spark.h2o.utils.SharedSparkTestContext
 import org.junit.runner.RunWith
-import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 
 /**
   * Tests for known Spark issues and our workaround which doesn't fit to any category in other tests
   */
 @RunWith(classOf[JUnitRunner])
 class KnownSparkIssues extends FunSuite
-  with Matchers with BeforeAndAfter with SparkTestContext {
+  with Matchers with BeforeAndAfter with SharedSparkTestContext {
 
-  override def beforeAll(){
-    super.beforeAll()
-    // we use local-cluster since the non-determinism isn't reproducible in local mode
-    sc = new SparkContext("local-cluster[2,2,2048]", "test-local-cluster", defaultSparkConf)
-  }
+  // we use local-cluster since the non-determinism isn't reproducible in local mode
+  override def createSparkContext: SparkContext = new SparkContext("local-cluster[2,2,2048]", "test-local-cluster", conf = defaultSparkConf)
 
   test("PUBDEV-3808 - Spark's BroadcastHashJoin is non deterministic - Negative test") {
 
@@ -62,7 +59,7 @@ class KnownSparkIssues extends FunSuite
     val sampleA = df.sample(withReplacement = false, 0.1, seed = 0)
     val sampleB = df.sample(withReplacement = false, 0.1, seed = 0)
 
-    val counts = (0 until 5).map( _ => sampleA.except(sampleB).count )
+    val counts = (0 until 5).map(_ => sampleA.except(sampleB).count)
     // check whether all elements are the same
     val first = counts.head
     val mismatch = counts.exists(c => c != first)

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -381,7 +381,7 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     assert(h2oFrame.vec(1).isString)
     assert(h2oFrame.vec(2).isTime)
   }
-  
+
   test("H2OFrame[Simple StructType] to DataFrame[flattened StructType]") {
     import spark.implicits._
     val num = 20
@@ -422,7 +422,7 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     val values = (1 to num).map(x => ComposedA(PrimitiveA(x, "name=" + x), x * 1.0))
     val rdd: RDD[ComposedA] = sc.parallelize(values)
     val df = rdd.toDF
-    
+
     val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
     val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(sc, flattenDF)
     val expandedSchema = H2OSchemaUtils.expandedSchema(sc, H2OSchemaUtils.flattenSchema(df.schema), maxElementSizes)
@@ -538,41 +538,41 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
   }
 
   test("Expand schema with ML dense vectors") {
-   import spark.implicits._
+    import spark.implicits._
 
-   val num = 2
-   val values = (1 to num).map(x =>
-     PrimitiveMlFixture(org.apache.spark.ml.linalg.Vectors.dense((1 to x).map(1.0 * _).toArray))
-   )
-   val df = sc.parallelize(values).toDF
+    val num = 2
+    val values = (1 to num).map(x =>
+      PrimitiveMlFixture(org.apache.spark.ml.linalg.Vectors.dense((1 to x).map(1.0 * _).toArray))
+    )
+    val df = sc.parallelize(values).toDF
 
-   val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
+    val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
 
-   assert(expandedSchema === Vector(
-     StructField("f0", DoubleType),
-     StructField("f1", DoubleType)))
+    assert(expandedSchema === Vector(
+      StructField("f0", DoubleType),
+      StructField("f1", DoubleType)))
 
-   // Verify transformation into DataFrame
-   val h2oFrame = hc.asH2OFrame(df)
-   // Basic invariants
-   assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
-   assert(expandedSchema.length == h2oFrame.numCols(), "Number columns should match")
-   assert(h2oFrame.names() === expandedSchema.map(_.name))
+    // Verify transformation into DataFrame
+    val h2oFrame = hc.asH2OFrame(df)
+    // Basic invariants
+    assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
+    assert(expandedSchema.length == h2oFrame.numCols(), "Number columns should match")
+    assert(h2oFrame.names() === expandedSchema.map(_.name))
 
-   // Verify data stored in h2oFrame after transformation
-   assertVectorDoubleValues(h2oFrame.vec(0), Seq(1.0, 1.0))
-   // For vectors missing values are replaced by zeros
-   assertVectorDoubleValues(h2oFrame.vec(1), Seq(0.0, 2.0))
- }
+    // Verify data stored in h2oFrame after transformation
+    assertVectorDoubleValues(h2oFrame.vec(0), Seq(1.0, 1.0))
+    // For vectors missing values are replaced by zeros
+    assertVectorDoubleValues(h2oFrame.vec(1), Seq(0.0, 2.0))
+  }
 
 
   test("Expand schema with ML sparse vectors") {
     import spark.implicits._
     val num = 3
     val values = (0 until num).map(x =>
-     PrimitiveMlFixture(
-       org.apache.spark.ml.linalg.Vectors.sparse(num, Seq((x, 1.0)))
-     ))
+      PrimitiveMlFixture(
+        org.apache.spark.ml.linalg.Vectors.sparse(num, Seq((x, 1.0)))
+      ))
     val df = sc.parallelize(values, num).toDF()
 
     val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
@@ -592,16 +592,16 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
     // Verify data stored in h2oFrame after transformation
     assertDoubleFrameValues(h2oFrame, values.map(_.f.toArray))
   }
-  
+
   test("Expand complex schema with sparse and dense vectors") {
     import spark.implicits._
     val num = 3
     val values = (0 until num).map(x =>
-     ComplexMlFixture(
-       org.apache.spark.ml.linalg.Vectors.sparse(num, Seq((x, 1.0))),
-       x,
-       org.apache.spark.ml.linalg.Vectors.dense((1 to x).map(1.0 * _).toArray)
-     ))
+      ComplexMlFixture(
+        org.apache.spark.ml.linalg.Vectors.sparse(num, Seq((x, 1.0))),
+        x,
+        org.apache.spark.ml.linalg.Vectors.dense((1 to x).map(1.0 * _).toArray)
+      ))
     println(values.mkString("\n"))
     val df = sc.parallelize(values, num).toDF()
 
@@ -614,12 +614,12 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
       StructField("idx", IntegerType, false),
       StructField("f20", DoubleType, true),
       StructField("f21", DoubleType, true)
-      )
+    )
     )
 
     // Verify transformation into DataFrame
     val h2oFrame = hc.asH2OFrame(df)
-    
+
     // Basic invariants
     assert(df.count == h2oFrame.numRows(), "Number of rows has to match")
     assert(expandedSchema.length == h2oFrame.numCols(), "Number columns should match")
@@ -627,8 +627,8 @@ class DataFrameConverterTest extends FunSuite with SharedSparkTestContext {
 
     // Verify data stored in h2oFrame after transformation
     assertDoubleFrameValues(h2oFrame, Seq(Array(1.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-                                          Array(0.0, 1.0, 0.0, 1.0, 1.0, 0.0),
-                                          Array(0.0, 0.0, 1.0, 2.0, 1.0, 2.0)))
+      Array(0.0, 1.0, 0.0, 1.0, 1.0, 0.0),
+      Array(0.0, 0.0, 1.0, 2.0, 1.0, 2.0)))
   }
 
   test("Add metadata to Dataframe") {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -69,7 +69,7 @@ integTest {
   systemProperty "sparkling.itest.jar", "${integTestJar.archivePath}"
 
   // Show standard out and standard error of the test JVM(s) on the console
-  // DEBUG testLogging.showStandardStreams = true
+  // testLogging.showStandardStreams = true
 }
 
 // Setup test environment for scripts test

--- a/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMojoModelTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMojoModelTest.scala
@@ -103,11 +103,11 @@ class H2OMojoModelTest extends FunSuite with SharedSparkTestContext {
     path.toString
   }
 
-  def irisDataFrame = {
+  lazy val irisDataFrame = {
     hc.asDataFrame(new H2OFrame(URI.create("examples/smalldata/iris.csv")))
   }
 
-  def prostateDataFrame = {
+  lazy val prostateDataFrame = {
     hc.asDataFrame(new H2OFrame(URI.create("examples/smalldata/prostate.csv")))
   }
 


### PR DESCRIPTION
- Also fixes bug with h2odriver name ( caused by SW-423 ) - the generated extended h2o jars need to have unique names
- Fix H2OConfTestSuite under external cluster
- Remove extended and download jars to have clean working environment. The downloaded jars are cached and it was possible that old one would be used
- Add missing libraries required for `RefineDateColum` into extended jar on class on external cluster