### PR TITLE
[SW-569] Fix stopping of application from PySparkling  ( fix & less n…

### DIFF
--- a/py/pysparkling/context.py
+++ b/py/pysparkling/context.py
@@ -136,8 +136,14 @@ class H2OContext(object):
         # In driver mode the application would call exit which is handled by Spark AM as failure
         deploy_mode = spark_session.sparkContext._conf.get("spark.submit.deployMode")
         if deploy_mode != "cluster":
-            atexit.register(lambda: h2o.cluster().shutdown())
+            atexit.register(lambda: h2o_context.__stop())
         return h2o_context
+
+    def __stop(self):
+        try:
+            h2o.cluster().shutdown()
+        except:
+            pass
 
     def stop(self):
         warnings.warn("Stopping H2OContext from PySparkling is not fully supported. Please restart your PySpark session and create a new H2OContext.")

--- a/py/pysparkling/context.py
+++ b/py/pysparkling/context.py
@@ -132,24 +132,15 @@ class H2OContext(object):
         print(h2o_context)
 
         # Stop h2o when running standalone pysparkling scripts, only in client deploy mode
-        #, so the user does not explicitly close h2o.
+        #, so the user does not need explicitly close h2o.
         # In driver mode the application would call exit which is handled by Spark AM as failure
         deploy_mode = spark_session.sparkContext._conf.get("spark.submit.deployMode")
         if deploy_mode != "cluster":
-            atexit.register(lambda: h2o_context.stop_with_jvm())
+            atexit.register(lambda: h2o.cluster().shutdown())
         return h2o_context
 
-
-    def stop_with_jvm(self):
-        Initializer.clean_temp_dir()
-        h2o.cluster().shutdown()
-        self.stop()
-
-
     def stop(self):
-        warnings.warn("Stopping H2OContext. (Restarting H2O is not yet fully supported...) ")
-        Initializer.clean_temp_dir()
-        self._jhc.stop(False)
+        warnings.warn("Stopping H2OContext from PySparkling is not fully supported. Please restart your PySpark session and create a new H2OContext.")
 
     def __del__(self):
         self.stop()

--- a/py/pysparkling/initializer.py
+++ b/py/pysparkling/initializer.py
@@ -73,12 +73,6 @@ class Initializer(object):
 
         return os.path.abspath("{}/sparkling_water/sparkling_water_assembly.jar".format(Initializer.__extracted_jar_dir))
 
-    @staticmethod
-    def clean_temp_dir():
-        ## Clean temporary directory containing extracted Sparkling Water Jar
-        if Initializer.__extracted_jar_dir is not None:
-            import shutil
-            shutil.rmtree(Initializer.__extracted_jar_dir)
 
     @staticmethod
     def __get_sw_jar():


### PR DESCRIPTION
…oise )

The change allowing running multiple pysparkling sessions in parallel is not the only cause of some noise when stopping pysparkling app.

This change is also motivated by another additional point:
 - When ensuring all tests are passing on external backend, I made stopping of backends consistent on both clusters. However this also caused that we can't stop H2OContext on both backends from PySparkling ( we stop java app and then we get a lots of exceptions because of py4j)

So this change just informs the user that H2OContext can't be stoped when called `hc.stop()` and PySpark sessions needs to be restarted. 

When the user calls `exit()` the cluster is shutdown as before using `h2o.cluster.stutdown()` which correctly stops the cluster. This was tested on internal and external cluster. In case of external cluster, it was tested also on yarn and I verified that the exit codes are correct.

From my point and point of the user this is the cleanest solution. We can stop cluster correctly during `exit` and inform the cluster that h2o just can't be restarted when calling `stop`. No other magic. 