### PR TITLE
[SW-610] Change of default client log level to INFO

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
@@ -231,7 +231,7 @@ object SharedBackendConf {
   val PROP_CLIENT_ICED_DIR = ("spark.ext.h2o.client.iced.dir", None)
 
   /** H2O log level for client running in Spark driver */
-  val PROP_CLIENT_LOG_LEVEL = ("spark.ext.h2o.client.log.level", "WARN")
+  val PROP_CLIENT_LOG_LEVEL = ("spark.ext.h2o.client.log.level", "INFO")
 
   /** Location of log directory for the driver instance. */
   val PROP_CLIENT_LOG_DIR = ("spark.ext.h2o.client.log.dir", None)


### PR DESCRIPTION
We would like to have INFO logs for H2O client instead of default WARN.