### PR TITLE
[SW-600] Proper Sparkling Water Nightly

### DIFF
--- a/jenkins/Jenkinsfile-external
+++ b/jenkins/Jenkinsfile-external
@@ -67,6 +67,9 @@ withCustomCommitStates(scm, 'h2o-ops-personal-auth-token', 'continuous-integrati
             backendMode = "external"
             hdpVersion = "${p.hdpVersion}"
             driverHadoopVersion = "${p.driverHadoopVersion}"
+            buildNightly = "false"
+            uploadNightly = "false"
+
          }
      }
  }

--- a/jenkins/Jenkinsfile-external_nightly
+++ b/jenkins/Jenkinsfile-external_nightly
@@ -25,11 +25,18 @@ node('dX-hadoop') {
         runIntegTests = "true"
         runPySparklingIntegTests = "true"
         sparklingTestEnv = "yarn"
-        buildAgainstH2OBranch = "true"
+        buildAgainstH2OBranch = "false"
         h2oBranch = "master"
         hadoopVersion = "2.6"
         backendMode = "external"
         hdpVersion = "2.2.6.3-1"
         driverHadoopVersion = "hdp2.2"
+        buildNightly = "true"
+        // We have 2 nightly jobs - for external and internal cluster for testing purposes,
+        // however it is sufficient to create nightly just after one of these jobs finish
+        // We therefore don't publish nightly here, but in the internal nightly job.
+        // Note: We can do that as these 2 jobs run at the same time
+        uploadNightly = "false"
+
     }
 }

--- a/jenkins/Jenkinsfile-internal
+++ b/jenkins/Jenkinsfile-internal
@@ -58,6 +58,8 @@ withCustomCommitStates(scm, 'h2o-ops-personal-auth-token', 'continuous-integrati
             h2oBranch = "${p.h2oBranch}"
             hadoopVersion = "2.6"
             backendMode = "internal"
+            buildNightly = "false"
+            uploadNightly = "false"
         }
     }
 }

--- a/jenkins/Jenkinsfile-internal_nightly
+++ b/jenkins/Jenkinsfile-internal_nightly
@@ -25,9 +25,11 @@ node('dX-hadoop') {
         runIntegTests = "true"
         runPySparklingIntegTests = "true"
         sparklingTestEnv = "yarn"
-        buildAgainstH2OBranch = "true"
+        buildAgainstH2OBranch = "false"
         h2oBranch = "master"
         hadoopVersion = "2.6"
         backendMode = "internal"
+        buildNightly = "true"
+        uploadNightly = "true"
     }
 }

--- a/jenkins/sparklingWaterPipeline.groovy
+++ b/jenkins/sparklingWaterPipeline.groovy
@@ -3,6 +3,7 @@
 def call(params, body) {
     def config = [:]
     body.resolveStrategy = Closure.DELEGATE_FIRST
+
     body.delegate = config
     body(params)
 
@@ -35,12 +36,23 @@ def call(params, body) {
                         scriptsTest()(config)
                         integTest()(config)
                         pysparklingIntegTest()(config)
+                        publishNightly()(config)
                     }
                 }
             }
         }
     }
 }
