### PR TITLE
[SW-851] Properly type and name output columns of mojo pipeline

### DIFF
--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
@@ -104,7 +104,7 @@ class H2OMOJOPipelineModel(val mojoData: Array[Byte], override val uid: String)
     var converted = flatten.select(col("*"), modelUdf(flatten.columns)(struct(names: _*)).as(outputCol))
 
     // This behaviour is turned off by default, it can be enabled manually and will be default
-    // in the release for Spark 2.54
+    // in the release for Spark 2.4
     if ($(namedMojoOutputColumns)) {
 
       def split(idx: Int) = udf[Double, mutable.WrappedArray[Double]] {

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
@@ -20,23 +20,25 @@ package org.apache.spark.ml.h2o.models
 import java.io._
 
 import ai.h2o.mojos.runtime.MojoPipeline
-import ai.h2o.mojos.runtime.frame.MojoColumn
 import ai.h2o.mojos.runtime.readers.MojoPipelineReaderBackendFactory
 import org.apache.hadoop.fs.Path
 import org.apache.spark.annotation.Since
 import org.apache.spark.h2o.utils.H2OSchemaUtils
+import org.apache.spark.ml.h2o.param.H2OMOJOPipelineModelParams
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.{Model => SparkModel}
+import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{col, struct, udf}
 import org.apache.spark.sql.types._
-import org.apache.spark.sql._
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
+import scala.util.Random
 
 
 class H2OMOJOPipelineModel(val mojoData: Array[Byte], override val uid: String)
-  extends SparkModel[H2OMOJOPipelineModel] with MLWritable {
+  extends SparkModel[H2OMOJOPipelineModel] with H2OMOJOPipelineModelParams with MLWritable {
 
   @transient private var model: MojoPipeline = _
 
@@ -52,7 +54,7 @@ class H2OMOJOPipelineModel(val mojoData: Array[Byte], override val uid: String)
 
   val outputCol = "prediction"
 
-  case class Mojo2Prediction(preds: List[String])
+  case class Mojo2Prediction(preds: List[Double])
 
   private val modelUdf = (names: Array[String]) =>
     udf[Mojo2Prediction, Row] {
@@ -78,11 +80,11 @@ class H2OMOJOPipelineModel(val mojoData: Array[Byte], override val uid: String)
         builder.addRow(rowBuilder)
         val output = m.transform(builder.toMojoFrame)
         val predictions = output.getColumnNames.zipWithIndex.map { case (_, i) =>
-          val predictedRows = output.getColumnData(i).asInstanceOf[Array[_]]
-          if (predictedRows.length != 1) {
+          val predictedVal = output.getColumnData(i).asInstanceOf[Array[Double]]
+          if (predictedVal.length != 1) {
             throw new RuntimeException("Invalid state, we predict on each row by row, independently at this moment.")
           }
-          predictedRows(0).toString
+          predictedVal(0)
         }
 
         Mojo2Prediction(predictions.toList)
@@ -99,7 +101,38 @@ class H2OMOJOPipelineModel(val mojoData: Array[Byte], override val uid: String)
     val names = flatten.schema.fields.map(f => flatten(f.name))
 
     // get the altered frame
-    flatten.select(col("*"), modelUdf(flatten.columns)(struct(names: _*)).as(outputCol))
+    var converted = flatten.select(col("*"), modelUdf(flatten.columns)(struct(names: _*)).as(outputCol))
+
+    // This behaviour is turned off by default, it can be enabled manually and will be default
+    // in the release for Spark 2.54
+    if ($(namedMojoOutputColumns)) {
+
+      def split(idx: Int) = udf[Double, mutable.WrappedArray[Double]] {
+        pred => pred(idx)
+      }
+
+      def uniqueRandomName(colName: String, r: Random) = {
+        var randName = r.nextString(30)
+        while (colName == randName) {
+          randName = r.nextString(30)
+        }
+        randName
+      }
+
+      val r = new scala.util.Random(31)
+      val tempColNames = getOutputNames().map(n => uniqueRandomName(n, r))
+      val tempCols = tempColNames.map(col)
+      // Transform the resulted Array of predictions into own columns
+      getOutputNames().indices.foreach { idx =>
+        val name = getOutputNames()(idx)
+        converted = converted.withColumn(tempColNames(idx), split(idx)(converted.col(outputCol + ".preds")))
+          .withColumn(outputCol, struct(tempCols.map(_.alias(name)): _*))
+          .drop(tempColNames(idx))
+
+      }
+    }
+
+    converted
   }
 
   def predictionSchema(): Seq[StructField] = {

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OMOJOPipelineModelParams.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OMOJOPipelineModelParams.scala
@@ -1,0 +1,50 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.apache.spark.ml.h2o.param
+
+import org.apache.spark.ml.param._
+
+/**
+  * Parameters which need to be available on the model itself for prediction purposes. This can't be backed
+  * byt H2OAlgoParamsHelper as at the time of prediction we might be using mojo and binary parameters are not available.
+  */
+trait H2OMOJOPipelineModelParams extends Params {
+
+  //
+  // Param definitions
+  //
+  final val namedMojoOutputColumns: Param[Boolean] = new Param[Boolean](this, "namedMojoOutputColumns", "Mojo Output is not stored" +
+    " in the array but in the properly named columns")
+
+  //
+  // Default values
+  //
+  setDefault(namedMojoOutputColumns -> false)
+
+  //
+  // Getters
+  //
+  /** @group getParam */
+  def getNamedMojoOutputColumns() = $(namedMojoOutputColumns)
+
+  //
+  // Setters
+  //
+  /** @group setParam */
+  def setNamedMojoOutputColumns(value: Boolean): this.type = set(namedMojoOutputColumns, value)
+
+}

--- a/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMOJOPipelineModelTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMOJOPipelineModelTest.scala
@@ -39,7 +39,7 @@ class H2OMOJOPipelineModelTest extends FunSuite with SparkTestContext {
   }
 
   test("Test columns names and numbers") {
-    val df = spark.read.option("header", "true").option("inferSchema", true).csv("../examples/smalldata/prostate/prostate.csv")
+    val df = spark.read.option("header", "true").option("inferSchema", true).csv("examples/smalldata/prostate/prostate.csv")
 
     val mojo = H2OMOJOPipelineModel.createFromMojo(
       this.getClass.getClassLoader.getResourceAsStream("mojo2data/pipeline.mojo"),
@@ -69,7 +69,7 @@ class H2OMOJOPipelineModelTest extends FunSuite with SparkTestContext {
 
   test("Prediction on Mojo Pipeline using internal API") {
     // Test data
-    val df = spark.read.option("header", "true").csv("../examples/smalldata/prostate/prostate.csv")
+    val df = spark.read.option("header", "true").csv("examples/smalldata/prostate/prostate.csv")
     // Test mojo
     val mojo = H2OMOJOPipelineModel.createFromMojo(
       this.getClass.getClassLoader.getResourceAsStream("mojo2data/pipeline.mojo"),
@@ -96,7 +96,7 @@ class H2OMOJOPipelineModelTest extends FunSuite with SparkTestContext {
 
   test("Verify that output columns are correct when using the named columns") {
     // Test data
-    val df = spark.read.option("header", "true").csv("../examples/smalldata/prostate/prostate.csv")
+    val df = spark.read.option("header", "true").csv("examples/smalldata/prostate/prostate.csv")
     // Test mojo
     val mojo = H2OMOJOPipelineModel.createFromMojo(
       this.getClass.getClassLoader.getResourceAsStream("mojo2data/pipeline.mojo"),
@@ -117,7 +117,7 @@ class H2OMOJOPipelineModelTest extends FunSuite with SparkTestContext {
     * The purpose of this test is to simply pass and don't throw NullPointerException
     */
   test("Prediction with null as row element") {
-    val df = spark.read.option("header", "true").csv("../examples/smalldata/prostate/prostate.csv")
+    val df = spark.read.option("header", "true").csv("examples/smalldata/prostate/prostate.csv")
     // Test mojo
     val mojo = H2OMOJOPipelineModel.createFromMojo(
       this.getClass.getClassLoader.getResourceAsStream("mojo2data/pipeline.mojo"),

--- a/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMOJOPipelineModelTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMOJOPipelineModelTest.scala
@@ -39,7 +39,7 @@ class H2OMOJOPipelineModelTest extends FunSuite with SparkTestContext {
   }
 
   test("Test columns names and numbers") {
-    val df = spark.read.option("header", "true").option("inferSchema", true).csv("examples/smalldata/prostate/prostate.csv")
+    val df = spark.read.option("header", "true").option("inferSchema", true).csv("../examples/smalldata/prostate/prostate.csv")
 
     val mojo = H2OMOJOPipelineModel.createFromMojo(
       this.getClass.getClassLoader.getResourceAsStream("mojo2data/pipeline.mojo"),
@@ -69,7 +69,7 @@ class H2OMOJOPipelineModelTest extends FunSuite with SparkTestContext {
 
   test("Prediction on Mojo Pipeline using internal API") {
     // Test data
-    val df = spark.read.option("header", "true").csv("examples/smalldata/prostate/prostate.csv")
+    val df = spark.read.option("header", "true").csv("../examples/smalldata/prostate/prostate.csv")
     // Test mojo
     val mojo = H2OMOJOPipelineModel.createFromMojo(
       this.getClass.getClassLoader.getResourceAsStream("mojo2data/pipeline.mojo"),
@@ -94,11 +94,30 @@ class H2OMOJOPipelineModelTest extends FunSuite with SparkTestContext {
     println(preds.mkString("\n"))
   }
 
+  test("Verify that output columns are correct when using the named columns") {
+    // Test data
+    val df = spark.read.option("header", "true").csv("../examples/smalldata/prostate/prostate.csv")
+    // Test mojo
+    val mojo = H2OMOJOPipelineModel.createFromMojo(
+      this.getClass.getClassLoader.getResourceAsStream("mojo2data/pipeline.mojo"),
+      "prostate_pipeline.mojo")
+    mojo.setNamedMojoOutputColumns(true)
+
+    val transDf = mojo.transform(df)
+    println("Predictions:")
+    val preds = transDf.select("prediction.AGE").take(5)
+    assert(preds(0).getDouble(0) == 65.36320409515132)
+    assert(preds(1).getDouble(0) == 64.96902128114817)
+    assert(preds(2).getDouble(0) == 64.96721023747583)
+    assert(preds(3).getDouble(0) == 65.78772654671035)
+    assert(preds(4).getDouble(0) == 66.11327967814829)
+  }
+
   /**
     * The purpose of this test is to simply pass and don't throw NullPointerException
     */
   test("Prediction with null as row element") {
-    val df = spark.read.option("header", "true").csv("examples/smalldata/prostate/prostate.csv")
+    val df = spark.read.option("header", "true").csv("../examples/smalldata/prostate/prostate.csv")
     // Test mojo
     val mojo = H2OMOJOPipelineModel.createFromMojo(
       this.getClass.getClassLoader.getResourceAsStream("mojo2data/pipeline.mojo"),
@@ -154,10 +173,10 @@ class H2OMOJOPipelineModelTest extends FunSuite with SparkTestContext {
   }
 
   private def assertPredictedValues(preds: Array[Row]): Unit = {
-    assert(preds(0).getSeq[String](0).head == "65.36320409515132")
-    assert(preds(1).getSeq[String](0).head == "64.96902128114817")
-    assert(preds(2).getSeq[String](0).head == "64.96721023747583")
-    assert(preds(3).getSeq[String](0).head == "65.78772654671035")
-    assert(preds(4).getSeq[String](0).head == "66.11327967814829")
+    assert(preds(0).getSeq[Double](0).head == 65.36320409515132)
+    assert(preds(1).getSeq[Double](0).head == 64.96902128114817)
+    assert(preds(2).getSeq[Double](0).head == 64.96721023747583)
+    assert(preds(3).getSeq[Double](0).head == 65.78772654671035)
+    assert(preds(4).getSeq[Double](0).head == 66.11327967814829)
   }
 }

--- a/py/py_sparkling/ml/models.py
+++ b/py/py_sparkling/ml/models.py
@@ -60,11 +60,11 @@ class H2OMOJOPipelineModel(JavaModel, JavaMLWritable, JavaMLReadable):
     def get_output_types(self):
         self._java_obj.getOutputTypes()
 
-    def get(self):
-            return self._java_obj.getConvertUnknownCategoricalLevelsToNa()
+    def get_named_mojo_output_columns(self):
+            return self._java_obj.getNamedMojoOutputColumns()
 
-    def setConvertUnknownCategoricalLevelsToNa(self, value):
-        self._java_obj.setConvertUnknownCategoricalLevelsToNa(value)
+    def set_named_mojo_output_columns(self, value):
+        self._java_obj.setNamedMojoOutputColumns(value)
         return self
 
 

--- a/py/py_sparkling/ml/models.py
+++ b/py/py_sparkling/ml/models.py
@@ -60,4 +60,11 @@ class H2OMOJOPipelineModel(JavaModel, JavaMLWritable, JavaMLReadable):
     def get_output_types(self):
         self._java_obj.getOutputTypes()
 
+    def get(self):
+            return self._java_obj.getConvertUnknownCategoricalLevelsToNa()
+
+    def setConvertUnknownCategoricalLevelsToNa(self, value):
+        self._java_obj.setConvertUnknownCategoricalLevelsToNa(value)
+        return self
+
 


### PR DESCRIPTION
The columns are now properly typed as double. Also, we currently store
the prediction output in an array for each row, loosing the information
about the name of the output column.

This has been fixed as well, however the behaviour is disabled by
default. It will be enabled by default in Spark 2.4