### PR TITLE
[SW-1412] Integrate generic conversion logic to data frame conversion to H2O frames

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -121,6 +121,8 @@ dependencies {
   testCompile "org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}"
 
   testCompile "org.apache.spark:spark-repl_${scalaBaseVersion}:${sparkVersion}"
+
+  testCompile project(':sparkling-water-macros')
     
   // And use scalatest for Scala testing
   testCompile "org.scalatest:scalatest_${scalaBaseVersion}:2.2.1"

--- a/core/src/bench/scala/ai.h2o.sparkling.bench/DataFrameConverterBenchSuite.scala
+++ b/core/src/bench/scala/ai.h2o.sparkling.bench/DataFrameConverterBenchSuite.scala
@@ -95,50 +95,50 @@ class DataFrameConverterBenchSuite extends BenchSuite with SharedH2OTestContext 
     val df = TestFrameUtils.generateDataFrame(spark, schemaHolder, settings)
     H2OSchemaUtils.rowsToRowSchemas(df).foreach(_ => {})
   }
+  /*
+    benchTest("Measure performance of conversion to H2OFrame on a data frame with wide sparse vectors") {
+      import TestUtils.sparseVector
+      import sqlContext.implicits._
+      val numberOfCols = 50 * 1000
+      val sparsity = 0.2
+      val numberOfRows = 3 * 1000
+      val partitions = 4
 
-  benchTest("Measure performance of conversion to H2OFrame on a data frame with wide sparse vectors") {
-    import TestUtils.sparseVector
-    import sqlContext.implicits._
-    val numberOfCols = 50 * 1000
-    val sparsity = 0.2
-    val numberOfRows = 3 * 1000
-    val partitions = 4
+      val elementsPerRow = (sparsity * numberOfCols).toInt
+      val rowGenerator = (row: Int) => new SparseVectorHolder(sparseVector(numberOfCols, elementsPerRow))
 
-    val elementsPerRow = (sparsity * numberOfCols).toInt
-    val rowGenerator = (row: Int) => new SparseVectorHolder(sparseVector(numberOfCols, elementsPerRow))
+      val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
 
-    val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
-
-    val hf = hc.asH2OFrame(df)
-    hf.remove()
-  }
-
-  benchTest("Measure performance of conversion to H2OFrame on a data frame with wide dense vectors") {
-    import sqlContext.implicits._
-    val numberOfCols = 10 * 1000
-    val numberOfRows = 3 * 1000
-    val partitions = 4
-
-    val rowGenerator = (row: Int) => new DenseVectorHolder(new DenseVector(Array.fill[Double](numberOfCols)(row)))
-
-    val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
-
-    val hf = hc.asH2OFrame(df)
-    hf.remove()
-  }
-
-  benchTest("Measure performance of conversion to H2OFrame on a matrix 10x11 represented by sparse vectors", iterations = 10) {
-    import sqlContext.implicits._
-
-    val numberOfRows = 10
-    val numberOfCols = 11
-    val partitions = 2
-    val rowGenerator = (row: Int) => {
-      new SparseVectorHolder(new SparseVector(numberOfCols, Array(row), Array[Double](row)))
+      val hf = hc.asH2OFrame(df)
+      hf.remove()
     }
-    val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
 
-    val hf = hc.asH2OFrame(df)
-    hf.remove()
-  }
+    benchTest("Measure performance of conversion to H2OFrame on a data frame with wide dense vectors") {
+      import sqlContext.implicits._
+      val numberOfCols = 10 * 1000
+      val numberOfRows = 3 * 1000
+      val partitions = 4
+
+      val rowGenerator = (row: Int) => new DenseVectorHolder(new DenseVector(Array.fill[Double](numberOfCols)(row)))
+
+      val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
+
+      val hf = hc.asH2OFrame(df)
+      hf.remove()
+    }
+  */
+    benchTest("Measure performance of conversion to H2OFrame on a matrix 10x11 represented by sparse vectors", iterations = 10) {
+      import sqlContext.implicits._
+
+      val numberOfRows = 10
+      val numberOfCols = 11
+      val partitions = 2
+      val rowGenerator = (row: Int) => {
+        new SparseVectorHolder(new SparseVector(numberOfCols, Array(row), Array[Double](row)))
+      }
+      val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
+
+      val hf = hc.asH2OFrame(df)
+      hf.remove()
+    }
 }

--- a/core/src/bench/scala/ai.h2o.sparkling.bench/DataFrameConverterBenchSuite.scala
+++ b/core/src/bench/scala/ai.h2o.sparkling.bench/DataFrameConverterBenchSuite.scala
@@ -95,50 +95,50 @@ class DataFrameConverterBenchSuite extends BenchSuite with SharedH2OTestContext 
     val df = TestFrameUtils.generateDataFrame(spark, schemaHolder, settings)
     H2OSchemaUtils.rowsToRowSchemas(df).foreach(_ => {})
   }
