### PR TITLE
[SW-553] Benchmark suite to measure performance of sparse transfers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
         - $HOME/.gradle/wrapper/
         - $SPARK_HOME
 
-script: ./gradlew clean build -x integTest -x :sparkling-water-py:build -PsparklingTestEnv=local -PsparkHome=$SPARK_HOME -PscalaBaseVersion=$SCALA_BASE_VERSION
+script: travis_wait ./gradlew clean build -x integTest -x :sparkling-water-py:build -PsparklingTestEnv=local -PsparkHome=$SPARK_HOME -PscalaBaseVersion=$SCALA_BASE_VERSION
 
 # To solve BufferOverflow on OpenJDK7 we setup short hostname (<64characters)
 # See:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
         - $HOME/.gradle/wrapper/
         - $SPARK_HOME
 
-script: travis_wait ./gradlew clean build -x integTest -x :sparkling-water-py:build -PsparklingTestEnv=local -PsparkHome=$SPARK_HOME -PscalaBaseVersion=$SCALA_BASE_VERSION
+script: travis_wait 30 ./gradlew clean build -x integTest -x :sparkling-water-py:build -PsparklingTestEnv=local -PsparkHome=$SPARK_HOME -PscalaBaseVersion=$SCALA_BASE_VERSION
 
 # To solve BufferOverflow on OpenJDK7 we setup short hostname (<64characters)
 # See:

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterBenchTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterBenchTest.scala
@@ -1,0 +1,77 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.converters
+
+import org.apache.spark.SparkContext
+import org.apache.spark.h2o.testdata.SparseVectorHolder
+import org.apache.spark.h2o.utils.SharedH2OTestContext
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import water.api.TestUtils
+import water.util.PrettyPrint
+
+@RunWith(classOf[JUnitRunner])
+class DataFrameConverterBenchTest extends FunSuite with SharedH2OTestContext {
+
+  override def createSparkContext: SparkContext = new SparkContext("local[*]", "bench-local", conf = defaultSparkConf)
+
+  // @formatter:off
+  test("Wide dataset to H2OFrame") {
+    import org.apache.spark.h2o.utils.BenchUtils.bench
+    import TestUtils.sparseVector
+    import sqlContext.implicits._
+    val NCOL = 50*1000
+    val SPARSITY = 0.2
+    val NROW = 3*1000
+    val PARTITIONS = 1
+
+    val elementsPerRow = (SPARSITY * NCOL).toInt
+    val rowGenerator = (row: Int) => {
+      new SparseVectorHolder(sparseVector(NCOL, elementsPerRow))
+    }
+    val df = sc.parallelize((0 until NROW).map(row => rowGenerator(row)), PARTITIONS).toDF()
+
+    val m1 = bench(5) {
+      val hf = hc.asH2OFrame(df)
+      hf.remove()
+    }
+
+    println(m1.show())
+  }
+
+  test("Convert matrix 10x11 to H2OFrame") {
+    import org.apache.spark.h2o.utils.BenchUtils.bench
+    import sqlContext.implicits._
+
+    val NROW = 10
+    val NCOL = 11
+    val PARTITIONS = 1
+    val rowGenerator = (row: Int) => {
+      new SparseVectorHolder(new org.apache.spark.ml.linalg.SparseVector(NCOL, Array(row), Array[Double](row)))
+    }
+    val df = sc.parallelize((0 until NROW).map(row => rowGenerator(row)), PARTITIONS).toDF()
+
+    val m1 = bench(10) {
+      val hf = hc.asH2OFrame(df)
+      hf.remove()
+    }
+
+    println(m1.show())
+  }
+}

