### PR TITLE
[SW-XXX] Pipeline instrumentation

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -1,0 +1,31 @@
+apply plugin: 'com.github.johnrengelman.shadow'
+
+description = "Sparkling Water Agent"
+
+dependencies{
+    compile "net.bytebuddy:byte-buddy:1.8.5"
+    compile "net.bytebuddy:byte-buddy-agent:1.8.5"
+    compile "org.apache.spark:spark-core_${scalaBaseVersion}:${sparkVersion}"
+}
+
+jar {
+    manifest {
+        attributes(
+                "Premain-Class": "Agent"
+        )
+    }
+}
+
+// Shadow jar settings
+shadowJar {
+    dependencies {
+        include(dependency("net.bytebuddy:byte-buddy"))
+        include(dependency("net.bytebuddy-agent:byte-buddy"))
+    }
+    manifest {
+        attributes "Premain-Class": "Agent"
+    }
+}
+artifacts {
+    archives shadowJar
+}

--- a/agent/src/main/scala/Agent.java
+++ b/agent/src/main/scala/Agent.java
@@ -1,0 +1,22 @@
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.matcher.ElementMatchers;
+
+import java.lang.instrument.Instrumentation;
+
+public class Agent {
+
+  public static void premain(String agentArgument, Instrumentation instrumentation) {
+    try {
+      new AgentBuilder.Default()
+              .type(ElementMatchers.nameContains("ErrorConsumer"))
+              .transform((builder, typeDescription, classLoader, javaModule) -> builder.method(ElementMatchers.nameContains("unseenCategorical")).intercept(MethodDelegation.to(new Interceptor()))).installOn(instrumentation);
+    } catch (RuntimeException e) {
+      System.out.println("Exception instrumenting code : " + e);
+      e.printStackTrace();
+    }
+
+  }
+
+}
+

--- a/agent/src/main/scala/Agent.java
+++ b/agent/src/main/scala/Agent.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.matcher.ElementMatchers;

--- a/agent/src/main/scala/Interceptor.scala
+++ b/agent/src/main/scala/Interceptor.scala
@@ -1,0 +1,12 @@
+import net.bytebuddy.implementation.bind.annotation.{AllArguments, RuntimeType}
+import org.apache.spark.internal.Logging
+
+
+class Interceptor extends Logging {
+
+  @RuntimeType
+  def intercept(@AllArguments allArguments: Array[AnyRef]): Any = {
+    logError("Unseen Categorical: " + allArguments(1))
+    this
+  }
+}

--- a/agent/src/main/scala/Interceptor.scala
+++ b/agent/src/main/scala/Interceptor.scala
@@ -1,3 +1,19 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 import net.bytebuddy.implementation.bind.annotation.{AllArguments, RuntimeType}
 import org.apache.spark.internal.Logging
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,8 @@ ext {
       project(':sparkling-water-examples'),
       project(':sparkling-water-ml'),
       project(':sparkling-water-app-streaming'),
-      project(':sparkling-water-package')
+      project(':sparkling-water-package'),
+      project(':sparkling-water-agent')
     ]
     javaProjects = [
       project(':sparkling-water-extension-stack-trace')

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,8 @@ include 'package'
 include 'doc'
 include 'extension-stack-trace'
 include 'templates'
+include 'agent'
+
 // Prefix all projects with sparkling-water name
 rootProject.children.each { project ->
     if (project.name.startsWith("app-")) {


### PR DESCRIPTION
Extremely simple example, can be further extended:

To try out:
```
cd sparkling-water

export AGENT_PATH="$(pwd)/agent/build/libs/sparkling-water-agent_2.11-2.3.99999-SNAPSHOT-all.jar"

./bin/pysparkling --conf "spark.driver.extraJavaOptions=-javaagent:$AGENT_PATH" --conf "spark.executor.extraJavaOptions=-javaagent:$AGENT_PATH"
```

```
from pysparkling import *
from pysparkling.ml import H2OMOJOModel

mojo = H2OMOJOModel.create_from_mojo("ml/src/test/resources/deep_learning_airlines_categoricals.zip")
mojo.setConvertUnknownCategoricalLevelsToNa(True)
d =[{'sepal_len':5.1, 'sepal_wid':3.5, 'petal_len':1.4, 'petal_wid':0.2, 'class':'Missing_categorical'}]
df = spark.createDataFrame(d)
data = mojo.transform(df).collect()[0]

d =[{'sepal_len':5.1, 'sepal_wid':3.5, 'petal_len':1.4, 'petal_wid':0.2, 'class':'abc'}]
df = spark.createDataFrame(d)
data = mojo.transform(df).collect()[0]
```
We should see to error messages from Spark about unseen categoricals. This code was added using the instrumentation. It will work cluster-wise if we add the instrumentation agent to each Spark executor as well.
 
Currently, the agent does not have any dependency on H2O. I added dependency on Spark so we can use Spark logging and possibly other sinks where we can report data later.

This PR is not for merging, just for demonstrating the example