### PR TITLE
[SW-683] Fix starting H2OContext on Databricks

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -127,8 +127,8 @@ class H2OContext private(val sparkSession: SparkSession, conf: H2OConf) extends 
     h2oNodes.append(nodes: _*)
     localClientIp = sys.env.getOrElse("SPARK_PUBLIC_DNS", sparkContext.env.rpcEnv.address.host)
     localClientPort = H2O.API_PORT
-    // Register UI
-    if (conf.getBoolean("spark.ui.enabled", true)) {
+    // Register UI, but not in Databricks as Databricks is not using standard Spark UI API
+    if (conf.getBoolean("spark.ui.enabled", true) && !isRunningOnDatabricks()) {
       new SparklingWaterUITab(sparklingWaterListener, sparkContext.ui.get)
     }
 

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextUtils.scala
@@ -77,4 +77,13 @@ private[spark] trait H2OContextUtils extends Logging {
     }
   }
 
+  def isRunningOnDatabricks(): Boolean = {
+    try {
+      Class.forName("com.databricks.backend.daemon.driver.DriverLocal")
+      true
+    } catch {
+      case _: ClassNotFoundException => false
+    }
+  }
+
 }

--- a/doc/tutorials/pysparkling_azure_dbc.rst
+++ b/doc/tutorials/pysparkling_azure_dbc.rst
@@ -29,7 +29,6 @@ To start Sparkling Water ``H2OContext`` on Databricks Azure, the steps are:
 4.  Create the cluster
 
     - Make sure the library is attached to the cluster
-    - Put ``spark.ui.enabled false`` line in the spark configuration field. This is currently required due to limitation in our code and will be fixed as soon as possible.
 
     - Select Spark version according to you Sparkling Water version:
         - for the latest PySparkling 2.2, select Spark 2.2.1.

--- a/doc/tutorials/rsparkling_azure_dbc.rst
+++ b/doc/tutorials/rsparkling_azure_dbc.rst
@@ -26,7 +26,6 @@ To start Sparkling Water ``H2OContext`` on Databricks Azure, the steps are:
 4.  Create the cluster
 
     - Make sure the assembly JAR is attached to the cluster
-    - Put ``spark.ui.enabled false`` line in the spark configuration field. This is currently required due to limitation in our code and will be fixed as soon as possible.
 
     - Select Spark version according to your Sparkling Water version:
         - for the latest Sparkling Water 2.2.7, select Spark 2.2.0. Spark 2.2.1 is not yet supported due to missing SparklyR support.

--- a/doc/tutorials/sw_azure_dbc.rst
+++ b/doc/tutorials/sw_azure_dbc.rst
@@ -27,7 +27,6 @@ To start Sparkling Water ``H2OContext`` on Databricks Azure, the steps are:
 4.  Create the cluster
 
     - Make sure the assembly JAR is attached to the cluster
-    - Put ``spark.ui.enabled false`` line in the spark configuration field. This is currently required due to limitation in our code and will be fixed as soon as possible.
 
     - Select Spark version according to your Sparkling Water version:
         - for the latest Sparkling Water 2.2.7, select Spark 2.2.1.


### PR DESCRIPTION
We are using internal Spark API available inside package `org.spark_project.jetty` to register new tabs, however this API(class) is not available on Databricks - they are using regular jetty for this in `org.eclipse.jetty` (this is even more complicated by the fact that we are shadowing the jetty)

We have several options here:

1) Add also `org.spark_project.jetty` to assembly jar and Sparkling Water core dependencies so it's available on the Databricks and in https://github.com/h2oai/sparkling-water/blob/0c19d249345dd1a01c89e25d71ba2a17fecdb148/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterInfoPage.scala#L171 create actually 2 variants of methods attachHandler where one would use the method from regular jetty and one from spark jetty and they would be invoked based on the current environment ( Databricks or not)

Also, we couldn't use features for downloading full and partial logs in case of Databricks since it's again using different paths and API for these handlers. So we can again disable obtaining logs on Databricks.

I have this PR prepared and tested, we can go with this variant, however,  I prefer the version implemented in this PR which is 2)

2) The second option is to simply not add Sparkling Water UI tab in case of Databricks.


The second option is definitely cleaner regarding the code and dependencies in spark assembly ( since we need to provide `org.apache.spark-core` to make those `org.spark_project` classes available and these classes might collide with the same classes in some environment`

The first option is more ugly, however, gives at least basic Sparkling Water UI to DBC users.

I still prefer the simple variant implemented in this PR. We can always implement the first when there is demand for it until then, keep the code cleaner.

What do you think @mmalohlava, please?