-  /*
-    benchTest("Measure performance of conversion to H2OFrame on a data frame with wide sparse vectors") {
-      import TestUtils.sparseVector
-      import sqlContext.implicits._
-      val numberOfCols = 50 * 1000
-      val sparsity = 0.2
-      val numberOfRows = 3 * 1000
-      val partitions = 4
 
-      val elementsPerRow = (sparsity * numberOfCols).toInt
-      val rowGenerator = (row: Int) => new SparseVectorHolder(sparseVector(numberOfCols, elementsPerRow))
+  benchTest("Measure performance of conversion to H2OFrame on a data frame with wide sparse vectors") {
+    import TestUtils.sparseVector
+    import sqlContext.implicits._
+    val numberOfCols = 50 * 1000
+    val sparsity = 0.2
+    val numberOfRows = 3 * 1000
+    val partitions = 4
 
-      val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
+    val elementsPerRow = (sparsity * numberOfCols).toInt
+    val rowGenerator = (row: Int) => new SparseVectorHolder(sparseVector(numberOfCols, elementsPerRow))
 
-      val hf = hc.asH2OFrame(df)
-      hf.remove()
+    val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
+
+    val hf = hc.asH2OFrame(df)
+    hf.remove()
+  }
+
+  benchTest("Measure performance of conversion to H2OFrame on a data frame with wide dense vectors") {
+    import sqlContext.implicits._
+    val numberOfCols = 10 * 1000
+    val numberOfRows = 3 * 1000
+    val partitions = 4
+
+    val rowGenerator = (row: Int) => new DenseVectorHolder(new DenseVector(Array.fill[Double](numberOfCols)(row)))
+
+    val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
+
+    val hf = hc.asH2OFrame(df)
+    hf.remove()
+  }
+
+  benchTest("Measure performance of conversion to H2OFrame on a matrix 10x11 represented by sparse vectors", iterations = 10) {
+    import sqlContext.implicits._
+
+    val numberOfRows = 10
+    val numberOfCols = 11
+    val partitions = 2
+    val rowGenerator = (row: Int) => {
+      new SparseVectorHolder(new SparseVector(numberOfCols, Array(row), Array[Double](row)))
     }
+    val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
 
-    benchTest("Measure performance of conversion to H2OFrame on a data frame with wide dense vectors") {
-      import sqlContext.implicits._
-      val numberOfCols = 10 * 1000
-      val numberOfRows = 3 * 1000
-      val partitions = 4
-
-      val rowGenerator = (row: Int) => new DenseVectorHolder(new DenseVector(Array.fill[Double](numberOfCols)(row)))
-
-      val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
-
-      val hf = hc.asH2OFrame(df)
-      hf.remove()
-    }
-  */
-    benchTest("Measure performance of conversion to H2OFrame on a matrix 10x11 represented by sparse vectors", iterations = 10) {
-      import sqlContext.implicits._
-
-      val numberOfRows = 10
-      val numberOfCols = 11
-      val partitions = 2
-      val rowGenerator = (row: Int) => {
-        new SparseVectorHolder(new SparseVector(numberOfCols, Array(row), Array[Double](row)))
-      }
-      val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
-
-      val hf = hc.asH2OFrame(df)
-      hf.remove()
-    }
+    val hf = hc.asH2OFrame(df)
+    hf.remove()
+  }
 }

--- a/core/src/bench/scala/ai.h2o.sparkling.bench/DataFrameConverterBenchSuite.scala
+++ b/core/src/bench/scala/ai.h2o.sparkling.bench/DataFrameConverterBenchSuite.scala
@@ -20,8 +20,7 @@ package ai.h2o.sparkling.bench
 import ai.h2o.sparkling.utils.schemas._
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.testdata.{DenseVectorHolder, SparseVectorHolder}
-
-import org.apache.spark.h2o.utils.{SharedH2OTestContext, TestFrameUtils}
+import org.apache.spark.h2o.utils.{H2OSchemaUtils, SharedH2OTestContext, TestFrameUtils}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -52,10 +51,49 @@ class DataFrameConverterBenchSuite extends BenchSuite with SharedH2OTestContext 
     testPerSchema(FlatArraysOnlySchema)
   }
 
