### PR TITLE
[SW-574] Process steam handle and use it for connection to external h…

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
@@ -135,6 +135,7 @@ trait SharedBackendConf {
   def setStacktraceCollectorInterval(interval: Int) = set(PROP_NODE_STACK_TRACE_COLLECTOR_INTERVAL._1, interval.toString)
   def setContextPath(contextPath: String) = set(PROP_CONTEXT_PATH._1, contextPath)
 
+
   /** H2O Client parameters */
   def setFlowDir(dir: String) = set(PROP_FLOW_DIR._1, dir)
   def setClientIp(ip: String) = set(PROP_CLIENT_IP._1, ip)
@@ -237,7 +238,7 @@ object SharedBackendConf {
 
   /** Path to flow dir. */
   val PROP_FLOW_DIR = ("spark.ext.h2o.client.flow.dir", None)
-
+  
   /** IP of H2O client node */
   val PROP_CLIENT_IP = ("spark.ext.h2o.client.ip", None)
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
@@ -85,7 +85,7 @@ private[backends] trait SharedBackendUtils extends Logging with Serializable {
     System.getProperty("user.dir") + java.io.File.separator + "h2ologs" + File.separator + appId
   }
 
-  private def addIfNotNull(arg: String, value: String) = if (value != null) Seq(arg, value.toString) else Nil
+  def addIfNotNull(arg: String, value: String) = if (value != null) Seq(arg, value.toString) else Nil
 
 
   /**
@@ -131,6 +131,7 @@ private[backends] trait SharedBackendUtils extends Logging with Serializable {
       ++ addIfNotNull("-port", Some(conf.clientWebPort).filter(_ > 0).map(_.toString).orNull)
       ++ addIfNotNull("-jks", conf.jks.orNull)
       ++ addIfNotNull("-jks_pass", conf.jksPass.orNull)
+      ++ addIfNotNull("-context_path", conf.contextPath.orNull)
       ++ conf.clientNetworkMask.map(mask => Seq("-network", mask)).getOrElse(Seq("-ip", conf.clientIp.get))
     ).toArray
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -93,7 +93,7 @@ class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend
     } else {
       // In local mode we don't start h2o client and use standalone h2o mode right away. We need to set login configuration
       // in this case explicitly
-      h2oNodeArgs = h2oNodeArgs ++ getLoginArgs(hc.getConf)
+      h2oNodeArgs = h2oNodeArgs ++ getLoginArgs(hc.getConf) ++ addIfNotNull("-context_path", hc.getConf.contextPath.orNull)
     }
     logDebug(s"Arguments used for launching h2o nodes: ${h2oNodeArgs.mkString(" ")}")
     val executors = InternalBackendUtils.startH2O(hc.sparkContext, spreadRDD, spreadRDDNodes.length, h2oNodeArgs, hc.getConf.nodeNetworkMask)

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -106,7 +106,7 @@ Configuration properties independent of selected backend
 |                                                    |                | -1 means that no stack traces will be  |
 |                                                    |                | taken.                                 |
 +----------------------------------------------------+----------------+----------------------------------------+
-| ``spark.ext.h2o.context.path``                     | ``None``       | H2O Flow context path.                 |
+| ``spark.ext.h2o.context.path``                     | ``None``       | Context path to expose H2O web server. |
 +----------------------------------------------------+----------------+----------------------------------------+
 | **H2O client parameters**                          |                |                                        |
 +----------------------------------------------------+----------------+----------------------------------------+


### PR DESCRIPTION
…2o cluster

This code still needs to be tested in steam environment.
It allows starting external h2o cluster using steam and then creating H2OContext on it using the following API.
```
import h2osteam
from pysparkling import *

# Get steam reference
l = h2osteam.login('https://steam', 'kuba', 'kuba', verify_ssl=False)
# Create cluster and get the handle
external_cluster_handle = l.start_h2o_cluster('cluster_name', 4)
# Create H2O Context
hc = H2OContext.getOrCreate(spark, external_cluster_handle=external_cluster_handle)
```

In the implementation, we need to get IP address and port of one node in the cluster. The handle contains the ip and port of the proxy so I'm not sure if that will do. We need to test it.