### PR TITLE
[SW-1083] Docs: Adding Install instructions to UG

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -486,7 +486,7 @@
               export HADOOP_CONF_DIR=/etc/hadoop/conf <br />
               export MASTER="yarn" <br />
             </p>
-            <p>4. Download Spark and Use spark-submit to launch Sparkling Shell on YARN.</p>
+            <p>4. Download Spark and use sparkling-shell to launch Sparkling Shell on YARN.</p>
             <p class="terminal">
               wget <script type="text/javascript">var url = location.href; var url2 = url.substring(0, url.lastIndexOf("/")); document.write(url2);</script>/sparkling-water-SUBST_PROJECT_VERSION.zip <br/>
               unzip sparkling-water-SUBST_PROJECT_VERSION.zip <br />
@@ -568,7 +568,7 @@
               java -cp h2odriver-extended.jar water.H2OApp -md5skip -name test
             </p>
 
-            <p>4 In your Sparkling Water application, create H2OContext:</p>
+            <p>4. In your Sparkling Water application, create H2OContext:</p>
             <p>Scala</p>
             <p class="terminal">
               import org.apache.spark.h2o._<br/>

--- a/doc/build.gradle
+++ b/doc/build.gradle
@@ -25,7 +25,7 @@ task substitute() {
     doLast {
         def siteDir = "${buildDir}/site"
 
-        def (first, second, third) = version.replace("-SNAPSHOT", "").tokenize(".")
+        def (first, second, third) = version.tokenize(".")
         def majorVersion = "${first}.${second}"
         def minorVersion = third
 
@@ -33,7 +33,7 @@ task substitute() {
             if (it.name.endsWith('.html')) {
                 def contents = file(it).getText('UTF-8')
                 contents = contents
-                        .replaceAll("SUBST_SW_VERSION", version.replace("-SNAPSHOT", ""))
+                        .replaceAll("SUBST_SW_VERSION", version)
                         .replaceAll("SUBST_SW_MAJOR_VERSION", majorVersion)
                         .replaceAll("SUBST_SW_MINOR_VERSION", minorVersion)
                         .replaceAll("SUBST_SPARK_VERSION", sparkVersion)

--- a/doc/src/site/sphinx/index.rst
+++ b/doc/src/site/sphinx/index.rst
@@ -21,6 +21,7 @@ Have questions about Sparkling Water? Post them on Stack Overflow using the `spa
    about
    typical_use_case
    requirements
+   install/install_and_start
    design/design
    configuration/configuration
    deployment/deployment

--- a/doc/src/site/sphinx/install/install_and_start.rst
+++ b/doc/src/site/sphinx/install/install_and_start.rst
@@ -6,7 +6,7 @@ This section describes how to download and run Sparkling Water in different envi
 Download and Run Locally
 ------------------------
 
-This section describes how to quickly get started with Sparkling Water.
+This section describes how to quickly get started with Sparkling Water on your personal computer.
 
 1. Download and install Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
 

--- a/doc/src/site/sphinx/install/install_and_start.rst
+++ b/doc/src/site/sphinx/install/install_and_start.rst
@@ -10,14 +10,13 @@ This section describes how to quickly get started with Sparkling Water on your p
 
 1. Download and install Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
 
-  .. code:: bash
 
-    Choose Spark release: SUBST_SPARK_VERSION
-    Choose package type: Pre-built for Hadoop 2.7 and later
+    - Choose Spark release: SUBST_SPARK_VERSION
+    - Choose package type: Pre-built for Hadoop 2.7 and later
 
 2. Point SPARK_HOME to the existing installation of Spark and export variable MASTER.
 
-  .. code:: bash
+.. code:: bash
 
     export SPARK_HOME="/path/to/spark/installation"
     # To launch a local Spark cluster.
@@ -25,20 +24,20 @@ This section describes how to quickly get started with Sparkling Water on your p
 
 3. From your terminal, run:
 
-  .. code:: bash
+.. code:: bash
 
     cd ~/Downloads
-    unzip sparkling-water-SUBST_PROJECT_VERSION.zip
-    cd sparkling-water-SUBST_PROJECT_VERSION
+    unzip sparkling-water-SUBST_SW_VERSION.zip
+    cd sparkling-water-SUBST_SW_VERSION
     bin/sparkling-shell --conf "spark.executor.memory=1g"
 
 4. Create an H2O cloud inside the Spark cluster:
 
-  .. code:: bash
+.. code:: scala
 
     import org.apache.spark.h2o._
     val h2oContext = H2OContext.getOrCreate(spark)
-    import h2oContext._ <br />
+    import h2oContext._
 
 5. Begin using Sparkling Water by following `this demo <https://github.com/h2oai/sparkling-water/tree/master/examples#step-by-step-weather-data-example>`__, which imports airlines and weather data and runs predictions on delays.
 
@@ -48,40 +47,38 @@ Run on Hadoop
 
 This section describes how to launch Sparkling Water on Hadoop using YARN.
 
-**Note**: The following is a list of supported Hadoop distributions: SUBST_H2O_DRIVERS_LIST
-
 1. Download Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
 
-  .. code:: bash
+.. code:: bash
 
-    Choose Spark release: SUBST_SPARK_VERSION
-    Choose package type: Pre-built for Hadoop 2.7 and later
+    - Choose Spark release: SUBST_SPARK_VERSION
+    - Choose package type: Pre-built for Hadoop 2.7 and later
 
 2. Point SPARK_HOME to the existing installation of Spark.
 
-  .. code:: bash
+.. code:: bash
 
     export SPARK_HOME='/path/to/spark/installation'
 
 3. Set the HADOOP_CONF_DIR and Spark MASTER environmental variables.
 
-  .. code:: bash
+.. code:: bash
 
     export HADOOP_CONF_DIR=/etc/hadoop/conf
     export MASTER="yarn"
 
 4. Download Spark and use ``sparkling-shell`` to launch Sparkling Shell on YARN.
 
-  .. code:: bash
+.. code:: bash
 
     wget https://s3.amazonaws.com/h2o-release/sparkling-water/rel-SUBST_SW_MAJOR_VERSION/SUBST_SW_MINOR_VERSION/sparkling-water-SUBST_SW_VERSION.zip
-    unzip sparkling-water-SUBST_PROJECT_VERSION.zip 
-    cd sparkling-water-SUBST_PROJECT_VERSION/
+    unzip sparkling-water-SUBST_SW_VERSION.zip 
+    cd sparkling-water-SUBST_SW_VERSION/
     bin/sparkling-shell --num-executors 3 --executor-memory 2g --master yarn --deploy-mode client
 
 5. Create an H2O cloud inside the Spark cluster:
 
-  .. code:: bash
+.. code:: scala
 
     import org.apache.spark.h2o._
     val h2oContext = H2OContext.getOrCreate(spark)
@@ -95,31 +92,31 @@ This section describes how to launch H2O on a standalone Spark cluster.
 
 1. Download Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
 
-  .. code:: bash
+.. code:: bash
 
-    Choose Spark release: SUBST_SPARK_VERSION
-    Choose package type: Pre-built for Hadoop 2.7 and later
+    - Choose Spark release: SUBST_SPARK_VERSION
+    - Choose package type: Pre-built for Hadoop 2.7 and later
 
 2. Point SPARK_HOME to the existing installation of Spark and export variable MASTER.
 
-  .. code:: bash
+.. code:: bash
 
     export SPARK_HOME='/path/to/spark/installation'
 
 3. From your terminal, run:
 
-  .. code:: bash
+.. code:: bash
 
     cd ~/Downloads
-    unzip sparkling-water-SUBST_PROJECT_VERSION.zip
-    cd sparkling-water-SUBST_PROJECT_VERSION
+    unzip sparkling-water-SUBST_SW_VERSION.zip
+    cd sparkling-water-SUBST_SW_VERSION
     bin/launch-spark-cloud.sh
     export MASTER="spark://localhost:7077"
     bin/sparkling-shell
 
 4. Create an H2O cloud inside the Spark cluster:
 
-  .. code:: bash
+.. code:: scala
 
     import org.apache.spark.h2o._
     val h2oContext = H2OContext.getOrCreate(spark)
@@ -135,37 +132,37 @@ Sparkling Water Kluster mode supports a connection to external H2O clusters (sta
 
 2. Download the corresponding ``h2odriver`` for your Hadoop distribution (e.g., hdp2.2, cdh5.4) or standalone one:
 
-  .. code:: bash
+.. code:: bash
 
     bin/get-extended-h2o.sh standalone
 
 3. Start an H2O cluster, for example, in standalone mode:
 
-  .. code:: bash
+.. code:: bash
 
     java -cp h2odriver-extended.jar water.H2OApp -md5skip -name test
 
 4. In your Sparkling Water application, create H2OContext:
 
-  **Scala**
+**Scala**
 
-  .. code:: scala
+.. code:: scala
 
-      import org.apache.spark.h2o._
-      val conf = new H2OConf(spark).setExternalClusterMode().useManualClusterStart().setCloudName("test")
-      val hc = H2OContext.getOrCreate(spark, conf)
+    import org.apache.spark.h2o._
+    val conf = new H2OConf(spark).setExternalClusterMode().useManualClusterStart().setCloudName("test")
+    val hc = H2OContext.getOrCreate(spark, conf)
 
-  **Python**
+**Python**
 
-  .. code:: python
+.. code:: python
 
-      from pysparkling import *
-      conf = H2OConf(spark).set_external_cluster_mode().use_manual_cluster_start().set_cloud_name("test")
-      hc = H2OContext.getOrCreate(spark, conf)
+    from pysparkling import *
+    conf = H2OConf(spark).set_external_cluster_mode().use_manual_cluster_start().set_cloud_name("test")
+    hc = H2OContext.getOrCreate(spark, conf)
 
 **Note**: The following is a list of supported Hadoop distributions: SUBST_H2O_DRIVERS_LIST
 
-For more information, please follow the `Kluster documentation <https://h2o-release.s3.amazonaws.com/sparkling-water/SUBST_PROJECT_GITBRANCH/SUBST_PROJECT_PATCH_VERSION/doc/deployment/backends.html>`__.
+For more information, please follow the :ref:`backend`.
 
 
 Use from Maven
@@ -182,10 +179,10 @@ See the `h2o-droplets GitHub repository <https://github.com/h2oai/h2o-droplets>`
   }
 
   dependencies {
-    compile "ai.h2o:sparkling-water-package_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION"
+    compile "ai.h2o:sparkling-water-package_2.11|SUBST_SW_VERSION"
   }
 
-See Maven Central for `artifact details <http://search.maven.org/#artifactdetails|ai.h2o|sparkling-water-package_SUBST_SCALA_VERSION|SUBST_PROJECT_VERSION|jar>`__.
+See Maven Central for `artifact details <http://search.maven.org/#artifactdetails|ai.h2o|sparkling-water-package_2.11|SUBST_SW_VERSION|jar>`__.
 
 
 Sparkling Water as a Spark Package
@@ -193,16 +190,16 @@ Sparkling Water as a Spark Package
 
 This section describes how to start Spark with Sparkling Water enabled via Spark package.
 
-1. Ensure that Spark is installed, and MASTER and SPARK_HOME environmental variables are properly set.
+1. Ensure that Spark is installed, and ``MASTER`` and ``SPARK_HOME`` environmental variables are properly set.
 2. Start Spark and point to maven coordinates of Sparkling Water:
 
-  .. code:: bash
+.. code:: bash
 
-   $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-package_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION
+   $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-package_2.11|SUBST_SW_VERSION
 
 3. Create an H2O cloud inside the Spark cluster:
 
-  .. code:: bash
+.. code:: scala
 
    import org.apache.spark.h2o._
    val h2oContext = H2OContext.getOrCreate(spark)

--- a/doc/src/site/sphinx/install/install_and_start.rst
+++ b/doc/src/site/sphinx/install/install_and_start.rst
@@ -74,6 +74,7 @@ This section describes how to launch Sparkling Water on Hadoop using YARN.
 
   .. code:: bash
 
+    wget https://s3.amazonaws.com/h2o-release/sparkling-water/rel-SUBST_SW_MAJOR_VERSION/SUBST_SW_MINOR_VERSION/sparkling-water-SUBST_SW_VERSION.zip
     unzip sparkling-water-SUBST_PROJECT_VERSION.zip 
     cd sparkling-water-SUBST_PROJECT_VERSION/
     bin/sparkling-shell --num-executors 3 --executor-memory 2g --master yarn --deploy-mode client

--- a/doc/src/site/sphinx/install/install_and_start.rst
+++ b/doc/src/site/sphinx/install/install_and_start.rst
@@ -6,7 +6,7 @@ This section describes how to download and run Sparkling Water in different envi
 Download and Run Locally
 ------------------------
 
-This section describes how to quickly get started with Sparkling Water on your personal computer.
+This section describes how to quickly get started with Sparkling Water on your personal computer (in Spark's ``local`` cluster mode).
 
 1. Download and install Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
 

--- a/doc/src/site/sphinx/install/install_and_start.rst
+++ b/doc/src/site/sphinx/install/install_and_start.rst
@@ -10,14 +10,14 @@ This section describes how to quickly get started with Sparkling Water on your p
 
 1. Download and install Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
 
-  ::
+  .. code:: bash
 
     Choose Spark release: SUBST_SPARK_VERSION
     Choose package type: Pre-built for Hadoop 2.7 and later
 
 2. Point SPARK_HOME to the existing installation of Spark and export variable MASTER.
 
-  ::
+  .. code:: bash
 
     export SPARK_HOME="/path/to/spark/installation"
     # To launch a local Spark cluster.
@@ -25,7 +25,7 @@ This section describes how to quickly get started with Sparkling Water on your p
 
 3. From your terminal, run:
 
-  ::
+  .. code:: bash
 
     cd ~/Downloads
     unzip sparkling-water-SUBST_PROJECT_VERSION.zip
@@ -34,7 +34,7 @@ This section describes how to quickly get started with Sparkling Water on your p
 
 4. Create an H2O cloud inside the Spark cluster:
 
-  ::
+  .. code:: bash
 
     import org.apache.spark.h2o._
     val h2oContext = H2OContext.getOrCreate(spark)
@@ -52,36 +52,35 @@ This section describes how to launch Sparkling Water on Hadoop using YARN.
 
 1. Download Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
 
-  ::
+  .. code:: bash
 
     Choose Spark release: SUBST_SPARK_VERSION
     Choose package type: Pre-built for Hadoop 2.7 and later
 
 2. Point SPARK_HOME to the existing installation of Spark.
 
-  ::
+  .. code:: bash
 
     export SPARK_HOME='/path/to/spark/installation'
 
 3. Set the HADOOP_CONF_DIR and Spark MASTER environmental variables.
 
-  ::
+  .. code:: bash
 
     export HADOOP_CONF_DIR=/etc/hadoop/conf
     export MASTER="yarn"
 
 4. Download Spark and use ``sparkling-shell`` to launch Sparkling Shell on YARN.
 
-  ::
+  .. code:: bash
 
-    wget <script type="text/javascript">var url = location.href; var url2 = url.substring(0, url.lastIndexOf("/")); document.write(url2);</script>/sparkling-water-SUBST_PROJECT_VERSION.zip 
     unzip sparkling-water-SUBST_PROJECT_VERSION.zip 
     cd sparkling-water-SUBST_PROJECT_VERSION/
     bin/sparkling-shell --num-executors 3 --executor-memory 2g --master yarn --deploy-mode client
 
 5. Create an H2O cloud inside the Spark cluster:
 
-  ::
+  .. code:: bash
 
     import org.apache.spark.h2o._
     val h2oContext = H2OContext.getOrCreate(spark)
@@ -94,20 +93,21 @@ Run on a Standalone Cluster
 This section describes how to launch H2O on a standalone Spark cluster.
 
 1. Download Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
-  ::
+
+  .. code:: bash
 
     Choose Spark release: SUBST_SPARK_VERSION
     Choose package type: Pre-built for Hadoop 2.7 and later
 
 2. Point SPARK_HOME to the existing installation of Spark and export variable MASTER.
 
-  ::
+  .. code:: bash
 
     export SPARK_HOME='/path/to/spark/installation'
 
 3. From your terminal, run:
 
-  ::
+  .. code:: bash
 
     cd ~/Downloads
     unzip sparkling-water-SUBST_PROJECT_VERSION.zip
@@ -118,7 +118,7 @@ This section describes how to launch H2O on a standalone Spark cluster.
 
 4. Create an H2O cloud inside the Spark cluster:
 
-  ::
+  .. code:: bash
 
     import org.apache.spark.h2o._
     val h2oContext = H2OContext.getOrCreate(spark)
@@ -134,26 +134,29 @@ Sparkling Water Kluster mode supports a connection to external H2O clusters (sta
 
 2. Download the corresponding ``h2odriver`` for your Hadoop distribution (e.g., hdp2.2, cdh5.4) or standalone one:
 
-  ::
+  .. code:: bash
 
     bin/get-extended-h2o.sh standalone
 
 3. Start an H2O cluster, for example, in standalone mode:
 
-  ::
+  .. code:: bash
 
     java -cp h2odriver-extended.jar water.H2OApp -md5skip -name test
 
 4. In your Sparkling Water application, create H2OContext:
 
-  .. example-code::
-     .. code-block:: Scala
+  **Scala**
+
+  .. code:: scala
 
       import org.apache.spark.h2o._
       val conf = new H2OConf(spark).setExternalClusterMode().useManualClusterStart().setCloudName("test")
       val hc = H2OContext.getOrCreate(spark, conf)
 
-     .. code-block:: python
+  **Python**
+
+  .. code:: python
 
       from pysparkling import *
       conf = H2OConf(spark).set_external_cluster_mode().use_manual_cluster_start().set_cloud_name("test")
@@ -171,14 +174,14 @@ This section provides a gradle-style specification for Maven artifacts.
 
 See the `h2o-droplets GitHub repository <https://github.com/h2oai/h2o-droplets>`__ for a working example.
 
-::
+.. code:: bash
 
   repositories {
-    &nbsp;mavenCentral()
+    mavenCentral()
   }
 
   dependencies {
-    &nbsp;compile "ai.h2o:sparkling-water-package_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION"
+    compile "ai.h2o:sparkling-water-package_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION"
   }
 
 See Maven Central for `artifact details <http://search.maven.org/#artifactdetails|ai.h2o|sparkling-water-package_SUBST_SCALA_VERSION|SUBST_PROJECT_VERSION|jar>`__.
@@ -192,13 +195,13 @@ This section describes how to start Spark with Sparkling Water enabled via Spark
 1. Ensure that Spark is installed, and MASTER and SPARK_HOME environmental variables are properly set.
 2. Start Spark and point to maven coordinates of Sparkling Water:
 
-  ::
+  .. code:: bash
 
    $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-package_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION
 
 3. Create an H2O cloud inside the Spark cluster:
 
-  ::
+  .. code:: bash
 
    import org.apache.spark.h2o._
    val h2oContext = H2OContext.getOrCreate(spark)

--- a/doc/src/site/sphinx/install/install_and_start.rst
+++ b/doc/src/site/sphinx/install/install_and_start.rst
@@ -1,0 +1,205 @@
+Installing and Starting
+=======================
+
+This section describes how to download and run Sparkling Water in different environments. Refer to the :ref:`pysparkling` and :ref:`rsparkling` sections for instructions on installing and running PySparkling and RSparkling. 
+
+Download and Run Locally
+------------------------
+
+This section describes how to quickly get started with Sparkling Water.
+
+1. Download and install Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
+
+  ::
+
+    Choose Spark release: SUBST_SPARK_VERSION
+    Choose package type: Pre-built for Hadoop 2.7 and later
+
+2. Point SPARK_HOME to the existing installation of Spark and export variable MASTER.
+
+  ::
+
+    export SPARK_HOME="/path/to/spark/installation"
+    # To launch a local Spark cluster.
+    export MASTER="local[*]"
+
+3. From your terminal, run:
+
+  ::
+
+    cd ~/Downloads
+    unzip sparkling-water-SUBST_PROJECT_VERSION.zip
+    cd sparkling-water-SUBST_PROJECT_VERSION
+    bin/sparkling-shell --conf "spark.executor.memory=1g"
+
+4. Create an H2O cloud inside the Spark cluster:
+
+  ::
+
+    import org.apache.spark.h2o._
+    val h2oContext = H2OContext.getOrCreate(spark)
+    import h2oContext._ <br />
+
+5. Begin using Sparkling Water by following `this demo <https://github.com/h2oai/sparkling-water/tree/master/examples#step-by-step-weather-data-example>`__, which imports airlines and weather data and runs predictions on delays.
+
+
+Run on Hadoop
+-------------
+
+This section describes how to launch Sparkling Water on Hadoop using YARN.
+
+**Note**: The following is a list of supported Hadoop distributions: SUBST_H2O_DRIVERS_LIST
+
+1. Download Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
+
+  ::
+
+    Choose Spark release: SUBST_SPARK_VERSION
+    Choose package type: Pre-built for Hadoop 2.7 and later
+
+2. Point SPARK_HOME to the existing installation of Spark.
+
+  ::
+
+    export SPARK_HOME='/path/to/spark/installation'
+
+3. Set the HADOOP_CONF_DIR and Spark MASTER environmental variables.
+
+  ::
+
+    export HADOOP_CONF_DIR=/etc/hadoop/conf
+    export MASTER="yarn"
+
+4. Download Spark and use ``sparkling-shell`` to launch Sparkling Shell on YARN.
+
+  ::
+
+    wget <script type="text/javascript">var url = location.href; var url2 = url.substring(0, url.lastIndexOf("/")); document.write(url2);</script>/sparkling-water-SUBST_PROJECT_VERSION.zip 
+    unzip sparkling-water-SUBST_PROJECT_VERSION.zip 
+    cd sparkling-water-SUBST_PROJECT_VERSION/
+    bin/sparkling-shell --num-executors 3 --executor-memory 2g --master yarn --deploy-mode client
+
+5. Create an H2O cloud inside the Spark cluster:
+
+  ::
+
+    import org.apache.spark.h2o._
+    val h2oContext = H2OContext.getOrCreate(spark)
+    import h2oContext._ 
+
+
+Run on a Standalone Cluster
+---------------------------
+
+This section describes how to launch H2O on a standalone Spark cluster.
+
+1. Download Spark (if not already installed) from the `Spark Downloads page <https://spark.apache.org/downloads.html>`__.
+  ::
+
+    Choose Spark release: SUBST_SPARK_VERSION
+    Choose package type: Pre-built for Hadoop 2.7 and later
+
+2. Point SPARK_HOME to the existing installation of Spark and export variable MASTER.
+
+  ::
+
+    export SPARK_HOME='/path/to/spark/installation'
+
+3. From your terminal, run:
+
+  ::
+
+    cd ~/Downloads
+    unzip sparkling-water-SUBST_PROJECT_VERSION.zip
+    cd sparkling-water-SUBST_PROJECT_VERSION
+    bin/launch-spark-cloud.sh
+    export MASTER="spark://localhost:7077"
+    bin/sparkling-shell
+
+4. Create an H2O cloud inside the Spark cluster:
+
+  ::
+
+    import org.apache.spark.h2o._
+    val h2oContext = H2OContext.getOrCreate(spark)
+    import h2oContext._ 
+
+
+Kluster Mode
+------------
+
+Sparkling Water Kluster mode supports a connection to external H2O clusters (standalone/hadoop). The extended H2O cluster needs to be started with a corresponding H2O build, which can be downloaded below.
+
+1. Download and unpack the Sparkling Water distribution.
+
+2. Download the corresponding ``h2odriver`` for your Hadoop distribution (e.g., hdp2.2, cdh5.4) or standalone one:
+
+  ::
+
+    bin/get-extended-h2o.sh standalone
+
+3. Start an H2O cluster, for example, in standalone mode:
+
+  ::
+
+    java -cp h2odriver-extended.jar water.H2OApp -md5skip -name test
+
+4. In your Sparkling Water application, create H2OContext:
+
+  .. example-code::
+     .. code-block:: Scala
+
+      import org.apache.spark.h2o._
+      val conf = new H2OConf(spark).setExternalClusterMode().useManualClusterStart().setCloudName("test")
+      val hc = H2OContext.getOrCreate(spark, conf)
+
+     .. code-block:: python
+
+      from pysparkling import *
+      conf = H2OConf(spark).set_external_cluster_mode().use_manual_cluster_start().set_cloud_name("test")
+      hc = H2OContext.getOrCreate(spark, conf)
+
+**Note**: The following is a list of supported Hadoop distributions: SUBST_H2O_DRIVERS_LIST
+
+For more information, please follow the `Kluster documentation <https://h2o-release.s3.amazonaws.com/sparkling-water/SUBST_PROJECT_GITBRANCH/SUBST_PROJECT_PATCH_VERSION/doc/deployment/backends.html>`__.
+
+
+Use from Maven
+--------------
+
+This section provides a gradle-style specification for Maven artifacts.
+
+See the `h2o-droplets GitHub repository <https://github.com/h2oai/h2o-droplets>`__ for a working example.
+
+::
+
+  repositories {
+    &nbsp;mavenCentral()
+  }
+
+  dependencies {
+    &nbsp;compile "ai.h2o:sparkling-water-package_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION"
+  }
+
+See Maven Central for `artifact details <http://search.maven.org/#artifactdetails|ai.h2o|sparkling-water-package_SUBST_SCALA_VERSION|SUBST_PROJECT_VERSION|jar>`__.
+
+
+Sparkling Water as a Spark Package
+----------------------------------
+
+This section describes how to start Spark with Sparkling Water enabled via Spark package.
+
+1. Ensure that Spark is installed, and MASTER and SPARK_HOME environmental variables are properly set.
+2. Start Spark and point to maven coordinates of Sparkling Water:
+
+  ::
+
+   $SPARK_HOME/bin/spark-shell --packages ai.h2o:sparkling-water-package_SUBST_SCALA_VERSION:SUBST_PROJECT_VERSION
+
+3. Create an H2O cloud inside the Spark cluster:
+
+  ::
+
+   import org.apache.spark.h2o._
+   val h2oContext = H2OContext.getOrCreate(spark)
+   import h2oContext._ 

--- a/doc/src/site/sphinx/pysparkling.rst
+++ b/doc/src/site/sphinx/pysparkling.rst
@@ -1,1 +1,3 @@
+.. _pysparkling:
+
 .. include:: ../../../../py/README.rst

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -60,13 +60,13 @@ Available Demos for Sparkling Shell
 Building and Running Examples
 -----------------------------
 
-Please see `Running Sparkling Water Examples <../doc/devel/running_examples.rst>`__ for more information how to build
+Please see `Running Sparkling Water Examples <../doc/src/site/sphinx/devel/running_examples.rst>`__ for more information how to build
 and run examples.
 
 Configuring Sparkling Water Variables
 -------------------------------------
 
-Please see `Available Sparkling Water Configuration Properties <../doc/configuration/configuration_properties.rst>`__ for
+Please see `Available Sparkling Water Configuration Properties <../doc/src/site/sphinx/configuration/configuration_properties.rst>`__ for
 more information about possible Sparkling Water configurations.
 
 Step-by-Step Weather Data Example


### PR DESCRIPTION
- Added a new topic, "Installing and Starting"
- Included new topic in the index
- Added an anchor to the PySparkling topic
Driveby fixes:
- Fixed broken links in the Examples/readme.rst file
- Fixed Run on Hadoop installation step 4 on the download page.