### PR TITLE
[SW-1018] Updates to R documentation files

### DIFF
--- a/doc/src/site/sphinx/deployment/rsparkling_on_windows.rst
+++ b/doc/src/site/sphinx/deployment/rsparkling_on_windows.rst
@@ -135,6 +135,6 @@ Troubleshooting
 References
 ~~~~~~~~~~
 
-- `Main RSparkling Documentation <docs.h2o.ai/sparkling-water/master/bleeding-edge/doc/rsparkling.html>`__
+- :ref:`rsparkling`
 - `H2O.ai website <http://h2o.ai>`__
 - `Running Spark Applications on Windows <https://jaceklaskowski.gitbooks.io/mastering-apache-spark/content/spark-tips-and-tricks-running-spark-windows.html>`__

--- a/doc/src/site/sphinx/deployment/rsparkling_on_windows.rst
+++ b/doc/src/site/sphinx/deployment/rsparkling_on_windows.rst
@@ -135,6 +135,6 @@ Troubleshooting
 References
 ~~~~~~~~~~
 
-- `Main RSparkling Documentation <../rsparkling.rst>`__
+- `Main RSparkling Documentation <docs.h2o.ai/sparkling-water/master/bleeding-edge/doc/rsparkling.html>`__
 - `H2O.ai website <http://h2o.ai>`__
 - `Running Spark Applications on Windows <https://jaceklaskowski.gitbooks.io/mastering-apache-spark/content/spark-tips-and-tricks-running-spark-windows.html>`__

--- a/r/README.rst
+++ b/r/README.rst
@@ -537,7 +537,7 @@ Additional Resources
 - `Main documentation site <http://docs.h2o.ai>`__
 - `H2O.ai website <http://h2o.ai>`__
 - `Example code <https://github.com/h2oai/rsparkling/blob/master/inst/examples/example_rsparkling.R>`__
-- `Troubleshooting RSparkling on Windows <http://docs.h2o.ai/sparkling-water/master/bleeding-edge/doc/tutorials/rsparkling_on_windows.html>`__
+- `Troubleshooting RSparkling on Windows <http://docs.h2o.ai/sparkling-water/master/bleeding-edge/doc/deployment/rsparkling_on_windows.html>`__
 
 If you are new to H2O for machine learning, we recommend you start with:
 


### PR DESCRIPTION
- In the R Readme, fixed the link for Troubleshooting RSparkling on Windows. This topic was moved from Tutorials to Deployment.
- Fixed a link to the Main RSparkling Documentation. This pointed to a local rst file rather than the HTML file, resulting in a broken link.