+  benchTest("Measure performance of flattening a data frame with nested structs") {
+    testflattenOnlyPerSchema(StructsOnlySchema)
+  }
+
+  benchTest("Measure performance of flattening a data frame with flat arrays") {
+    testflattenOnlyPerSchema(FlatArraysOnlySchema)
+  }
+
+  benchTest("Measure performance of flattening a schema with nested structs") {
+    testflattenSchema(StructsOnlySchema)
+  }
+
+  benchTest("Measure performance of flattening a schema with flat arrays") {
+    testflattenSchema(FlatArraysOnlySchema)
+  }
+
+  benchTest("Measure performance of row to schema with nested structs") {
+    rowToSchema(StructsOnlySchema)
+  }
+
+  benchTest("Measure performance of row to schema with flat arrays") {
+    rowToSchema(FlatArraysOnlySchema)
+  }
+
   def testPerSchema(schemaHolder: TestFrameUtils.SchemaHolder): Unit = {
     val df = TestFrameUtils.generateDataFrame(spark, schemaHolder, settings)
     val hf = hc.asH2OFrame(df)
     hf.remove()
+  }
+
+  def testflattenOnlyPerSchema(schemaHolder: TestFrameUtils.SchemaHolder): Unit = {
+    val df = TestFrameUtils.generateDataFrame(spark, schemaHolder, settings)
+    H2OSchemaUtils.flattenDataFrame(df).foreach(_ => {})
+  }
+
+  def testflattenSchema(schemaHolder: TestFrameUtils.SchemaHolder): Unit = {
+    val df = TestFrameUtils.generateDataFrame(spark, schemaHolder, settings)
+    H2OSchemaUtils.flattenSchema(df)
+  }
+
+  def rowToSchema(schemaHolder: TestFrameUtils.SchemaHolder): Unit = {
+    val df = TestFrameUtils.generateDataFrame(spark, schemaHolder, settings)
+    H2OSchemaUtils.rowsToRowSchemas(df).foreach(_ => {})
   }
 
   benchTest("Measure performance of conversion to H2OFrame on a data frame with wide sparse vectors") {

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -51,8 +51,8 @@ private[h2o] object SparkDataFrameConverter extends Logging {
   /** Transform Spark's DataFrame into H2O Frame */
   def toH2OFrame(hc: H2OContext, dataFrame: DataFrame, frameKeyName: Option[String]): H2OFrame = {
     import H2OSchemaUtils._
-    // Flatten the Spark data frame so we don't have any nested rows
-    val flatDataFrame = flattenStructsInDataFrame(dataFrame)
+
+    val flatDataFrame = flattenDataFrame(dataFrame)
     val dfRdd = flatDataFrame.rdd
     val keyName = frameKeyName.getOrElse("frame_rdd_" + dfRdd.id + Key.rand())
 
@@ -71,7 +71,7 @@ private[h2o] object SparkDataFrameConverter extends Logging {
       // Transform datatype into h2o types
       flatRddSchema.map(f => ReflectionUtils.vecTypeFor(f.dataType)).toArray
     } else {
-      val internalJavaClasses = H2OSchemaUtils.expandWithoutVectors(flatDataFrame.schema, elemMaxSizes).map { f =>
+      val internalJavaClasses = flatDataFrame.schema.map { f =>
         ExternalWriteConverterCtx.internalJavaClassOf(f.dataType)
       }.toArray
       ExternalBackendUtils.prepareExpectedTypes(internalJavaClasses)

--- a/core/src/main/scala/org/apache/spark/h2o/utils/DatasetShape.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/DatasetShape.scala
@@ -1,0 +1,23 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.h2o.utils
+
+object DatasetShape extends Enumeration {
+  type DatasetShape = Value
+  val Flat, StructsOnly, Nested = Value
+}

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
@@ -289,9 +289,9 @@ object H2OSchemaUtils {
     val map = data.asInstanceOf[Map[Any, Any]]
     val subRow = Row.fromSeq(map.values.toSeq)
     val result = new ArrayBuffer[FieldWithOrder]()
-    map.foreach { case(key, value) =>
+    map.foreach { case (key, value) =>
       val fieldQualifiedName = getQualifiedName(qualifiedName, key.toString)
-      flattenField(fieldQualifiedName, valueType, nullable, metadata, value, key :: path)
+      result ++= flattenField(fieldQualifiedName, valueType, nullable, metadata, value, key :: path)
     }
     result
   }

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
@@ -112,7 +112,9 @@ object H2OSchemaUtils {
       (qualifiedName: String, dataType: DataType, data: Any) = {
     if (data != null) {
       dataType match {
-        case BinaryType => fillArray(qualifiedName, ByteType, flatSchemaIndexes, buffer, data)
+        case BinaryType =>
+          val binaryData = data.asInstanceOf[Array[Byte]].toSeq
+          fillArray(qualifiedName, ByteType, flatSchemaIndexes, buffer, binaryData)
         case m: MapType => fillMap(qualifiedName, m.valueType, flatSchemaIndexes, buffer, data)
         case a: ArrayType => fillArray(qualifiedName, a.elementType, flatSchemaIndexes, buffer, data)
         case s: StructType => fillStruct(qualifiedName, s.fields, flatSchemaIndexes, buffer, data)
@@ -244,7 +246,8 @@ object H2OSchemaUtils {
     if (data != null) {
       dataType match {
         case BinaryType =>
-          flattenArrayType(qualifiedName, ByteType, nullable, metadata, data, path)
+          val binaryData = data.asInstanceOf[Array[Byte]].toSeq
+          flattenArrayType(qualifiedName, ByteType, nullable, metadata, binaryData, path)
         case MapType(_, valueType, containsNull) =>
           flattenMapType(qualifiedName, valueType, containsNull || nullable, metadata, data, path)
         case ArrayType(elementType, containsNull) =>

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
@@ -188,7 +188,6 @@ object H2OSchemaUtils {
 
   private def mergeRowSchemas(ds: Dataset[ArrayBuffer[FieldWithOrder]]): ArrayBuffer[FieldWithOrder] = ds.reduce {
     (first, second) =>
-
       var fidx = 0
       var sidx = 0
       val result = new ArrayBuffer[FieldWithOrder]()

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OSchemaUtils.scala
@@ -426,7 +426,7 @@ object H2OSchemaUtils {
     *  - all arrays are expanded into columns based on the longest one
     *  - all vectors are expanded into columns based on the longest one
     *
-    * @param flatDataFrame flat data framez
+    * @param flatDataFrame flat data frame
     * @param elemMaxSizes  max sizes of each element in the dataframe
     * @return list of types with their positions
     */

--- a/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
@@ -33,57 +33,6 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
 
   sc = new SparkContext("local[*]", this.getClass.getSimpleName, conf = defaultSparkConf)
 
-  "flattenStructsInSchema" should "flatten a simple schema" in {
-    val expSchema = StructType(
-        StructField("a", IntegerType, true) ::
-        StructField("b", IntegerType, false)
-        :: Nil
-    )
-    val flatSchema = H2OSchemaUtils.flattenStructsInSchema(expSchema)
-    assert (flatSchema.fields === Seq(StructField("a", IntegerType, true), StructField("b", IntegerType, false)))
-  }
-
-  "flattenStructsInSchema" should "flatten a composed schema" in {
-    val expSchema = StructType(
-        StructField("a", StructType(
-          StructField("a1", DoubleType, false)::
-          StructField("a2", StringType, true):: Nil
-        ), true) ::
-        StructField("b", StructType(
-          StructField("b1", DoubleType, false)::
-          StructField("b2", StringType, true):: Nil
-        ), false)
-        :: Nil
-    )
-    val flatSchema = H2OSchemaUtils.flattenStructsInSchema(expSchema)
-    assert (flatSchema.fields === Seq(StructField("a.a1", DoubleType, true),
-                                StructField("a.a2", StringType, true),
-                                StructField("b.b1", DoubleType, false),
-                                StructField("b.b2", StringType, true)))
-  }
-
-  "flattenStructsInSchema" should "be compatible with collectStringIndices" in {
-    val expSchema = StructType(
-      StructField("a", StructType(
-        StructField("a1", DoubleType, false)::
-        StructField("a2", StringType, true):: Nil
-      ), true) ::
-        StructField("b", StructType(
-          StructField("b1", StringType, false)::
-          StructField("b2", StringType, true):: Nil
-        ), false) ::
-        StructField("c", StringType, false)
-        :: Nil
-    )
-
-    val flattenSchema = H2OSchemaUtils.flattenStructsInSchema(expSchema)
-    val stringIndices = H2OSchemaUtils.collectStringIndices(flattenSchema)
-    val arrayIndices = H2OSchemaUtils.collectArrayLikeTypes(flattenSchema)
-
-    assert (stringIndices === List (1, 2, 3, 4))
-    assert (arrayIndices === Nil)
-  }
-
   "flattenDataFrame" should "flatten an array of structs" in {
     import spark.implicits._
 

--- a/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
@@ -60,10 +60,10 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     )
     val flatSchema = H2OSchemaUtils.flattenStructsInSchema(expSchema)
     val expected = Seq(
-      (StructField("a_a1", DoubleType, true), "a.a1"),
-      (StructField("a_a2", StringType, true), "a.a2"),
-      (StructField("b_b1", DoubleType, false), "b.b1"),
-      (StructField("b_b2", StringType, true), "b.b2"))
+      (StructField("a.a1", DoubleType, true), "a.a1"),
+      (StructField("a.a2", StringType, true), "a.a2"),
+      (StructField("b.b1", DoubleType, false), "b.b1"),
+      (StructField("b.b2", StringType, true), "b.b2"))
     assert(flatSchema === expected)
   }
 
@@ -77,7 +77,7 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val expected = Seq[(Integer, Integer, Integer, Integer, Integer, Integer)](
       (1, 2, 3, 4, null, null),
       (1, 2, 3, 4, 5, 6)
-    ).toDF("arr_0__1", "arr_0__2", "arr_1__1", "arr_1__2", "arr_2__1", "arr_2__2")
+    ).toDF("arr.0._1", "arr.0._2", "arr.1._1", "arr.1._2", "arr.2._1", "arr.2._2")
 
     val result = H2OSchemaUtils.flattenDataFrame(input)
 
@@ -95,7 +95,7 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val expected = Seq[(Integer, Integer, Integer, Integer, Integer, Integer)](
       (1, null, 3, 4, 5, null),
       (1, 2, null, null, 5, 6)
-    ).toDF("struct_arr1_0", "struct_arr1_1", "struct_arr2_0", "struct_arr2_1", "struct_arr3_0", "struct_arr3_1")
+    ).toDF("struct.arr1.0", "struct.arr1.1", "struct.arr2.0", "struct.arr2.1", "struct.arr3.0", "struct.arr3.1")
 
     val result = H2OSchemaUtils.flattenDataFrame(input)
 
@@ -113,7 +113,7 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val expected = Seq[(Integer, Integer, Integer, Integer, Integer, Integer, Integer, String)](
       (1 , null, null, null, 3, 4, 5, "extra"),
       (1, 2, 3, 4, 5, 6, null, "extra")
-    ).toDF("arr_0_0", "arr_0_1", "arr_1_0", "arr_1_1", "arr_2_0", "arr_2_1", "arr_2_2", "extra")
+    ).toDF("arr.0.0", "arr.0.1", "arr.1.0", "arr.1.1", "arr.2.0", "arr.2.1", "arr.2.2", "extra")
 
     val result = H2OSchemaUtils.flattenDataFrame(input)
 
@@ -131,7 +131,7 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val expected = Seq[(Integer, Integer, Integer, Integer)](
       (1, null, 3, 4),
       (1, 2, null, 4)
-    ).toDF("struct_struct1__1", "struct_struct1__2", "struct_struct2__1", "struct_struct2__2")
+    ).toDF("struct.struct1._1", "struct.struct1._2", "struct.struct2._1", "struct.struct2._2")
 
     val result = H2OSchemaUtils.flattenDataFrame(input)
 
@@ -149,7 +149,7 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val expected = Seq[(Integer, Integer, Integer, Integer, String)](
       (1, 2, null, null, "extra"),
       (null, 2, 3, 4, "extra")
-    ).toDF("arr_0_a", "arr_0_b", "arr_0_c", "arr_1_a", "extra")
+    ).toDF("arr.0.a", "arr.0.b", "arr.0.c", "arr.1.a", "extra")
 
     val result = H2OSchemaUtils.flattenDataFrame(input)
 
@@ -167,7 +167,7 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val expected = Seq[(Integer, Integer, Integer, Integer, Integer, Integer, String)](
       (1, 2, 3, null, null, null, "extra"),
       (null, null, null, 4, 5, 6, "extra")
-    ).toDF("map_a_0", "map_a_1", "map_b_0", "map_b_1", "map_c_0", "map_c_1", "extra")
+    ).toDF("map.a.0", "map.a.1", "map.b.0", "map.b.1", "map.c.0", "map.c.1", "extra")
 
     val result = H2OSchemaUtils.flattenDataFrame(input)
 
@@ -192,12 +192,12 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val df = spark.createDataFrame(rdd, schema)
 
     val expectedSchema = StructType(
-      StructField("arr_0_a", IntegerType, false) ::
-      StructField("arr_0_b", IntegerType, true) ::
-      StructField("arr_1_a", IntegerType, false) ::
-      StructField("arr_1_b", IntegerType, true) ::
-      StructField("arr_2_a", IntegerType, true) ::
-      StructField("arr_2_b", IntegerType, true) ::
+      StructField("arr.0.a", IntegerType, false) ::
+      StructField("arr.0.b", IntegerType, true) ::
+      StructField("arr.1.a", IntegerType, false) ::
+      StructField("arr.1.b", IntegerType, true) ::
+      StructField("arr.2.a", IntegerType, true) ::
+      StructField("arr.2.b", IntegerType, true) ::
       Nil)
 
     val result = H2OSchemaUtils.flattenSchema(df)
@@ -222,14 +222,14 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val df = spark.createDataFrame(rdd, schema)
 
     val expectedSchema = StructType(
-      StructField("struct_a_0", IntegerType, true) ::
-      StructField("struct_a_1", IntegerType, true) ::
-      StructField("struct_b_0", IntegerType, true) ::
-      StructField("struct_b_1", IntegerType, true) ::
-      StructField("struct_c_0", IntegerType, false) ::
-      StructField("struct_c_1", IntegerType, true) ::
-      StructField("struct_d_0", IntegerType, true) ::
-      StructField("struct_d_1", IntegerType, true) ::
+      StructField("struct.a.0", IntegerType, true) ::
+      StructField("struct.a.1", IntegerType, true) ::
+      StructField("struct.b.0", IntegerType, true) ::
+      StructField("struct.b.1", IntegerType, true) ::
+      StructField("struct.c.0", IntegerType, false) ::
+      StructField("struct.c.1", IntegerType, true) ::
+      StructField("struct.d.0", IntegerType, true) ::
+      StructField("struct.d.1", IntegerType, true) ::
       Nil)
 
     val result = H2OSchemaUtils.flattenSchema(df)
@@ -254,14 +254,14 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val df = spark.createDataFrame(rdd, schema)
 
     val expectedSchema = StructType(
-      StructField("map_a_a", IntegerType, false) ::
-      StructField("map_a_b", IntegerType, true) ::
-      StructField("map_b_a", IntegerType, false) ::
-      StructField("map_b_b", IntegerType, true) ::
-      StructField("map_c_a", IntegerType, true) ::
-      StructField("map_c_b", IntegerType, true) ::
-      StructField("map_d_a", IntegerType, true) ::
-      StructField("map_d_b", IntegerType, true) ::
+      StructField("map.a.a", IntegerType, false) ::
+      StructField("map.a.b", IntegerType, true) ::
+      StructField("map.b.a", IntegerType, false) ::
+      StructField("map.b.b", IntegerType, true) ::
+      StructField("map.c.a", IntegerType, true) ::
+      StructField("map.c.b", IntegerType, true) ::
+      StructField("map.d.a", IntegerType, true) ::
+      StructField("map.d.b", IntegerType, true) ::
       Nil)
 
     val result = H2OSchemaUtils.flattenSchema(df)
@@ -286,15 +286,15 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     val df = spark.createDataFrame(rdd, schema)
 
     val expectedSchema = StructType(
-      StructField("struct_a_a", IntegerType, true) ::
-      StructField("struct_a_b", IntegerType, true) ::
-      StructField("struct_a_c", IntegerType, true) ::
-      StructField("struct_b_d", IntegerType, true) ::
-      StructField("struct_b_e", IntegerType, true) ::
-      StructField("struct_c_f", IntegerType, false) ::
-      StructField("struct_c_g", IntegerType, true) ::
-      StructField("struct_d_h", IntegerType, true) ::
-      StructField("struct_d_i", IntegerType, true) ::
+      StructField("struct.a.a", IntegerType, true) ::
+      StructField("struct.a.b", IntegerType, true) ::
+      StructField("struct.a.c", IntegerType, true) ::
+      StructField("struct.b.d", IntegerType, true) ::
+      StructField("struct.b.e", IntegerType, true) ::
+      StructField("struct.c.f", IntegerType, false) ::
+      StructField("struct.c.g", IntegerType, true) ::
+      StructField("struct.d.h", IntegerType, true) ::
+      StructField("struct.d.i", IntegerType, true) ::
       Nil)
 
     val result = H2OSchemaUtils.flattenSchema(df)

--- a/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
@@ -41,9 +41,9 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     )
     val flatSchema = H2OSchemaUtils.flattenStructsInSchema(expSchema)
     val expected = Seq(
-      StructField("a", IntegerType, true),
-      StructField("b", IntegerType, false))
-    assert (flatSchema.fields === expected)
+      (StructField("a", IntegerType, true), "a"),
+      (StructField("b", IntegerType, false), "b"))
+    assert(flatSchema === expected)
   }
 
   "flattenStructsInSchema" should "flatten a composed schema" in {
@@ -60,11 +60,11 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
     )
     val flatSchema = H2OSchemaUtils.flattenStructsInSchema(expSchema)
     val expected = Seq(
-      StructField("a_a1", DoubleType, true),
-      StructField("a_a2", StringType, true),
-      StructField("b_b1", DoubleType, false),
-      StructField("b_b2", StringType, true))
-    assert (flatSchema.fields === expected)
+      (StructField("a_a1", DoubleType, true), "a.a1"),
+      (StructField("a_a2", StringType, true), "a.a2"),
+      (StructField("b_b1", DoubleType, false), "b.b1"),
+      (StructField("b_b2", StringType, true), "b.b2"))
+    assert(flatSchema === expected)
   }
 
   "flattenDataFrame" should "flatten an array of structs" in {

--- a/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/H2OSchemaUtilsTestSuite.scala
@@ -33,6 +33,40 @@ class H2OSchemaUtilsTestSuite extends FlatSpec with Matchers with SparkTestConte
 
   sc = new SparkContext("local[*]", this.getClass.getSimpleName, conf = defaultSparkConf)
 
+  "flattenStructsInSchema" should "flatten a simple schema" in {
+    val expSchema = StructType(
+      StructField("a", IntegerType, true) ::
+        StructField("b", IntegerType, false)
+        :: Nil
+    )
+    val flatSchema = H2OSchemaUtils.flattenStructsInSchema(expSchema)
+    val expected = Seq(
+      StructField("a", IntegerType, true),
+      StructField("b", IntegerType, false))
+    assert (flatSchema.fields === expected)
+  }
+
+  "flattenStructsInSchema" should "flatten a composed schema" in {
+    val expSchema = StructType(
+      StructField("a", StructType(
+        StructField("a1", DoubleType, false)::
+          StructField("a2", StringType, true):: Nil
+      ), true) ::
+        StructField("b", StructType(
+          StructField("b1", DoubleType, false)::
+            StructField("b2", StringType, true):: Nil
+        ), false)
+        :: Nil
+    )
+    val flatSchema = H2OSchemaUtils.flattenStructsInSchema(expSchema)
+    val expected = Seq(
+      StructField("a_a1", DoubleType, true),
+      StructField("a_a2", StringType, true),
+      StructField("b_b1", DoubleType, false),
+      StructField("b_b2", StringType, true))
+    assert (flatSchema.fields === expected)
+  }
+
   "flattenDataFrame" should "flatten an array of structs" in {
     import spark.implicits._
 

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -468,8 +468,8 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
     val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(flattenDF)
     val expandedSchema = H2OSchemaUtils.expandedSchema(H2OSchemaUtils.flattenSchema(df), maxElementSizes)
     val expected: Vector[StructField] = Vector(
-      StructField("a_n", IntegerType, nullable = false),
-      StructField("a_name", StringType, nullable = true),
+      StructField("a.n", IntegerType, nullable = false),
+      StructField("a.name", StringType, nullable = true),
       StructField("weight", DoubleType, nullable = false))
     Assertions.assertResult(expected.length)(expandedSchema.length)
 
@@ -500,11 +500,11 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
     val metadatas = expandedSchema.map(f => f.metadata)
 
     assert(expandedSchema === Array(
-      (StructField("f_0", IntegerType, nullable = false, metadatas.head)),
-      (StructField("f_1", IntegerType, nullable = true, metadatas(1))),
-      (StructField("f_2", IntegerType, nullable = true, metadatas(2))),
-      (StructField("f_3", IntegerType, nullable = true, metadatas(3))),
-      (StructField("f_4", IntegerType, nullable = true, metadatas(4)))))
+      (StructField("f.0", IntegerType, nullable = false, metadatas.head)),
+      (StructField("f.1", IntegerType, nullable = true, metadatas(1))),
+      (StructField("f.2", IntegerType, nullable = true, metadatas(2))),
+      (StructField("f.3", IntegerType, nullable = true, metadatas(3))),
+      (StructField("f.4", IntegerType, nullable = true, metadatas(4)))))
 
     // Verify transformation into dataframe
     val h2oFrame = hc.asH2OFrame(df)
@@ -785,7 +785,7 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
     val renamedDF = spark.sqlContext.createDataFrame(df.rdd, personSchema)
     val hf = hc.asH2OFrame(renamedDF)
 
-    assert(hf.names() sameElements Array("name_given.name", "name_family", "person.age"))
+    assert(hf.names() sameElements Array("name.given.name", "name.family", "person.age"))
   }
 
   test("Test conversion of frame with high number of columns"){

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -807,7 +807,7 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
 
   def assertH2OFrameInvariants(inputDF: DataFrame, df: H2OFrame): Unit = {
     assert(inputDF.count == df.numRows(), "Number of rows has to match")
-    assert(df.numCols() == H2OSchemaUtils.flattenStructsInSchema(inputDF.schema).length, "Number columns should match")
+    assert(df.numCols() == H2OSchemaUtils.flattenSchema(inputDF).length, "Number columns should match")
   }
 
   def getSchemaInfo(df: DataFrame): (DataFrame, Array[Int], Seq[StructField]) = {

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -464,12 +464,12 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
     ))
     val df = spark.createDataFrame(rdd, schema)
 
-    val flattenDF = H2OSchemaUtils.flattenStructsInDataFrame(df)
+    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
     val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(flattenDF)
-    val expandedSchema = H2OSchemaUtils.expandedSchema(H2OSchemaUtils.flattenStructsInSchema(df.schema), maxElementSizes)
+    val expandedSchema = H2OSchemaUtils.expandedSchema(H2OSchemaUtils.flattenSchema(df), maxElementSizes)
     val expected: Vector[StructField] = Vector(
-      StructField("a.n", IntegerType, nullable = false),
-      StructField("a.name", StringType, nullable = true),
+      StructField("a_n", IntegerType, nullable = false),
+      StructField("a_name", StringType, nullable = true),
       StructField("weight", DoubleType, nullable = false))
     Assertions.assertResult(expected.length)(expandedSchema.length)
 

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -490,21 +490,21 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
   }
 
   test("Expand schema with array") {
-    import spark.implicits._
     val num = 5
-    val values = (1 to num).map(x => PrimitiveB(1 to x))
-    val df = sc.parallelize(values).toDF
+    val rdd = sc.parallelize(1 to num).map(x => Row(1 to x))
+    val schema = StructType(StructField("f", ArrayType(IntegerType, containsNull = false), nullable = false) :: Nil)
+    val df = spark.createDataFrame(rdd, schema)
 
     val (flattenDF, maxElementSizes, expandedSchema) = getSchemaInfo(df)
 
     val metadatas = expandedSchema.map(f => f.metadata)
 
-    assert(expandedSchema === Vector(
-      (StructField("f0", IntegerType, nullable = false, metadatas.head)),
-      (StructField("f1", IntegerType, nullable = false, metadatas(1))),
-      (StructField("f2", IntegerType, nullable = false, metadatas(2))),
-      (StructField("f3", IntegerType, nullable = false, metadatas(3))),
-      (StructField("f4", IntegerType, nullable = false, metadatas(4)))))
+    assert(expandedSchema === Array(
+      (StructField("f_0", IntegerType, nullable = false, metadatas.head)),
+      (StructField("f_1", IntegerType, nullable = true, metadatas(1))),
+      (StructField("f_2", IntegerType, nullable = true, metadatas(2))),
+      (StructField("f_3", IntegerType, nullable = true, metadatas(3))),
+      (StructField("f_4", IntegerType, nullable = true, metadatas(4)))))
 
     // Verify transformation into dataframe
     val h2oFrame = hc.asH2OFrame(df)
@@ -785,7 +785,7 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
     val renamedDF = spark.sqlContext.createDataFrame(df.rdd, personSchema)
     val hf = hc.asH2OFrame(renamedDF)
 
-    assert(hf.names() sameElements Array("name.given.name", "name.family", "person.age"))
+    assert(hf.names() sameElements Array("name_given.name", "name_family", "person.age"))
   }
 
   test("Test conversion of frame with high number of columns"){
@@ -811,9 +811,9 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
   }
 
   def getSchemaInfo(df: DataFrame): (DataFrame, Array[Int], Seq[StructField]) = {
-    val flattenDF = H2OSchemaUtils.flattenStructsInDataFrame(df)
+    val flattenDF = H2OSchemaUtils.flattenDataFrame(df)
     val maxElementSizes = H2OSchemaUtils.collectMaxElementSizes(flattenDF)
-    val expandedSchema = H2OSchemaUtils.expandedSchema(H2OSchemaUtils.flattenStructsInSchema(df.schema), maxElementSizes)
+    val expandedSchema = H2OSchemaUtils.expandedSchema(H2OSchemaUtils.flattenSchema(df), maxElementSizes)
     (flattenDF, maxElementSizes, expandedSchema)
   }
 }

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModel.scala
@@ -157,12 +157,7 @@ class H2OMOJOModel(override val uid: String) extends H2OMOJOModelBase[H2OMOJOMod
 
   override def copy(extra: ParamMap): H2OMOJOModel = defaultCopy(extra)
 
-  override def transform(dataset: Dataset[_]): DataFrame = {
-    val flattenedDF = H2OSchemaUtils.flattenDataFrame(dataset.toDF())
-    val relevantColumnNames = flattenedDF.columns.intersect(getFeaturesCols())
-    val args = relevantColumnNames.map(flattenedDF(_))
-    flattenedDF.withColumn(getPredictionCol(), getModelUdf()(struct(args: _*)))
-  }
+  override def transform(dataset: Dataset[_]): DataFrame = applyPredictionUdf(dataset, _ => getModelUdf())
 }
 
 

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModel.scala
@@ -158,7 +158,7 @@ class H2OMOJOModel(override val uid: String) extends H2OMOJOModelBase[H2OMOJOMod
   override def copy(extra: ParamMap): H2OMOJOModel = defaultCopy(extra)
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-    val flattenedDF = H2OSchemaUtils.flattenStructsInDataFrame(dataset.toDF())
+    val flattenedDF = H2OSchemaUtils.flattenDataFrame(dataset.toDF())
     val relevantColumnNames = flattenedDF.columns.intersect(getFeaturesCols())
     val args = relevantColumnNames.map(flattenedDF(_))
     flattenedDF.withColumn(getPredictionCol(), getModelUdf()(struct(args: _*)))

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModelBase.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModelBase.scala
@@ -18,10 +18,14 @@
 package org.apache.spark.ml.h2o.models
 
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.h2o.utils.H2OSchemaUtils
 import org.apache.spark.ml.h2o.param.H2OMOJOModelParams
 import org.apache.spark.ml.util.{MLWritable, MLWriter}
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.ml.{Model => SparkModel}
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions._
 
 abstract class H2OMOJOModelBase[T <: SparkModel[T]]
   extends SparkModel[T] with H2OMOJOModelParams with MLWritable with HasMojoData {
@@ -37,4 +41,30 @@ abstract class H2OMOJOModelBase[T <: SparkModel[T]]
   }
 
   override def write: MLWriter = new H2OMOJOWriter(this, getMojoData)
+
+  protected def applyPredictionUdf(
+      dataset: Dataset[_],
+      udfConstructor: Array[String] => UserDefinedFunction): DataFrame = {
+    val originalDF = dataset.toDF()
+    if (H2OSchemaUtils.isSchemaFlat(originalDF.schema)) {
+      applyPredictionUdfToFlatDataFrame(originalDF, udfConstructor)
+    } else {
+      val temporaryIdColumnName = "SparklingWater_MOJO_temporary_id_for_join"
+      val withIdentifierDF = originalDF.withColumn(temporaryIdColumnName, monotonically_increasing_id()).cache()
+      val flattenedDF = H2OSchemaUtils.flattenDataFrame(withIdentifierDF)
+      val flatWithPredictionsDF = applyPredictionUdfToFlatDataFrame(flattenedDF, udfConstructor)
+      val predictionsOnlyDF = flatWithPredictionsDF.select(temporaryIdColumnName, getPredictionCol())
+      val joinedDF = withIdentifierDF.join(predictionsOnlyDF, temporaryIdColumnName :: Nil, joinType = "left")
+      joinedDF.drop(temporaryIdColumnName)
+    }
+  }
+
+  private def applyPredictionUdfToFlatDataFrame(
+      flatDataFrame: DataFrame,
+      udfConstructor: Array[String] => UserDefinedFunction): DataFrame = {
+    val relevantColumnNames = flatDataFrame.columns.intersect(getFeaturesCols())
+    val args = relevantColumnNames.map(flatDataFrame(_))
+    val udf = udfConstructor(relevantColumnNames)
+    flatDataFrame.withColumn(getPredictionCol(), udf(struct(args: _*)))
+  }
 }

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModelBase.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOModelBase.scala
@@ -53,7 +53,7 @@ abstract class H2OMOJOModelBase[T <: SparkModel[T]]
         val flattenedDF = H2OSchemaUtils.appendFlattenedStructsToDataFrame(originalDF, RowConverter.temporaryColumnPrefix)
         val flatWithPredictionsDF = applyPredictionUdfToFlatDataFrame(flattenedDF, udfConstructor)
         flatWithPredictionsDF.schema.foldLeft(flatWithPredictionsDF) { (df, field) =>
-          if(field.name.startsWith(RowConverter.temporaryColumnPrefix)) df.drop(field.name) else df
+          if (field.name.startsWith(RowConverter.temporaryColumnPrefix)) df.drop(field.name) else df
         }
     }
   }

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
@@ -125,7 +125,6 @@ class H2OMOJOPipelineModel(override val uid: String) extends H2OMOJOModelBase[H2
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-    // get the altered frame
     val frameWithPredictions = applyPredictionUdf(dataset, modelUdf)
 
     val fr = if (getNamedMojoOutputColumns()) {

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
@@ -125,7 +125,7 @@ class H2OMOJOPipelineModel(override val uid: String) extends H2OMOJOModelBase[H2
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-    val flattenedDF = H2OSchemaUtils.flattenStructsInDataFrame(dataset.toDF())
+    val flattenedDF = H2OSchemaUtils.flattenDataFrame(dataset.toDF())
     val relevantColumnNames = flattenedDF.columns.intersect(getFeaturesCols())
     val args = relevantColumnNames.map(flattenedDF(_))
 

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/models/H2OMOJOPipelineModel.scala
@@ -125,12 +125,8 @@ class H2OMOJOPipelineModel(override val uid: String) extends H2OMOJOModelBase[H2
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-    val flattenedDF = H2OSchemaUtils.flattenDataFrame(dataset.toDF())
-    val relevantColumnNames = flattenedDF.columns.intersect(getFeaturesCols())
-    val args = relevantColumnNames.map(flattenedDF(_))
-
     // get the altered frame
-    val frameWithPredictions = flattenedDF.withColumn(getPredictionCol(), modelUdf(relevantColumnNames)(struct(args: _*)))
+    val frameWithPredictions = applyPredictionUdf(dataset, modelUdf)
 
     val fr = if (getNamedMojoOutputColumns()) {
 

--- a/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMojoModelTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMojoModelTest.scala
@@ -143,7 +143,6 @@ class H2OMojoModelTest extends FunSuite with SharedH2OTestContext with Matchers 
 
   test("DataFrame contains structs") {
     import spark.implicits._
-    val gbm = configureGBMforProstateDF()
 
     val structuredDF = prostateDataFrame.select(
       'ID,


### PR DESCRIPTION
Original performance:
```
Measure performance of conversion to H2OFrame on a flat data frame: 1021.000000 ± 448.612305 (526.000000, 1512.000000)
Measure performance of conversion to H2OFrame on a data frame with nested structs: 1318.199951 ± 299.074738 (1013.000000, 1774.000000)
Measure performance of conversion to H2OFrame on a data frame with flat arrays: 4314.600098 ± 1080.290405 (3613.000000, 6139.000000)
Measure performance of conversion to H2OFrame on a data frame with wide sparse vectors: 44770.800781 ± 3306.025635 (41178.000000, 49193.000000)
Measure performance of conversion to H2OFrame on a data frame with wide dense vectors: 8320.400391 ± 385.206177 (7841.000000, 8870.000000)
Measure performance of conversion to H2OFrame on a matrix 10x11 represented by sparse vectors: 110.099998 ± 16.134504 (84.000000, 134.000000)
```

New performance:
```
Measure performance of conversion to H2OFrame on a flat data frame: 476.200012 ± 180.286438 (327.000000, 745.000000)
Measure performance of conversion to H2OFrame on a data frame with nested structs: 1106.800049 ± 169.364105 (955.000000, 1334.000000)
Measure performance of conversion to H2OFrame on a data frame with flat arrays: 7653.600098 ± 1384.298706 (6505.000000, 9365.000000)
Measure performance of conversion to H2OFrame on a data frame with wide sparse vectors: 40712.199219 ± 2861.103760 (38700.000000, 45742.000000)
Measure performance of conversion to H2OFrame on a data frame with wide dense vectors: 6805.799805 ± 327.368591 (6516.000000, 7342.000000)
Measure performance of conversion to H2OFrame on a matrix 10x11 represented by sparse vectors: 73.900002 ± 9.848294 (67.000000, 99.000000)
```

More details:
```
Measure performance of flattening a data frame with nested structs: 745.200012 ± 9.011105 (736.000000, 760.000000)
Measure performance of flattening a data frame with flat arrays: 4380.799805 ± 821.219910 (3925.000000, 5844.000000)
Measure performance of flattening a schema with nested structs: 538.000000 ± 111.377739 (450.000000, 727.000000)
Measure performance of flattening a schema with flat arrays: 1905.199951 ± 28.674030 (1877.000000, 1951.000000)
Measure performance of row to schema with nested structs: 423.799988 ± 14.202112 (411.000000, 448.000000)
Measure performance of row to schema with flat arrays: 1784.800049 ± 167.281799 (1625.000000, 2069.000000)
```