### PR TITLE
[SW-562] Disable web on external H2O nodes in external cluster mode

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
@@ -51,6 +51,7 @@ trait SharedBackendConf {
   def h2oNodeLogDir  = sparkConf.getOption(PROP_NODE_LOG_DIR._1)
   def uiUpdateInterval = sparkConf.getInt(PROP_UI_UPDATE_INTERVAL._1, PROP_UI_UPDATE_INTERVAL._2)
   def cloudTimeout = sparkConf.getInt(PROP_CLOUD_TIMEOUT._1, PROP_CLOUD_TIMEOUT._2)
+  def h2oNodeWebEnabled = sparkConf.getBoolean(PROP_NODE_ENABLE_WEB._1, PROP_NODE_ENABLE_WEB._2)
 
 
   /** H2O Client parameters */
@@ -123,6 +124,10 @@ trait SharedBackendConf {
   def setH2ONodeLogDir(dir: String) = set(PROP_NODE_LOG_DIR._1, dir)
   def setUiUpdateInterval(interval: Int) = set(PROP_UI_UPDATE_INTERVAL._1, interval.toString)
   def setCloudTimeout(timeout: Int) = set(PROP_CLOUD_TIMEOUT._1, timeout.toString)
+
+  def setH2ONodeWebEnabled() = set(PROP_NODE_ENABLE_WEB._1, true)
+  def setH2ONodeWebDisabled() = set(PROP_NODE_ENABLE_WEB._1, false)
+
 
 
   /** H2O Client parameters */
@@ -212,6 +217,9 @@ object SharedBackendConf {
 
   /** Configuration property - timeout for cloud up. */
   val PROP_CLOUD_TIMEOUT = ("spark.ext.h2o.cloud.timeout", 60 * 1000)
+
+  /** Enable or disable web on h2o worker nodes. It is disabled by default for security reasons. */
+  val PROP_NODE_ENABLE_WEB = ("spark.ext.h2o.node.enable.web", false)
 
   /** Path to flow dir. */
   val PROP_FLOW_DIR = ("spark.ext.h2o.client.flow.dir", None)

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -66,6 +66,7 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
       "-mapperXmx", conf.mapperXmx,
       "-output", conf.HDFSOutputDir.get,
       "-J", "-log_level", "-J", conf.h2oNodeLogLevel,
+      "-J", "-disable_web",
       "-timeout", conf.clusterStartTimeout.toString,
       "-disown",
       "-J", "-watchdog_stop_without_client",

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -73,8 +73,8 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
       "-J", "-watchdog_client_retry_timeout", "-J", conf.clientCheckRetryTimeout.toString
     )
 
-    if(!hc.getConf.h2oNodeWebEnabled){
-      cmdToLaunch ++ Seq[String]("-J", "-disable_web")
+    if (!hc.getConf.h2oNodeWebEnabled) {
+      cmdToLaunch = cmdToLaunch ++ Seq[String]("-J", "-disable_web")
     }
 
     // start external H2O cluster and log the output

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -66,13 +66,16 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
       "-mapperXmx", conf.mapperXmx,
       "-output", conf.HDFSOutputDir.get,
       "-J", "-log_level", "-J", conf.h2oNodeLogLevel,
-      "-J", "-disable_web",
       "-timeout", conf.clusterStartTimeout.toString,
       "-disown",
       "-J", "-watchdog_stop_without_client",
       "-J", "-watchdog_client_connect_timeout", "-J", conf.clientConnectionTimeout.toString,
       "-J", "-watchdog_client_retry_timeout", "-J", conf.clientCheckRetryTimeout.toString
     )
+
+    if(!hc.getConf.h2oNodeWebEnabled){
+      cmdToLaunch ++ Seq[String]("-J", "-disable_web")
+    }
 
     // start external H2O cluster and log the output
     logInfo("Command used to start H2O on yarn: " + cmdToLaunch.mkString(" "))

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -92,7 +92,7 @@ class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend
 
     var h2oNodeArgs = InternalBackendUtils.getH2ONodeArgs(hc.getConf)
     // Disable web on h2o nodes in non-local mode
-    if (!hc.sparkContext.isLocal) {
+    if (!hc.sparkContext.isLocal &&  !hc.getConf.h2oNodeWebEnabled) {
       h2oNodeArgs = h2oNodeArgs ++ Array("-disable_web")
     } else {
       // In local mode we don't start h2o client and use standalone h2o mode right away. We need to set login configuration

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -92,7 +92,7 @@ class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend
 
     var h2oNodeArgs = InternalBackendUtils.getH2ONodeArgs(hc.getConf)
     // Disable web on h2o nodes in non-local mode
-    if (!hc.sparkContext.isLocal &&  !hc.getConf.h2oNodeWebEnabled) {
+    if (!hc.sparkContext.isLocal && !hc.getConf.h2oNodeWebEnabled) {
       h2oNodeArgs = h2oNodeArgs ++ Array("-disable_web")
     } else {
       // In local mode we don't start h2o client and use standalone h2o mode right away. We need to set login configuration

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -92,8 +92,10 @@ class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend
 
     var h2oNodeArgs = InternalBackendUtils.getH2ONodeArgs(hc.getConf)
     // Disable web on h2o nodes in non-local mode
-    if (!hc.sparkContext.isLocal && !hc.getConf.h2oNodeWebEnabled) {
-      h2oNodeArgs = h2oNodeArgs ++ Array("-disable_web")
+    if (!hc.sparkContext.isLocal) {
+      if (!hc.getConf.h2oNodeWebEnabled) {
+        h2oNodeArgs = h2oNodeArgs ++ Array("-disable_web")
+      }
     } else {
       // In local mode we don't start h2o client and use standalone h2o mode right away. We need to set login configuration
       // in this case explicitly

--- a/doc/configuration/configuration_properties.rst
+++ b/doc/configuration/configuration_properties.rst
@@ -86,7 +86,7 @@ Configuration properties independent on selected backend
 | ``spark.ext.h2o.cloud.timeout``                    | ``60*1000``    | Timeout (in msec) for cluster          |
 |                                                    |                | formation.                             |
 +----------------------------------------------------+----------------+----------------------------------------+
-| ``spark.ext.h2o.node.enable.web``                  | ``false``      | Enable or disable web on h2o worker    |
+| ``spark.ext.h2o.node.enable.web``                  | ``false``      | Enable or disable web on H2O worker    |
 |                                                    |                | nodes. It is disabled by default for   |
 |                                                    |                | security reasons.                      |
 +----------------------------------------------------+----------------+----------------------------------------+

--- a/doc/configuration/configuration_properties.rst
+++ b/doc/configuration/configuration_properties.rst
@@ -86,6 +86,10 @@ Configuration properties independent on selected backend
 | ``spark.ext.h2o.cloud.timeout``                    | ``60*1000``    | Timeout (in msec) for cluster          |
 |                                                    |                | formation.                             |
 +----------------------------------------------------+----------------+----------------------------------------+
+| ``spark.ext.h2o.node.enable.web``                  | ``false``      | Enable or disable web on h2o worker    |
+|                                                    |                | nodes. It is disabled by default for   |
+|                                                    |                | security reasons.                      |
++----------------------------------------------------+----------------+----------------------------------------+
 | **H2O client parameters**                          |                |                                        |
 +----------------------------------------------------+----------------+----------------------------------------+
 | ``spark.ext.h2o.client.flow.dir``                  | ``None``       | Directory where flows from H2O Flow    |

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -156,6 +156,14 @@ class H2OConf(object):
         self._jconf.setCloudTimeout(timeout)
         return self
 
+    def set_h2o_node_web_enabled(self):
+        self._jconf.setH2ONodeWebEnabled()
+        return self
+
+    def set_h2o_node_web_disabled(self):
+        self._jconf.setH2ONodeWebDisabled()
+        return self
+
     def set_flow_dir(self, dir):
         self._jconf.setFlowDir(dir)
         return self
@@ -392,6 +400,9 @@ class H2OConf(object):
 
     def cloud_timeout(self):
         return self._jconf.cloudTimeout()
+
+    def h2o_node_web_enabled(self):
+        return self._jconf.h2oNodeWebEnabled()
 
     def flow_dir(self):
         return self._get_option(self._jconf.flowDir())


### PR DESCRIPTION
The web remains opened on the client node, therefore this change should not be breaking change. We expose the ip:port of the client node