### PR TITLE
[SW-1380] ShadowJar in benchmarks does not need to be created from scratch

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -8,16 +8,6 @@ dependencies {
 }
 
 shadowJar {
-    configurations = [project.configurations.shadowRuntime]
-
-    mergeServiceFiles()
-
-    relocate 'javassist', 'ai.h2o.javassist'
-    relocate 'com.google.common', 'ai.h2o.com.google.common'
-    relocate 'org.eclipse.jetty', 'ai.h2o.org.eclipse.jetty'
-    relocate 'org.eclipse.jetty.orbit', 'ai.h2o.org.eclipse.jetty.orbit'
-
-    exclude 'www/flow/packs/test-*/**'
 }
 
 build.dependsOn shadowJar

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -4,19 +4,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply from: "$rootDir/gradle/shadowRuntime.gradle"
 
 dependencies {
-
-    // Sparkling Water libraries
-    compile project(":sparkling-water-ml")
-    compile project(":sparkling-water-repl")
-    compile(project(":sparkling-water-core")) {
-        exclude group: "javax.servlet", module: "servlet-api"
-    }
-
-    // Spark libraries
-    compile "org.apache.spark:spark-core_${scalaBaseVersion}:${sparkVersion}"
-    compile "org.apache.spark:spark-sql_${scalaBaseVersion}:${sparkVersion}"
-    compile "org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}"
-    compile "org.apache.spark:spark-repl_${scalaBaseVersion}:${sparkVersion}"
+    compile project(path: ':sparkling-water-assembly', configuration: 'shadow')
 }
 
 shadowJar {


### PR DESCRIPTION
Speed up the build. Benchmarks still can add additional dependencies.

Note: need to think more