### PR TITLE
[SW-1186] No need to pass properties defined in spark-defaults.conf to cli

### DIFF
--- a/bin/run-sparkling.sh
+++ b/bin/run-sparkling.sh
@@ -18,12 +18,9 @@ DRIVER_MEMORY=${DRIVER_MEMORY:-$DEFAULT_DRIVER_MEMORY}
 MASTER=${MASTER:-"$DEFAULT_MASTER"}
 VERBOSE=--verbose
 VERBOSE=
-if [ -f "$SPARK_HOME"/conf/spark-defaults.conf ]; then
-    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" "$SPARK_HOME"/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
-fi
 
 # Show banner
 banner 
 
-spark-submit "$@" $VERBOSE --driver-memory "$DRIVER_MEMORY" --master "$MASTER" --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS" --class "$DRIVER_CLASS" "$FAT_JAR_FILE"
+spark-submit "$@" $VERBOSE --driver-memory "$DRIVER_MEMORY" --master "$MASTER" --class "$DRIVER_CLASS" "$FAT_JAR_FILE"
 

--- a/bin/sparkling-shell
+++ b/bin/sparkling-shell
@@ -21,9 +21,6 @@ DRIVER_MEMORY=${DRIVER_MEMORY:-2G}
 USER_MASTER=${MASTER:-$(getMasterArg "$@")}
 USER_MASTER=${USER_MASTER:-"$DEFAULT_MASTER"}
 export MASTER="$USER_MASTER"
-if [ -f "$SPARK_HOME/conf/spark-defaults.conf" ]; then
-    EXTRA_DRIVER_PROPS=$(grep "^spark.driver.extraJavaOptions" "$SPARK_HOME"/conf/spark-defaults.conf 2>/dev/null | sed -e 's/spark.driver.extraJavaOptions//' )
-fi
 
 banner
 
@@ -34,5 +31,6 @@ ARGS="$@"
 ARGS=$(removeArgWithParam "--jars" "$ARGS")
 ARGS=$(removeArgWithParam "--master" "$ARGS")
 
+echo $ARGS
 # If extra java properties are defined use them and append our property
-spark-shell --jars "$JARS" --driver-memory "$DRIVER_MEMORY" --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS" $ARGS
+spark-shell --jars "$JARS" --driver-memory "$DRIVER_MEMORY" $ARGS

--- a/bin/sparkling-shell
+++ b/bin/sparkling-shell
@@ -31,6 +31,5 @@ ARGS="$@"
 ARGS=$(removeArgWithParam "--jars" "$ARGS")
 ARGS=$(removeArgWithParam "--master" "$ARGS")
 
-echo $ARGS
 # If extra java properties are defined use them and append our property
 spark-shell --jars "$JARS" --driver-memory "$DRIVER_MEMORY" $ARGS


### PR DESCRIPTION
There is no need to additionally pass this configuration to CLI as Spark reads the spark-defaults.conf file