### PR TITLE
[SW-553] Improve Sparse vector handling for internal cluster

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalWriteConverterCtx.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalWriteConverterCtx.scala
@@ -37,7 +37,7 @@ class ExternalWriteConverterCtx(nodeDesc: NodeDesc, totalNumOfRows: Int, writeTi
     *         This has also effect of Spark stopping the current job and
     *         rescheduling it
     */
-  override def closeChunks(): Unit = {
+  override def closeChunks(numRows: Int): Unit = {
     try{
       externalFrameWriter.waitUntilAllWritten(writeTimeout)
     } finally {
@@ -48,7 +48,7 @@ class ExternalWriteConverterCtx(nodeDesc: NodeDesc, totalNumOfRows: Int, writeTi
   /**
     * Initialize the communication before the chunks are created
     */
-  override def createChunks(keystr: String, expectedTypes: Array[Byte], chunkId: Int, maxVecSizes: Array[Int]): Unit = {
+  override def createChunks(keystr: String, expectedTypes: Array[Byte], chunkId: Int, maxVecSizes: Array[Int], vecStartSize: Map[Int, Int]): Unit = {
     externalFrameWriter.createChunks(keystr, expectedTypes, chunkId, totalNumOfRows, maxVecSizes)
   }
 
@@ -76,6 +76,9 @@ class ExternalWriteConverterCtx(nodeDesc: NodeDesc, totalNumOfRows: Int, writeTi
   override def putDenseVector(startIdx: Int, vector: DenseVector, maxVecSize: Int): Unit = {
     externalFrameWriter.sendDenseVector(vector.values)
   }
+
+  override def startRow(rowIdx: Int): Unit = {}
+  override def finishRow(): Unit = {}
 }
 
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalWriteConverterCtx.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalWriteConverterCtx.scala
@@ -27,11 +27,26 @@ import water.fvec.{FrameUtils, NewChunk}
 class InternalWriteConverterCtx extends WriteConverterCtx {
 
   private var chunks: Array[NewChunk] = _
-  override def createChunks(keyName: String, vecTypes: Array[Byte], chunkId: Int, maxVecSizes: Array[Int]): Unit = {
-   chunks = FrameUtils.createNewChunks(keyName, vecTypes, chunkId)
+
+  private var sparseVectorPts: collection.mutable.Map[Int, Array[Int]] = _
+
+  private var rowIdx: Int = _
+
+  override def createChunks(keyName: String, h2oTypes: Array[Byte], chunkId: Int, maxVecSizes: Array[Int], vecStartSize: Map[Int, Int]): Unit = {
+    chunks = FrameUtils.createNewChunks(keyName, h2oTypes, chunkId)
+    sparseVectorPts = collection.mutable.Map(vecStartSize.mapValues(size => new Array[Int](size)).toSeq: _*)
   }
 
-  override def closeChunks(): Unit = {
+  override def closeChunks(numRows: Int): Unit = {
+    sparseVectorPts.foreach { case (startIdx, pts) =>
+        var i = 0
+        while (i < pts.length) {
+          if (pts(i) < numRows) {
+            chunks(startIdx + i).addZeros(numRows - pts(i))
+          }
+          i += 1
+        }
+    }
     FrameUtils.closeNewChunks(chunks)
   }
 
@@ -50,10 +65,26 @@ class InternalWriteConverterCtx extends WriteConverterCtx {
 
   override def numOfRows(): Int = chunks(0).len()
 
-
   override def putSparseVector(startIdx: Int, vector: SparseVector, maxVecSize: Int): Unit = {
-    putAnyVector(startIdx, vector, maxVecSize)
+    val sparseVectorPt = sparseVectorPts(startIdx)
+    var i = 0
+    while (i < vector.indices.length) {
+      val idx = vector.indices(i)
+      val value = vector.values(i)
+      val zeros = rowIdx - sparseVectorPt(idx) - 1
+      if (zeros > 0) {
+        chunks(startIdx + idx).addZeros(zeros)
+      }
+      put(startIdx + idx, value)
+      sparseVectorPt(idx) = rowIdx
+      i += 1
+    }
   }
+
+  override def startRow(rowIdx: Int): Unit = {
+    this.rowIdx = rowIdx
+  }
+  override def finishRow(): Unit = {}
 
   override def putDenseVector(startIdx: Int, vector: DenseVector, maxVecSize: Int): Unit = {
     putAnyVector(startIdx, vector, maxVecSize)

--- a/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtx.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtx.scala
@@ -27,9 +27,13 @@ import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vectors}
   * via unified API
   */
 trait WriteConverterCtx {
-  def createChunks(keyName: String, vecTypes: Array[Byte], chunkId: Int, maxVecSizes: Array[Int])
+  def createChunks(keyName: String, h2oTypes: Array[Byte], chunkId: Int, maxVecSizes: Array[Int], vecStartSize: Map[Int, Int] = Map.empty)
 
-  def closeChunks()
+  def closeChunks(numRows: Int = -1)
+
+  def startRow(rowIdx: Int)
+
+  def finishRow()
 
   def put(colIdx: Int, data: Boolean)
 

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterBenchTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterBenchTest.scala
@@ -1,0 +1,77 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.converters
+
+import org.apache.spark.SparkContext
+import org.apache.spark.h2o.testdata.SparseVectorHolder
+import org.apache.spark.h2o.utils.SharedH2OTestContext
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import water.api.TestUtils
+import water.util.PrettyPrint
+
+@RunWith(classOf[JUnitRunner])
+class DataFrameConverterBenchTest extends FunSuite with SharedH2OTestContext {
+
+  override def createSparkContext: SparkContext = new SparkContext("local[*]", "bench-local", conf = defaultSparkConf)
+
+  // @formatter:off
+  test("Wide dataset to H2OFrame") {
+    import org.apache.spark.h2o.utils.BenchUtils.bench
+    import TestUtils.sparseVector
+    import sqlContext.implicits._
+    val NCOL = 50*1000
+    val SPARSITY = 0.2
+    val NROW = 3*1000
+    val PARTITIONS = 1
+
+    val elementsPerRow = (SPARSITY * NCOL).toInt
+    val rowGenerator = (row: Int) => {
+      new SparseVectorHolder(sparseVector(NCOL, elementsPerRow))
+    }
+    val df = sc.parallelize((0 until NROW).map(row => rowGenerator(row)), PARTITIONS).toDF()
+
+    val m1 = bench(5) {
+      val hf = hc.asH2OFrame(df)
+      hf.remove()
+    }
+
+    println(m1.show())
+  }
+
+  test("Convert matrix 10x11 to H2OFrame") {
+    import org.apache.spark.h2o.utils.BenchUtils.bench
+    import sqlContext.implicits._
+
+    val NROW = 10
+    val NCOL = 11
+    val PARTITIONS = 1
+    val rowGenerator = (row: Int) => {
+      new SparseVectorHolder(new org.apache.spark.ml.linalg.SparseVector(NCOL, Array(row), Array[Double](row)))
+    }
+    val df = sc.parallelize((0 until NROW).map(row => rowGenerator(row)), PARTITIONS).toDF()
+
+    val m1 = bench(10) {
+      val hf = hc.asH2OFrame(df)
+      hf.remove()
+    }
+
+    println(m1.show())
+  }
+}

--- a/core/src/test/scala/org/apache/spark/h2o/testdata/TestData.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/testdata/TestData.scala
@@ -101,3 +101,5 @@ case class SemiPartialPerson(name: String, age: Option[Int], email: Option[Strin
 case class SampleString(x: String)
 
 case class SampleAltString(y: String)
+
+case class SparseVectorHolder(v: org.apache.spark.ml.linalg.SparseVector)

--- a/core/src/test/scala/org/apache/spark/h2o/utils/BenchUtils.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/BenchUtils.scala
@@ -1,0 +1,72 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.utils
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.TimeUnit
+
+object BenchUtils {
+  /**
+    * Measure execution time of given block in nanoseconds.
+    * 
+    * @param block  block to measure
+    * @return  number of ns to execute given block
+    */
+  def timer(block: =>Unit): Long = {
+    val now = System.nanoTime()
+    block
+    System.nanoTime() - now
+  }
+
+  /**
+    * Benchmark given block of code.
+    *
+    * @param iterations number of iterations to execute the block of code
+    * @param block block to execute as benchmark
+    * @return
+    */
+  def bench(iterations: Int, warmup: Int = 4, outputTimeUnit: TimeUnit = TimeUnit.MILLISECONDS)(block: =>Unit): BenchResult = {
+    val times = new Array[Long](iterations)
+    // Warmup
+    for (i <- 0 until warmup) {
+      timer(block)
+    }
+    // Measure
+    for (i <- 0 until iterations) {
+      times(i) = timer(block)
+    }
+
+    BenchResult(times, TimeUnit.NANOSECONDS, outputTimeUnit)
+  }
+}
+
+case class BenchResult(mean: Float, stdDev: Float, min: Float, max: Float, unit: TimeUnit) {
+  def show(): String = {
+    f"${mean}%4f ± ${stdDev}%4f (${min}%4f, ${max}%4f)"
+  }
+}
+
+object BenchResult {
+  def apply(measurements: Array[Long], inputUnit: TimeUnit, outputUnit: TimeUnit): BenchResult = {
+    val convMeasurements = measurements.map(x => outputUnit.convert(x, inputUnit))
+    val mean = convMeasurements.sum.toFloat / convMeasurements.length
+    val stdev = (Math.sqrt(convMeasurements.map(x => (x - mean)*(x-mean)).sum/(convMeasurements.length - 1))).toFloat
+    new BenchResult(mean, stdev, convMeasurements.min, convMeasurements.max, outputUnit)
+  }
+}

--- a/core/src/test/scala/water/api/SupportAPISuite.scala
+++ b/core/src/test/scala/water/api/SupportAPISuite.scala
@@ -20,12 +20,14 @@ import java.io.File
 
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.utils.SharedH2OTestContext
+import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.FunSuite
 import water.fvec.{AppendableVec, Frame, NewChunk, Vec}
 import water.munging.JoinMethod
 
 import scala.collection.immutable.IndexedSeq
 import scala.reflect.ClassTag
+import scala.util.Random
 
 class SupportAPISuite extends FunSuite with SharedH2OTestContext {
 
@@ -116,6 +118,12 @@ object TestUtils {
     val vec = avec.layout_and_close(fs)
     fs.blockForPending
     vec
+  }
+
+  def sparseVector(len: Int, elements: Int, rng: Random = Random): org.apache.spark.ml.linalg.SparseVector = {
+    assert(elements < len)
+    val data = (1 to elements).map(_ => rng.nextInt(len)).sortBy(identity).distinct.map(it => (it, rng.nextDouble()))
+    Vectors.sparse(len, data).toSparse
   }
 
   implicit object TestJoinSupportConverter extends ((Frame, Int) => (String, Int, Int)) {


### PR DESCRIPTION
The change writes only non-zero parts of sparse vectors, keep track of
zero parts in vertical dimension and write them into Chunk via addZero()
method.

Preliminary benchmarks shows speed up for dataset 3,000x50,000 (50k is
represented by Sparse vector with sparsity 0.2) from 40seconds to 18
seconds locally.

Results for 3k x 50k (rows x cols), sparse vector, 0.2 sparsity (20% of
non-zeros), single Spark partition transfered to a single H2O chunk:

```
Mean           Stdev        Min           Max            Unit
39452.800781 ± 1380.934204 (37205.000000, 40707.000000) (msec) (BEFORE
CHANGE)
13518.599609 ± 663.543762 (12781.000000, 14495.000000)  (msec)
```

Results for 10 x 11 matrics, sparse vector with a single non-zero
element (matrix has a single zero column):

```
Mean        Stdev     Min        Max         Unit
64.500000 ± 8.669871 (56.000000, 80.000000)  (msec) (BEFORE CHANGE)
51.299999 ± 4.762119 (46.000000, 61.000000)  (msec)
```

TODO:
  - [ ] Make backend selection more configurable and provide internal backend for sparse data
  - [ ] Implement assertions for benchmarks (we need to have ^ first to run both version and show that sparse support introduced by this PR is faster)
