### PR TITLE
[SW-620] Fix obtaining version from bundled h2o inside pysparkling

### DIFF
--- a/py/MANIFEST.in
+++ b/py/MANIFEST.in
@@ -1,2 +1,5 @@
 # include additional files which are not fetched by default by setuptools
 include version.txt
+# We need to manually specify version files for h2o to make sdist happy
+include h2o/version.txt
+include h2o/buildinfo.txt

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -157,6 +157,37 @@ task distPython(type: Zip, dependsOn: [checkPythonEnv, configurations.compile] )
         }
         // Copy basic python setup
         copyPySetup()
+
+        def replaceStr =
+                """
+import zipfile
+from os import path
+
+__version__ = "0.0.local"
+if '.zip' in here:
+    with zipfile.ZipFile(path.dirname(here), 'r') as archive:
+        __version__ = archive.read('h2o/version.txt')
+else:
+    with open(path.join(here, 'version.txt'), encoding='utf-8') as f:
+        __version__ = f.read()
+
+if '.zip' in here:
+    with zipfile.ZipFile(path.dirname(here), 'r') as archive:
+        __buildinfo__ = archive.read('h2o/buildinfo.txt')
+else:
+    with open(path.join(here, 'buildinfo.txt'), encoding='utf-8') as f:
+        __buildinfo__ = f.read()
+                """
+
+        // Change __init__.py in H2O to be aware of being zipped
+        def initFile = file("${project.pkgDir}/h2o/__init__.py")
+        def initContent = initFile.readLines()
+        def lineStart = initContent.findIndexOf {it == "with open(os.path.join(here, 'buildinfo.txt'), encoding='utf-8') as f:"}
+        def lineEnd = initContent.findIndexOf {it == "    __version__ = f.read()"}
+        def before = initContent.subList(0, lineStart).join("\n")
+        def full = before + replaceStr + initContent.subList(lineEnd + 1, initContent.size()).join("\n")
+        initFile.write(full)
+
         // Copy sparkling water fatjar
         def fatJarName = "sparkling-water-assembly_${scalaBaseVersion}-${version}-all.jar"
         def fatJar = configurations.compile.filter{


### PR DESCRIPTION
Ugly, but we need to handle the case when we access the h2o version files from zip.

this is not h2o business as it's not deployed in zip files and therefore we need to handle that on sparkling water side