+
+
+def getGradleCommand(config) {
+    if (config.buildAgainstH2OBranch.toBoolean()) {
+        "H2O_HOME=${env.WORKSPACE}/h2o-3 ${env.WORKSPACE}/gradlew --include-build ${env.WORKSPACE}/h2o-3"
+    } else {
+        "${env.WORKSPACE}/gradlew"
+    }
+}
+
 
 def prepareSparkEnvironment() {
     return { config ->
@@ -70,6 +82,22 @@ def prepareSparklingWaterEnvironment() {
     return { config ->
         stage('QA: Prepare Sparkling Water Environment') {
 
+            // In case of nightly build, modify gradle.properties
+            if(config.buildNightly.toBoolean()){
+
+                def h2oNightlyBuildVersion = new URL("http://h2o-release.s3.amazonaws.com/h2o/master/latest").getText().trim()
+
+                def h2oNightlyMajorVersion = new URL("http://h2o-release.s3.amazonaws.com/h2o/master/${h2oNightlyBuildVersion}/project_version").getText().trim()
+                h2oNightlyMajorVersion = h2oNightlyMajorVersion.substring(0, h2oNightlyMajorVersion.lastIndexOf('.'))
+
+                sh  """
+                     sed -i.backup -E "s/h2oMajorName=.*/h2oMajorName=master/" gradle.properties
+                     sed -i.backup -E "s/h2oMajorVersion=.*/h2oMajorVersion=${h2oNightlyMajorVersion}/" gradle.properties
+                     sed -i.backup -E "s/h2oBuild=.*/h2oBuild=${h2oNightlyBuildVersion}/" gradle.properties
+                     sed -i.backup -E "s/\\.[0-9]+-SNAPSHOT/.\${BUILD_NUMBER}_nightly/" gradle.properties
+                    """
+            }
+
             sh  """
                 # Check if we are bulding against specific H2O branch
                 if [ ${config.buildAgainstH2OBranch} = true ]; then
@@ -96,14 +124,6 @@ def prepareSparklingWaterEnvironment() {
     
                 """
         }
-    }
-}
-
-def getGradleCommand(config) {
-    if (config.buildAgainstH2OBranch.toBoolean()) {
-        "H2O_HOME=${env.WORKSPACE}/h2o-3 ${env.WORKSPACE}/gradlew --include-build ${env.WORKSPACE}/h2o-3"
-    } else {
-        "${env.WORKSPACE}/gradlew"
     }
 }
 
@@ -220,4 +240,51 @@ def pysparklingIntegTest() {
     }
 }
 
+def publishNightly(){
+    return { config ->
+        stage ('Nightly: Publishing Artifacts to S3'){
+            if (config.buildNightly.toBoolean() && config.uploadNightly.toBoolean()) {
+
+                sh """
+                    # echo 'Making distribution'
+                    ${getGradleCommand(config)} buildSparklingWaterDist
+
+                    # Upload to S3
+                    """
+
+                sh """
+                    # Publish the output to S3.
+                    echo
+                    echo PUBLISH
+                    echo
+                    s3cmd --rexclude='target/classes/*' --acl-public sync ${env.WORKSPACE}/dist/build/ s3://h2o-release/sparkling-water/${BRANCH_NAME}/${BUILD_NUMBER}/
+                    
+                    echo EXPLICITLY SET MIME TYPES AS NEEDED
+                    list_of_html_files=`find dist/build -name '*.html' | sed 's/dist\\/build\\///g'`
+                    echo \${list_of_html_files}
+                    for f in \${list_of_html_files}
+                    do
+                        s3cmd --acl-public --mime-type text/html put dist/build/\${f} s3://h2o-release/sparkling-water/${BRANCH_NAME}/${BUILD_NUMBER}/\${f}
+                    done
+                    
+                    list_of_js_files=`find dist/build -name '*.js' | sed 's/dist\\/build\\///g'`
+                    echo \${list_of_js_files}
+                    for f in \${list_of_js_files}
+                    do
+                        s3cmd --acl-public --mime-type text/javascript put dist/build/\${f} s3://h2o-release/sparkling-water/\${BRANCH_NAME}/\${BUILD_NUMBER}/\${f}
+                    done
+                    
+                    list_of_css_files=`find dist/build -name '*.css' | sed 's/dist\\/build\\///g'`
+                    echo \${list_of_css_files}
+                    for f in \${list_of_css_files}
+                    do
+                        s3cmd --acl-public --mime-type text/css put dist/build/\${f} s3://h2o-release/sparkling-water/${BRANCH_NAME}/${BUILD_NUMBER}/\${f}
+                    done
+                    
+                    echo Release available at: https://s3.amazonaws.com/h2o-release/sparkling-water/${BRANCH_NAME}/${BUILD_NUMBER}/index.html
+                    """
+            }
+        }
+    }
+}
 return this


### PR DESCRIPTION
Testing against h2o nightly.

We build and test sw against latest H2O nightly and upload the results into S3.

I think that we don't have to generate also all extended jars for external cluster as if we need to get them, we can just download the distribution and call script `./get-extended-h2o`. What do you think @mmalohlava ?