### PR TITLE
[SW-1138] Fix several cases in spark vector -> h2o conversion

### DIFF
--- a/core/src/test/scala/org/apache/spark/h2o/utils/H2OAsserts.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/utils/H2OAsserts.scala
@@ -29,7 +29,7 @@ object H2OAsserts {
 
   def assertVectorDoubleValues(vec: water.fvec.Vec, values: Seq[Double]): Unit = {
     (0 until vec.length().toInt).foreach { rIdx =>
-      assert(if (vec.isNA(rIdx)) values(rIdx) == Double.NaN // this is Scala i can do NaN comparision
+      assert(if (vec.isNA(rIdx)) values(rIdx).equals(Double.NaN) // this is Scala i can do NaN comparision
              else vec.at(rIdx) == values(rIdx), "Values stored in H2OFrame has to match specified values")
     }
   }


### PR DESCRIPTION
Fixes:
-> Wrong conversion between RDD[SparseVector] -> H2OFrame
-> Wrong conversion between RDD[Vector] in case the vector had different number of elements