### PR TITLE
[SW-1136] Fix bug affecting loading pipeline in python when stored in scala

### DIFF
--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModel.scala
@@ -260,7 +260,7 @@ private[models] class H2OMOJOModelReader[T <: H2OMOJOModel : ClassTag]
   }
 }
 
-class H2OMOJOModelHelper[T <: H2OMOJOModel](implicit m: ClassTag[T]) extends MLReadable[T] {
+class H2OMOJOModelHelper[T <: py_sparkling.ml.models.H2OMOJOModel](implicit m: ClassTag[T]) extends MLReadable[T] {
   val defaultFileName = "mojo_model"
 
   @Since("1.6.0")
@@ -294,4 +294,4 @@ class H2OMOJOModelHelper[T <: H2OMOJOModel](implicit m: ClassTag[T]) extends MLR
   }
 }
 
-object H2OMOJOModel extends H2OMOJOModelHelper[H2OMOJOModel] {}
+object H2OMOJOModel extends H2OMOJOModelHelper[py_sparkling.ml.models.H2OMOJOModel] {}

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
@@ -274,7 +274,7 @@ private[models] class H2OMOJOPipelineModelReader[T <: H2OMOJOPipelineModel : Cla
 }
 
 
-class H2OMOJOPipelineModelHelper[T<: H2OMOJOPipelineModel](implicit m: ClassTag[T]) extends MLReadable[T]{
+class H2OMOJOPipelineModelHelper[T<: py_sparkling.ml.models.H2OMOJOPipelineModel](implicit m: ClassTag[T]) extends MLReadable[T]{
   val defaultFileName = "mojo_pipeline_model"
 
   @Since("1.6.0")
@@ -301,4 +301,4 @@ class H2OMOJOPipelineModelHelper[T<: H2OMOJOPipelineModel](implicit m: ClassTag[
   }
 }
 
-object H2OMOJOPipelineModel extends H2OMOJOPipelineModelHelper[H2OMOJOPipelineModel] {}
+object H2OMOJOPipelineModel extends H2OMOJOPipelineModelHelper[py_sparkling.ml.models.H2OMOJOPipelineModel] {}


### PR DESCRIPTION
We always need internally use models from py_sparkling submodule to be able to load them in PySparkling