### PR TITLE
[SW-697] Additional updates to Sparkling Water help system

### DIFF
--- a/doc/src/site/sphinx/about.rst
+++ b/doc/src/site/sphinx/about.rst
@@ -1,0 +1,9 @@
+About Sparkling Water
+=====================
+
+Sparkling Water allows users to combine the fast, scalable machine learning algorithms of H2O with the capabilities of Spark. With Sparkling Water, users can drive computation from Scala/R/Python and utilize the H2O Flow UI, providing an ideal machine learning platform for application developers.
+
+Spark is an elegant and powerful general-purpose, open-source, in-memory platform with tremendous momentum. H2O is an in-memory application for machine learning that is reshaping how people apply math and predictive analytics to their business problems.
+
+Integrating these two open-source environments provides a seamless experience for users who want to make a query  using Spark SQL, feed the results into H2O to build a model and make predictions, and then use the results again in
+Spark. For any given problem, better interoperability between tools provides a better experience.

--- a/doc/src/site/sphinx/deployment/backends.rst
+++ b/doc/src/site/sphinx/deployment/backends.rst
@@ -156,7 +156,7 @@ There is also a less strict configuration ``setClientNetworkMask`` in Scala and 
 
 The same configuration can be applied when the H2O cluster has been started via multicast discovery.
 
-Automatic Mode of External backend
+Automatic Mode of External Backend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In automatic mode, the H2O cluster is started automatically. The cluster can be started automatically only in a YARN environment at the moment. We recommend this approach, as it is easier to deploy external clusters in this mode and it is also more suitable for production environments. When the H2O cluster is started on YARN, it is started as a map reduce job, and it always uses the flatfile approach for nodes to cloud up.

--- a/doc/src/site/sphinx/index.rst
+++ b/doc/src/site/sphinx/index.rst
@@ -7,9 +7,9 @@
 Overview
 ========
 
-Welcome to the H2O Sparkling Water documentation site! Sparkling Water allows users to combine the fast, scalable machine learning algorithms of H2O with the capabilities of Spark. With Sparkling Water, users can drive computation from Scala/R/Python and utilize the H2O Flow UI, providing an ideal machine learning platform for application developers.
+Welcome to the H2O Sparkling Water documentation site! This document describes how to install and run Sparkling Water.
 
-Depending on your area of interest, select a learning path from the sidebar, or look at the full content outline below.
+Depending on your area of interest, select a learning path from the sidebar, or look at the full content outline below. To view Sparkling Water examples, please visit the Sparkling Water GitHub repository at https://github.com/h2oai/sparkling-water/tree/master/examples.
 
 Have questions about Sparkling Water? Post them on Stack Overflow using the `sparkling-water tag <http://stackoverflow.com/questions/tagged/sparkling-water>`__, or join the chat on `Gitter <https://gitter.im/h2oai/sparkling-water>`__.
 
@@ -18,6 +18,7 @@ Have questions about Sparkling Water? Post them on Stack Overflow using the `spa
 .. toctree::
    :maxdepth: 2
    
+   about
    typical_use_case
    requirements
    design/design
@@ -26,6 +27,7 @@ Have questions about Sparkling Water? Post them on Stack Overflow using the `spa
    tutorials/tutorials
    devel/devel
    pysparkling
+   rsparkling
    FAQ
    CHANGELOG
 

--- a/doc/src/site/sphinx/rsparkling.rst
+++ b/doc/src/site/sphinx/rsparkling.rst
@@ -1,0 +1,7 @@
+RSparkling
+----------
+
+The **rsparkling** R package is an extension package for `sparklyr <http://spark.rstudio.com/>`__ that creates an R front-end for the `Sparkling Water package <https://mvnrepository.com/search?q=h2o+sparkling+water>`__ from H2O. This provides an interface to H2O's high performance, distributed machine learning algorithms on Spark, using R.
+
+More information about RSparkling is available in the `rsparkling GitHub repository <https://github.com/h2oai/rsparkling>`__.
+

--- a/doc/src/site/sphinx/tutorials/tutorials.rst
+++ b/doc/src/site/sphinx/tutorials/tutorials.rst
@@ -1,5 +1,5 @@
-How to
-======
+How to...
+=========
 
 
 **General**

--- a/py/README.rst
+++ b/py/README.rst
@@ -1,5 +1,7 @@
-An Introduction to PySparkling
-==============================
+PySparkling
+===========
+
+This section provides an introduction to PySparkling. To understand more about PySparkling, it's best to first understand H2O, Spark, and Sparkling Water. 
 
 What is H2O?
 ------------


### PR DESCRIPTION
- Added an “About Sparkling Water” section (and updated the index’s “Overview” in the process)
- Added a small overview section about Sparkling and a link to the RSparkling repo
- Changed “An Introduction to PySparkling” to just “PySparkling.” Added small introductory text with this update.
- Added ellipsis to the “How to” section.