### PR TITLE
[SW-559] Test for missing 0-len chunks

### DIFF
--- a/core/src/test/scala/org/apache/spark/h2o/converters/RDDToDataFrameViaH2OFrameTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/RDDToDataFrameViaH2OFrameTest.scala
@@ -21,7 +21,8 @@ import org.apache.spark.SparkContext
 import org.apache.spark.h2o.IntHolder
 import org.apache.spark.h2o.utils.SharedH2OTestContext
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
-import water.fvec.H2OFrame
+import water.{Key, MRTask}
+import water.fvec.{Chunk, H2OFrame, NewChunk, Vec}
 
 /**
   * Test conversion from RDD to DataFrame via H2OFrame
@@ -41,5 +42,30 @@ class RDDToDataFrameViaH2OFrameTest extends FunSuite with SharedH2OTestContext w
 
     assert (rdd.count == h2oFrame.numRows())
     assert (rdd.count == dataFrame.count)
+  }
+
+  // @formatter:off
+  test("SW-559: Convert RDD to H2OFrame with 0-length chunks") {
+    // Generate RDD which contains empty partitions
+    val rdd = sc.parallelize(1 to 10, 10).map(i => IntHolder(Some(i))).filter(x => x.result.get < 5)
+    assert(rdd.partitions.length == 10, "Number of partitions after filtering should be 10")
+
+    // The frame contains number of chunks == number of RDD partitions, but some of
+    val hf: H2OFrame = hc.asH2OFrame(rdd)
+    val espcBeforeMr = hf.anyVec().espc()
+    // Now touch the frame with MRTask which produces a new vector,
+    // which is closed by AppendableVec.close() call (see Frame#closeFrame() method)
+    val zeroHf = new ZeroMR().doAll(Array(Vec.T_NUM), hf).outputFrame(Array("X"), null)
+    val espcAfterMr = zeroHf.anyVec().espc()
+    // The ESPC of frame vectors before and after invocation of MRTask should match
+    assert(espcBeforeMr === espcAfterMr, "The ESPC of frame vectors before and after invocation of MRTask should match")
+  }
+
+  class ZeroMR extends MRTask[ZeroMR] {
+    override def map(c: Chunk, nc: NewChunk): Unit = {
+      for (i <- 0 until c.len()) {
+        nc.addNum(0.0)
+      }
+    }
   }
 }


### PR DESCRIPTION
Note: this will fail till the patched H2O version is used (see https://github.com/h2oai/h2o-3/pull/1661)