### PR TITLE
[SW-1299] Warn user that default value of predictionCol on H2OMOJOModel will change in the next major release to 'prediction'

### DIFF
--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModel.scala
@@ -32,6 +32,8 @@ import water.support.ModelSerializationSupport
 
 class H2OMOJOModel(override val uid: String) extends H2OMOJOModelBase[H2OMOJOModel] {
 
+  logWarning("Default value of 'predictionCol' parameter on H2OMOJOModel will be changed to 'prediction' from 'prediction_output' in the next" +
+    " major release.")
   setDefault(predictionCol, "prediction_output")
   // Some MojoModels are not serializable ( DeepLearning ), so we are reusing the mojoData to keep information about mojo model
   @transient private var easyPredictModelWrapper: EasyPredictModelWrapper = _


### PR DESCRIPTION
Another step towards consistency with Spark.

H2OMOJOPipelineModel is already using `prediction` as default value for prediction column