### PR TITLE
[SW-701] Kill client when the external H2O cluster disappears. Normally

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -95,7 +95,6 @@ class H2OContext private(val sparkSession: SparkSession, conf: H2OConf) extends 
     * otherwise it creates new H2O cluster living in Spark
     */
   def init(): H2OContext = {
-
     // Use H2O's logging as H2O info log level is default
     Log.info("Sparkling Water version: " + BuildInfo.SWVersion)
     Log.info("Spark version: " + sparkContext.version)

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -19,6 +19,7 @@ package org.apache.spark.h2o.backends.external
 
 import org.apache.spark.h2o.H2OConf
 import org.apache.spark.h2o.backends.SharedBackendConf
+import water.HeartBeatThread
 
 /**
   * External backend configuration
@@ -51,6 +52,8 @@ trait ExternalBackendConf extends SharedBackendConf {
   def h2oDriverPath = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_DRIVER_PATH._1)
   def YARNQueue = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_YARN_QUEUE._1)
   def h2oDriverIf = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_DRIVER_IF._1)
+  def healthCheckInterval = sparkConf.getInt(PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._1, PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._2)
+  def isKillOnUnhealthyClusterEnabled = sparkConf.getBoolean(PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._1, PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._2)
 
   /** Setters */
 
@@ -101,6 +104,10 @@ trait ExternalBackendConf extends SharedBackendConf {
 
   def setH2ODriverIf(ip: String) = set(PROP_EXTERNAL_CLUSTER_DRIVER_IF._1, ip)
 
+  def setHealthCheckInterval(interval: Int) = set(PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._1, interval.toString)
+
+  def setKillOnUnhealthyClusterEnabled = set(PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._1, true)
+  def setKillOnUnhealthyClusterDisabled = set(PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._1, false)
 
   def externalConfString: String =
     s"""Sparkling Water configuration:
@@ -162,4 +169,12 @@ object ExternalBackendConf {
   /** Driver IP address in case of auto mode in external cluster backend */
   val PROP_EXTERNAL_CLUSTER_DRIVER_IF = ("spark.ext.h2o.external.driver.if", None)
 
+  /** Health check interval. Needs to be higher than HeartBeatThread.TIMEOUT
+    */
+  val PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL = ("spark.ext.h2o.external.health.check.interval", HeartBeatThread.TIMEOUT * 3)
+
+  /**
+    * If true, the client will try to kill the cluster and then itself in case some nodes in the cluster report unhealthy status
+    */
+  val PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY = ("spark.ext.h2o.external.kill.on.unhealthy", true)
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -54,6 +54,7 @@ trait ExternalBackendConf extends SharedBackendConf {
   def h2oDriverIf = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_DRIVER_IF._1)
   def healthCheckInterval = sparkConf.getInt(PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._1, PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._2)
   def isKillOnUnhealthyClusterEnabled = sparkConf.getBoolean(PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._1, PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._2)
+  def killOnUnhealthyClusterInterval = sparkConf.getInt(PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._1, PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._2)
 
   /** Setters */
 
@@ -106,8 +107,10 @@ trait ExternalBackendConf extends SharedBackendConf {
 
   def setHealthCheckInterval(interval: Int) = set(PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._1, interval.toString)
 
-  def setKillOnUnhealthyClusterEnabled = set(PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._1, true)
-  def setKillOnUnhealthyClusterDisabled = set(PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._1, false)
+  def setKillOnUnhealthyClusterEnabled() = set(PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._1, true)
+  def setKillOnUnhealthyClusterDisabled() = set(PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY._1, false)
+
+  def setKillOnUnhealthyClusterInterval(interval: Int) = set(PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL._1, interval.toString)
 
   def externalConfString: String =
     s"""Sparkling Water configuration:
@@ -169,12 +172,17 @@ object ExternalBackendConf {
   /** Driver IP address in case of auto mode in external cluster backend */
   val PROP_EXTERNAL_CLUSTER_DRIVER_IF = ("spark.ext.h2o.external.driver.if", None)
 
-  /** Health check interval. Needs to be higher than HeartBeatThread.TIMEOUT
+  /** Health check interval for external H2O nodes
     */
-  val PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL = ("spark.ext.h2o.external.health.check.interval", HeartBeatThread.TIMEOUT * 3)
+  val PROP_EXTERNAL_CLUSTER_HEALTH_CHECK_INTERVAL = ("spark.ext.h2o.external.health.check.interval", HeartBeatThread.TIMEOUT)
 
   /**
     * If true, the client will try to kill the cluster and then itself in case some nodes in the cluster report unhealthy status
     */
   val PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY = ("spark.ext.h2o.external.kill.on.unhealthy", true)
+
+  /**
+    * How often check the healthy status for the decision whether to kill the cloud or not.
+    */
+  val PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY_INTERVAL = ("spark.ext.h2o.external.kill.on.unhealthy.interval", HeartBeatThread.TIMEOUT * 3)
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -180,11 +180,11 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
       cloudHealthCheckThread = Some(new Thread {
         override def run(): Unit = {
           while (true) {
+            Thread.sleep(HeartBeatThread.TIMEOUT * 3)
             if (!H2O.CLOUD.healthy()) {
               Log.info("Exiting! External H2O cloud not healthy!!")
               H2O.exit(-1)
             }
-            Thread.sleep(HeartBeatThread.TIMEOUT + HeartBeatThread.TIMEOUT/2)
           }
         }
       })

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -180,10 +180,10 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
       cloudHealthCheckThread = Some(new Thread {
         override def run(): Unit = {
           while (true) {
-            Thread.sleep(HeartBeatThread.TIMEOUT * 3)
-            if (!H2O.CLOUD.healthy()) {
-              Log.info("Exiting! External H2O cloud not healthy!!")
-              H2O.exit(-1)
+            Thread.sleep(hc.getConf.healthCheckInterval)
+            if (!H2O.CLOUD.healthy() && hc.getConf.isKillOnUnhealthyClusterEnabled) {
+              Log.err("Exiting! External H2O cloud not healthy!!")
+              H2O.shutdown(-1)
             }
           }
         }

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -259,7 +259,20 @@ External backend configuration properties
 | ``spark.ext.h2o.external.driver.if``                  | ``None``       | IP address of H2O driver in case of |
 |                                                       |                | external cluster in automatic mode. |
 +-------------------------------------------------------+----------------+-------------------------------------+
+| ``spark.ext.h2o.external.health.check.interval``      | ``HeartBeatThr | Health check interval. Needs to be  |
+|                                                       | ead.TIMEOUT *  | higher than                         |
+|                                                       | 3``            | ``HeartBeatThread.TIMEOUT``         |
++-------------------------------------------------------+----------------+-------------------------------------+
+| ``spark.ext.h2o.external.kill.on.unhealthy``          | ``true``       | If true, the client will try to     |
+|                                                       |                | kill the cluster and then itself in |
+|                                                       |                | case some nodes in the cluster      |
+|                                                       |                | report unhealthy status.            |
++-------------------------------------------------------+----------------+-------------------------------------+
 
+  /**
+    * If true, the client will try to kill the cluster and then itself in case some nodes in the cluster report unhealthy status
+    */
+  val PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY = ("", true)
 --------------
 
 .. |H2ONThreadsDefault| replace:: ``Runtime.getRuntime().availableProcessors()``

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -272,10 +272,6 @@ External backend configuration properties
 |                                                       | * 3``          | the cloud or not.                   |
 +-------------------------------------------------------+----------------+-------------------------------------+
 
-  /**
-    * If true, the client will try to kill the cluster and then itself in case some nodes in the cluster report unhealthy status
-    */
-  val PROP_EXTERNAL_CLUSTER_KILL_ON_UNHEALTHY = ("", true)
 --------------
 
 .. |H2ONThreadsDefault| replace:: ``Runtime.getRuntime().availableProcessors()``

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -259,14 +259,17 @@ External backend configuration properties
 | ``spark.ext.h2o.external.driver.if``                  | ``None``       | IP address of H2O driver in case of |
 |                                                       |                | external cluster in automatic mode. |
 +-------------------------------------------------------+----------------+-------------------------------------+
-| ``spark.ext.h2o.external.health.check.interval``      | ``HeartBeatThr | Health check interval. Needs to be  |
-|                                                       | ead.TIMEOUT *  | higher than                         |
-|                                                       | 3``            | ``HeartBeatThread.TIMEOUT``         |
+| ``spark.ext.h2o.external.health.check.interval``      | ``HeartBeatThr | Health check interval for external  |
+|                                                       | ead.TIMEOUT``  | H2O nodes.                          |
 +-------------------------------------------------------+----------------+-------------------------------------+
 | ``spark.ext.h2o.external.kill.on.unhealthy``          | ``true``       | If true, the client will try to     |
 |                                                       |                | kill the cluster and then itself in |
 |                                                       |                | case some nodes in the cluster      |
 |                                                       |                | report unhealthy status.            |
++-------------------------------------------------------+----------------+-------------------------------------+
+| ``spark.ext.h2o.external.kill.on.unhealthy.interval`` | ``HeartBeatThr | How often check the healthy status  |
+|                                                       | ead.TIMEOUT    | for the decision whether to kill    |
+|                                                       | * 3``          | the cloud or not.                   |
 +-------------------------------------------------------+----------------+-------------------------------------+
 
   /**

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -334,6 +334,18 @@ class H2OConf(object):
         self._jconf.setH2ODriverIf(ip)
         return self
 
+    def set_health_check_interval(self, interval):
+        self._jconf.setHealthCheckInterval(interval)
+        return self
+
+    def set_kill_on_unhealthy_cluster_enabled(self):
+        self._jconf.setKillOnUnhealthyClusterEnabled()
+        return self
+
+    def set_kill_on_unhealthy_cluster_disabled(self):
+        self._jconf.setKillOnUnhealthyClusterDisabled()
+        return self
+
     # getters independent on backend
 
     def backend_cluster_mode(self):
@@ -523,6 +535,11 @@ class H2OConf(object):
     def h2o_driver_if(self):
         return self._get_option(self._jconf.h2oDriverIf())
 
+    def get_health_check_interval(self):
+        return self._jconf.healthCheckInterval()
+
+    def is_kill_on_unhealthy_cluster_enabled(self):
+        return self._jconf.isKillOnUnhealthyClusterEnabled()
 
     def set(self, key, value):
         self._jconf.set(key, value)

--- a/py/pysparkling/conf.py
+++ b/py/pysparkling/conf.py
@@ -346,7 +346,11 @@ class H2OConf(object):
         self._jconf.setKillOnUnhealthyClusterDisabled()
         return self
 
-    # getters independent on backend
+    def set_kill_on_unhealthy_cluster_interval(self, interval):
+        self._jconf.setKillOnUnhealthyClusterInterval(interval)
+        return self
+
+# getters independent on backend
 
     def backend_cluster_mode(self):
         return self._jconf.backendClusterMode()
@@ -540,6 +544,9 @@ class H2OConf(object):
 
     def is_kill_on_unhealthy_cluster_enabled(self):
         return self._jconf.isKillOnUnhealthyClusterEnabled()
+
+    def kill_on_unhealthy_cluster_interval(self):
+        return self._jconf.killOnUnhealthyClusterInterval()
 
     def set(self, key, value):
         self._jconf.set(key, value)


### PR DESCRIPTION
the client is informed about the cluster being killed, but for example,
if the cloud is killed for memory reasons by YARN, we don't get such
    messages and the client hangs forever