### PR TITLE
[SW-1150] Change exit() to sys.exit()

### DIFF
--- a/py/pysparkling/context.py
+++ b/py/pysparkling/context.py
@@ -191,7 +191,7 @@ class H2OContext(object):
 
     def stop(self):
         self.__stop()
-        exit()
+        sys.exit()
 
     def download_h2o_logs(self, destination):
         return self._jhc.h2oContext().downloadH2OLogs(destination)


### PR DESCRIPTION
When running `hc.stop()` there is an error: `NameError: global name 'exit' is not defined`. The `exit()` is not correct refering its source package, change to `sys.exit()`.