### PR TITLE
[SW-706] Fix pysparkling.ml import for non-interactive sessions

### DIFF
--- a/examples/scripts/tests/pysparkling_ml_import_overrides_spark_test.py
+++ b/examples/scripts/tests/pysparkling_ml_import_overrides_spark_test.py
@@ -1,0 +1,14 @@
+from pyspark.sql import SparkSession
+from pysparkling.ml import *
+spark = (SparkSession.builder
+         .appName("test")
+         .enableHiveSupport()
+         .getOrCreate()
+         )
+
+sc = spark.sparkContext
+
+spark.sql("create table if not exists test_table (id INT)")
+
+# Check that the table was correctly created
+assert len(spark.sql("show tables").filter("tableName == 'test_table'").collect()) == 1

--- a/py/pysparkling/ml/algo.py
+++ b/py/pysparkling/ml/algo.py
@@ -6,15 +6,17 @@ from pyspark.sql import SparkSession
 from pysparkling import *
 from .params import H2OGBMParams, H2ODeepLearningParams
 
+java_max_double_value = (2-2**(-52))*(2**1023)
+
 class H2OGBM(JavaEstimator, H2OGBMParams, JavaMLReadable, JavaMLWritable):
     @keyword_only
     def __init__(self, ratio=1.0, predictionCol=None, featuresCols=[], allStringColumnsToCategorical=True, nfolds=0,
                  keepCrossValidationPredictions=False, keepCrossValidationFoldAssignment=False, parallelizeCrossValidation=True,
                  seed=-1, distribution="AUTO", ntrees=50, maxDepth=5, minRows=10.0, nbins=20, nbinsCats=1024, minSplitImprovement=1e-5,
-                 histogramType="AUTO", r2Stopping=SparkSession.builder.getOrCreate()._jvm.Double.MAX_VALUE,
+                 histogramType="AUTO", r2Stopping=java_max_double_value,
                  nbinsTopLevel=1<<10, buildTreeOneNode=False, scoreTreeInterval=0,
                  sampleRate=1.0, sampleRatePerClass=None, colSampleRateChangePerLevel=1.0, colSampleRatePerTree=1.0,
-                 learnRate=0.1, learnRateAnnealing=1.0, colSampleRate=1.0, maxAbsLeafnodePred=SparkSession.builder.getOrCreate()._jvm.Double.MAX_VALUE,
+                 learnRate=0.1, learnRateAnnealing=1.0, colSampleRate=1.0, maxAbsLeafnodePred=java_max_double_value,
                  predNoiseBandwidth=0.0):
         super(H2OGBM, self).__init__()
         self._hc = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)
@@ -38,10 +40,10 @@ class H2OGBM(JavaEstimator, H2OGBMParams, JavaMLReadable, JavaMLWritable):
     def setParams(self, ratio=1.0, predictionCol=None, featuresCols=[], allStringColumnsToCategorical=True,
                   nfolds=0, keepCrossValidationPredictions=False, keepCrossValidationFoldAssignment=False,parallelizeCrossValidation=True,
                   seed=-1, distribution="AUTO", ntrees=50, maxDepth=5, minRows=10.0, nbins=20, nbinsCats=1024, minSplitImprovement=1e-5,
-                  histogramType="AUTO", r2Stopping=SparkSession.builder.getOrCreate()._jvm.Double.MAX_VALUE,
+                  histogramType="AUTO", r2Stopping=java_max_double_value,
                   nbinsTopLevel=1<<10, buildTreeOneNode=False, scoreTreeInterval=0,
                   sampleRate=1.0, sampleRatePerClass=None, colSampleRateChangePerLevel=1.0, colSampleRatePerTree=1.0,
-                  learnRate=0.1, learnRateAnnealing=1.0, colSampleRate=1.0, maxAbsLeafnodePred=SparkSession.builder.getOrCreate()._jvm.Double.MAX_VALUE,
+                  learnRate=0.1, learnRateAnnealing=1.0, colSampleRate=1.0, maxAbsLeafnodePred=java_max_double_value,
                   predNoiseBandwidth=0.0):
         kwargs = self._input_kwargs
 

--- a/py/tests/tests_integ_local.py
+++ b/py/tests/tests_integ_local.py
@@ -49,6 +49,18 @@ class LocalIntegTestSuite(unittest.TestCase):
 
         launch(env, "examples/pipelines/ham_or_spam_deep_learning.py")
 
+    def test_import_pysparkling_standalone_app(self):
+        env = IntegTestEnv()
+
+        env.set_spark_master("local")
+        # Configure YARN environment
+        env.conf("spark.yarn.max.executor.failures", 1) # In fail of executor, fail the test
+        env.conf("spark.executor.instances", 3)
+        env.conf("spark.executor.memory", "2g")
+        env.conf("spark.ext.h2o.port.base", 63331)
+        env.conf("spark.driver.memory", "2g")
+
+        launch(env, "py/scripts/tests/pysparkling_ml_import_overrides_spark_test.py")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We can't use `SparkSession.builder.getOrCreate` in `@keyword_only` annotated methods.