### PR TITLE
[SW-539] Fix bug when pysparkling is executed in parallel on the same node

### DIFF
--- a/py/pysparkling/context.py
+++ b/py/pysparkling/context.py
@@ -139,12 +139,14 @@ class H2OContext(object):
 
 
     def stop_with_jvm(self):
+        Initializer.clean_temp_dir()
         h2o.cluster().shutdown()
         self.stop()
 
 
     def stop(self):
         warnings.warn("Stopping H2OContext. (Restarting H2O is not yet fully supported...) ")
+        Initializer.clean_temp_dir()
         self._jhc.stop(False)
 
     def __del__(self):


### PR DESCRIPTION
This bug fix introduce back the cache which @mmalohlava wrote a while ago. However it also changes the python egg cache path for tests so the tests always uses the correct latest artefact ( this was source of issues and also reason why the cache was removed ).


Also when testing SNAPSHOT versions locally on different sparkling-water we make sure to use temporary cache for python eggs, again to be sure we run on the latest code.

The cache is fine if it's used by the users on the released versions.