--- a/core/src/test/scala/org/apache/spark/h2o/testdata/TestData.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/testdata/TestData.scala
@@ -101,3 +101,5 @@ case class SemiPartialPerson(name: String, age: Option[Int], email: Option[Strin
 case class SampleString(x: String)
 
 case class SampleAltString(y: String)
+
+case class SparseVectorHolder(v: org.apache.spark.ml.linalg.SparseVector)

--- a/core/src/test/scala/org/apache/spark/h2o/utils/BenchUtils.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/BenchUtils.scala
@@ -1,0 +1,72 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.utils
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.TimeUnit
+
+object BenchUtils {
+  /**
+    * Measure execution time of given block in nanoseconds.
+    * 
+    * @param block  block to measure
+    * @return  number of ns to execute given block
+    */
+  def timer(block: =>Unit): Long = {
+    val now = System.nanoTime()
+    block
+    System.nanoTime() - now
+  }
+
+  /**
+    * Benchmark given block of code.
+    *
+    * @param iterations number of iterations to execute the block of code
+    * @param block block to execute as benchmark
+    * @return
+    */
+  def bench(iterations: Int, warmup: Int = 4, outputTimeUnit: TimeUnit = TimeUnit.MILLISECONDS)(block: =>Unit): BenchResult = {
+    val times = new Array[Long](iterations)
+    // Warmup
+    for (i <- 0 until warmup) {
+      timer(block)
+    }
+    // Measure
+    for (i <- 0 until iterations) {
+      times(i) = timer(block)
+    }
+
+    BenchResult(times, TimeUnit.NANOSECONDS, outputTimeUnit)
+  }
+}
+
+case class BenchResult(mean: Float, stdDev: Float, min: Float, max: Float, unit: TimeUnit) {
+  def show(): String = {
+    f"${mean}%4f ± ${stdDev}%4f (${min}%4f, ${max}%4f)"
+  }
+}
+
+object BenchResult {
+  def apply(measurements: Array[Long], inputUnit: TimeUnit, outputUnit: TimeUnit): BenchResult = {
+    val convMeasurements = measurements.map(x => outputUnit.convert(x, inputUnit))
+    val mean = convMeasurements.sum.toFloat / convMeasurements.length
+    val stdev = (Math.sqrt(convMeasurements.map(x => (x - mean)*(x-mean)).sum/(convMeasurements.length - 1))).toFloat
+    new BenchResult(mean, stdev, convMeasurements.min, convMeasurements.max, outputUnit)
+  }
+}

--- a/core/src/test/scala/water/api/SupportAPISuite.scala
+++ b/core/src/test/scala/water/api/SupportAPISuite.scala
@@ -20,12 +20,14 @@ import java.io.File
 
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.utils.SharedH2OTestContext
+import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.FunSuite
 import water.fvec.{AppendableVec, Frame, NewChunk, Vec}
 import water.munging.JoinMethod
 
 import scala.collection.immutable.IndexedSeq
 import scala.reflect.ClassTag
+import scala.util.Random
 
 class SupportAPISuite extends FunSuite with SharedH2OTestContext {
 
@@ -116,6 +118,12 @@ object TestUtils {
     val vec = avec.layout_and_close(fs)
     fs.blockForPending
     vec
+  }
+
+  def sparseVector(len: Int, elements: Int, rng: Random = Random): org.apache.spark.ml.linalg.SparseVector = {
+    assert(elements < len)
+    val data = (1 to elements).map(_ => rng.nextInt(len)).sortBy(identity).distinct.map(it => (it, rng.nextDouble()))
+    Vectors.sparse(len, data).toSparse
   }
 
   implicit object TestJoinSupportConverter extends ((Frame, Int) => (String, Int, Int)) {


### PR DESCRIPTION
The benchmark measures time of transfering ultra wide Spark sparse
vectors to H2O Frame representation.

Results for 3k x 50k (rows x cols), sparse vector, 0.2 sparsity (20% of
non-zeros), single Spark partition transfered to a single H2O chunk:

```
Mean           Stdev        Min           Max            Unit
39452.800781 ± 1380.934204 (37205.000000, 40707.000000) (msec)
```

Results for 10 x 11 matrics, sparse vector with a single non-zero
element (matrix has a single zero column):

```
Mean        Stdev     Min        Max         Unit
64.500000 ± 8.669871 (56.000000, 80.000000)  (msec)
```