### PR TITLE
[SW-1439] [Prototype] Switch to using String value on the setters & getters in the ml API ( just on distribution param so far)

### DIFF
--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParams.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParams.scala
@@ -78,8 +78,7 @@ trait H2OAlgoParams[P <: Parameters] extends H2OAlgoParamsHelper[P] with H2OComm
   def setDistribution(value: DistributionFamily): this.type = setDistribution(value.name())
 
   def setDistribution(value: String): this.type = {
-    checkAllowedEnumValues[DistributionFamily](value)
-    set(distribution, getCorrectEnumCase[DistributionFamily](value))
+    set(distribution, getValidatedEnumValue[DistributionFamily](value))
   }
 
   /** Update H2O params based on provided parameters to Spark Transformer/Estimator */

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParams.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParams.scala
@@ -16,6 +16,7 @@
 */
 package org.apache.spark.ml.h2o.param
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import hex.Model.Parameters
 import hex.genmodel.utils.DistributionFamily
 import org.apache.spark.ml.param.Params
@@ -36,7 +37,7 @@ trait H2OAlgoParams[P <: Parameters] extends H2OAlgoParamsHelper[P] with H2OComm
   private val keepCrossValidationPredictions = booleanParam("keepCrossValidationPredictions")
   private val keepCrossValidationFoldAssignment = booleanParam("keepCrossValidationFoldAssignment")
   private val parallelizeCrossValidation = booleanParam("parallelizeCrossValidation")
-  private val distribution = H2ODistributionParam("distribution")
+  private val distribution = stringParam("distribution")
 
   //
   // Default values
@@ -46,7 +47,7 @@ trait H2OAlgoParams[P <: Parameters] extends H2OAlgoParamsHelper[P] with H2OComm
     keepCrossValidationPredictions -> parameters._keep_cross_validation_predictions,
     keepCrossValidationFoldAssignment -> parameters._keep_cross_validation_fold_assignment,
     parallelizeCrossValidation -> parameters._parallelize_cross_validation,
-    distribution -> parameters._distribution
+    distribution -> parameters._distribution.name()
   )
 
   //
@@ -60,7 +61,7 @@ trait H2OAlgoParams[P <: Parameters] extends H2OAlgoParamsHelper[P] with H2OComm
 
   def getParallelizeCrossValidation(): Boolean = $(parallelizeCrossValidation)
 
-  def getDistribution(): DistributionFamily = $(distribution)
+  def getDistribution(): String = $(distribution)
 
   //
   // Setters
@@ -73,10 +74,12 @@ trait H2OAlgoParams[P <: Parameters] extends H2OAlgoParamsHelper[P] with H2OComm
 
   def setParallelizeCrossValidation(value: Boolean): this.type = set(parallelizeCrossValidation, value)
 
-  def setDistribution(value: DistributionFamily): this.type = set(distribution, value)
+  @DeprecatedMethod("setDistribution(value: String)")
+  def setDistribution(value: DistributionFamily): this.type = setDistribution(value.name())
 
-  def H2ODistributionParam(name: String): H2ODistributionParam = {
-    new H2ODistributionParam(this, name, getDoc(None, name))
+  def setDistribution(value: String): this.type = {
+    checkAllowedEnumValues[DistributionFamily](value, nullAllowed = false)
+    set(distribution, value)
   }
 
   /** Update H2O params based on provided parameters to Spark Transformer/Estimator */
@@ -89,12 +92,6 @@ trait H2OAlgoParams[P <: Parameters] extends H2OAlgoParamsHelper[P] with H2OComm
     parameters._keep_cross_validation_fold_assignment = $(keepCrossValidationFoldAssignment)
     parameters._parallelize_cross_validation = $(parallelizeCrossValidation)
     parameters._seed = getSeed()
-    parameters._distribution = $(distribution)
+    parameters._distribution = DistributionFamily.valueOf(getDistribution())
   }
-}
-
-class H2ODistributionParam(parent: Params, name: String, doc: String, isValid: DistributionFamily => Boolean)
-  extends EnumParam[DistributionFamily](parent, name, doc) {
-
-  def this(parent: Params, name: String, doc: String) = this(parent, name, doc, _ => true)
 }

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParams.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParams.scala
@@ -78,8 +78,8 @@ trait H2OAlgoParams[P <: Parameters] extends H2OAlgoParamsHelper[P] with H2OComm
   def setDistribution(value: DistributionFamily): this.type = setDistribution(value.name())
 
   def setDistribution(value: String): this.type = {
-    checkAllowedEnumValues[DistributionFamily](value, nullAllowed = false)
-    set(distribution, value)
+    checkAllowedEnumValues[DistributionFamily](value)
+    set(distribution, getCorrectEnumCase[DistributionFamily](value))
   }
 
   /** Update H2O params based on provided parameters to Spark Transformer/Estimator */

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
@@ -145,7 +145,7 @@ trait H2OAlgoParamsHelper[P <: Parameters] extends Params {
     }
   }
 
-  // Expects that checkAllowedEnumValues was called before this method
+  // Expects that checkAllowedEnumValues method was called before this method
   protected def getCorrectEnumCase[T <: Enum[T]](name: String)
                                                 (implicit ctag: reflect.ClassTag[T]): String = {
     val names = ctag.runtimeClass.getDeclaredMethod("values").invoke(null).asInstanceOf[Array[T]].map(_.name())

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
@@ -132,10 +132,29 @@ trait H2OAlgoParamsHelper[P <: Parameters] extends Params {
 
   protected def checkAllowedEnumValues[T <: Enum[T]](name: String, nullAllowed: Boolean = false)
                                                     (implicit ctag: reflect.ClassTag[T]): Unit = {
+
     val names = ctag.runtimeClass.getDeclaredMethod("values").invoke(null).asInstanceOf[Array[T]].map(_.name())
-    if (name == null && !nullAllowed || !names.contains(name)) {
+
+    if (!nullAllowed && name == null) {
+      throw new IllegalArgumentException(s"Null is not a valid value. Allowed values are: ${names.mkString(", ")}")
+    }
+
+    if (!names.map(_.toLowerCase()).contains(name.toLowerCase())) {
       val nullStr = if (nullAllowed) "null or " else ""
       throw new IllegalArgumentException(s"'$name' is not a valid value. Allowed values are: $nullStr${names.mkString(", ")}")
     }
   }
+
+  // Expects that checkAllowedEnumValues was called before this method
+  protected def getCorrectEnumCase[T <: Enum[T]](name: String)
+                                                (implicit ctag: reflect.ClassTag[T]): String = {
+    val names = ctag.runtimeClass.getDeclaredMethod("values").invoke(null).asInstanceOf[Array[T]].map(_.name())
+
+    if (name == null) {
+      null
+    } else {
+      names.find(_.toLowerCase() == name.toLowerCase).get
+    }
+  }
+
 }

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
@@ -20,10 +20,6 @@ import com.google.common.base.CaseFormat
 import hex.Model.Parameters
 import org.apache.spark.h2o.utils.ReflectionUtils.api
 import org.apache.spark.ml.param._
-import org.json4s.JsonAST.JArray
-import org.json4s.jackson.JsonMethods.{compact, parse, render}
-import org.json4s.{JDouble, JNull, JString}
-
 
 import scala.reflect.ClassTag
 
@@ -132,5 +128,14 @@ trait H2OAlgoParamsHelper[P <: Parameters] extends Params {
 
   protected def nullableStringArrayParam(name: String, doc: Option[String] = None): NullableStringArrayParam = {
     new NullableStringArrayParam(this, name, getDoc(doc, name))
+  }
+
+  protected def checkAllowedEnumValues[T <: Enum[T]](name: String, nullAllowed: Boolean = false)
+                                                    (implicit ctag: reflect.ClassTag[T]): Unit = {
+    val names = ctag.runtimeClass.getDeclaredMethod("values").invoke(null).asInstanceOf[Array[T]].map(_.name())
+    if (name == null && !nullAllowed || !names.contains(name)) {
+      val nullStr = if (nullAllowed) "null or " else ""
+      throw new IllegalArgumentException(s"'$name' is not a valid value. Allowed values are: $nullStr${names.mkString(", ")}")
+    }
   }
 }

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
@@ -130,13 +130,13 @@ trait H2OAlgoParamsHelper[P <: Parameters] extends Params {
     new NullableStringArrayParam(this, name, getDoc(doc, name))
   }
 
-  def getValidatedEnumValue[T <: Enum[T]](name: String, nullAllowed: Boolean = false)
+  protected def getValidatedEnumValue[T <: Enum[T]](name: String, nullAllowed: Boolean = false)
                                          (implicit ctag: reflect.ClassTag[T]): String = {
     H2OAlgoParamsHelper.getValidatedEnumValue(name, nullAllowed)
   }
 }
 
-object H2OAlgoParamsHelper {
+private[param] object H2OAlgoParamsHelper {
   def getValidatedEnumValue[T <: Enum[T]](name: String, nullAllowed: Boolean = false)
                                          (implicit ctag: reflect.ClassTag[T]): String = {
 

--- a/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelper.scala
@@ -131,16 +131,23 @@ trait H2OAlgoParamsHelper[P <: Parameters] extends Params {
   }
 
   protected def getValidatedEnumValue[T <: Enum[T]](name: String, nullAllowed: Boolean = false)
-                                         (implicit ctag: reflect.ClassTag[T]): String = {
+                                                   (implicit ctag: reflect.ClassTag[T]): String = {
     H2OAlgoParamsHelper.getValidatedEnumValue(name, nullAllowed)
   }
 }
 
-private[param] object H2OAlgoParamsHelper {
+object H2OAlgoParamsHelper {
   def getValidatedEnumValue[T <: Enum[T]](name: String, nullAllowed: Boolean = false)
                                          (implicit ctag: reflect.ClassTag[T]): String = {
+    getValidatedEnumValue(ctag.runtimeClass, name, nullAllowed)
+  }
 
-    val names = ctag.runtimeClass.getDeclaredMethod("values").invoke(null).asInstanceOf[Array[T]].map(_.name())
+  def getValidatedEnumValue(className: String, name: String, nullAllowed: Boolean): String = {
+    getValidatedEnumValue(Class.forName(className), name, nullAllowed)
+  }
+
+  def getValidatedEnumValue(clazz: Class[_], name: String, nullAllowed: Boolean): String = {
+    val names = clazz.getDeclaredMethod("values").invoke(null).asInstanceOf[Array[Enum[_]]].map(_.name())
 
     if (!nullAllowed && name == null) {
       throw new IllegalArgumentException(s"Null is not a valid value. Allowed values are: ${names.mkString(", ")}")
@@ -154,4 +161,5 @@ private[param] object H2OAlgoParamsHelper {
     }
     names.find(_.toLowerCase() == name.toLowerCase).get
   }
+
 }

--- a/ml/src/test/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelperTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelperTest.scala
@@ -1,3 +1,20 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 package org.apache.spark.ml.h2o.param
 
 import hex.genmodel.utils.DistributionFamily
@@ -24,8 +41,8 @@ class H2OAlgoParamsHelperTest extends FunSuite with Matchers {
   }
 
   test("getValidatedEnumValue with null") {
-      val ret = getValidatedEnumValue[DistributionFamily](null, nullAllowed = true)
-      assert(ret == null)
+    val ret = getValidatedEnumValue[DistributionFamily](null, nullAllowed = true)
+    assert(ret == null)
   }
 
   test("getValidatedEnumValue with valid enum value") {

--- a/ml/src/test/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelperTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/h2o/param/H2OAlgoParamsHelperTest.scala
@@ -1,0 +1,40 @@
+package org.apache.spark.ml.h2o.param
+
+import hex.genmodel.utils.DistributionFamily
+import org.apache.spark.ml.h2o.param.H2OAlgoParamsHelper.getValidatedEnumValue
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FunSuite, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class H2OAlgoParamsHelperTest extends FunSuite with Matchers {
+
+  test("getValidatedEnumValue with unknown enum") {
+    val thrown = intercept[IllegalArgumentException] {
+      getValidatedEnumValue[DistributionFamily]("not_exist")
+    }
+    assert(thrown.getMessage.startsWith("'not_exist' is not a valid value. Allowed values are:"))
+  }
+
+  test("getValidatedEnumValue with null, but null not allowed") {
+    val thrown = intercept[IllegalArgumentException] {
+      getValidatedEnumValue[DistributionFamily](null)
+    }
+    assert(thrown.getMessage.startsWith("Null is not a valid value. Allowed values are:"))
+  }
+
+  test("getValidatedEnumValue with null") {
+      val ret = getValidatedEnumValue[DistributionFamily](null, nullAllowed = true)
+      assert(ret == null)
+  }
+
+  test("getValidatedEnumValue with valid enum value") {
+    val ret = getValidatedEnumValue[DistributionFamily]("gaussian")
+    assert(ret == "gaussian")
+  }
+
+  test("getValidatedEnumValue with valid enum value, different case then the enum") {
+    val ret = getValidatedEnumValue[DistributionFamily]("gAuSsiAn")
+    assert(ret == "gaussian")
+  }
+}

--- a/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMojoModelTest.scala
+++ b/ml/src/test/scala/org/apache/spark/ml/spark/models/H2OMojoModelTest.scala
@@ -192,7 +192,7 @@ class H2OMojoModelTest extends FunSuite with SharedH2OTestContext with Matchers 
     new H2OGBM()
       .setNtrees(2)
       .setSeed(42)
-      .setDistribution(DistributionFamily.bernoulli)
+      .setDistribution("bernoulli")
       .setLabelCol("CAPSULE")
   }
 
@@ -246,7 +246,7 @@ class H2OMojoModelTest extends FunSuite with SharedH2OTestContext with Matchers 
     val gbm = new H2OGBM()
       .setNtrees(2)
       .setSeed(42)
-      .setDistribution(DistributionFamily.bernoulli)
+      .setDistribution("bernoulli")
       .setLabelCol("capsule")
 
     (inputDf, gbm.fit(inputDf))
@@ -257,7 +257,7 @@ class H2OMojoModelTest extends FunSuite with SharedH2OTestContext with Matchers 
     val gbm = new H2OGBM()
       .setNtrees(2)
       .setSeed(42)
-      .setDistribution(DistributionFamily.multinomial)
+      .setDistribution("multinomial")
       .setLabelCol("class")
 
     (inputDf, gbm.fit(inputDf))

--- a/py/py_sparkling/ml/algos.py
+++ b/py/py_sparkling/ml/algos.py
@@ -44,7 +44,7 @@ class H2OGBM(H2OGBMParams, JavaEstimator, JavaH2OMLReadable, JavaMLWritable):
 
         self._setDefault(modelId=None, splitRatio=1.0, labelCol="label", weightCol=None, featuresCols=[], allStringColumnsToCategorical=True, columnsToCategorical=[],
                          nfolds=0, keepCrossValidationPredictions=False, keepCrossValidationFoldAssignment=False, parallelizeCrossValidation=True,
-                         seed=-1, distribution=self._hc._jvm.hex.genmodel.utils.DistributionFamily.valueOf("AUTO"),
+                         seed=-1, distribution="AUTO",
                          ntrees=50, maxDepth=5, minRows=10.0, nbins=20, nbinsCats=1024, minSplitImprovement=1e-5,
                          histogramType=self._hc._jvm.hex.tree.SharedTreeModel.SharedTreeParameters.HistogramType.valueOf("AUTO"),
                          r2Stopping=self._hc._jvm.Double.MAX_VALUE, nbinsTopLevel=1<<10, buildTreeOneNode=False, scoreTreeInterval=0,
@@ -65,8 +65,6 @@ class H2OGBM(H2OGBMParams, JavaEstimator, JavaH2OMLReadable, JavaMLWritable):
                   predNoiseBandwidth=0.0, convertUnknownCategoricalLevelsToNa=False, foldCol=None, **deprecatedArgs):
         kwargs = get_input_kwargs(self)
 
-        if "distribution" in kwargs:
-            kwargs["distribution"] = self._hc._jvm.hex.genmodel.utils.DistributionFamily.valueOf(kwargs["distribution"])
         if "histogramType" in kwargs:
             kwargs["histogramType"] = self._hc._jvm.hex.tree.SharedTreeModel.SharedTreeParameters.HistogramType.valueOf(kwargs["histogramType"])
 
@@ -99,7 +97,7 @@ class H2ODeepLearning(H2ODeepLearningParams, JavaEstimator, JavaH2OMLReadable, J
 
         self._setDefault(modelId=None, splitRatio=1.0, labelCol="label", weightCol=None, featuresCols=[], allStringColumnsToCategorical=True, columnsToCategorical=[],
                          nfolds=0, keepCrossValidationPredictions=False, keepCrossValidationFoldAssignment=False, parallelizeCrossValidation=True,
-                         seed=-1, distribution=self._hc._jvm.hex.genmodel.utils.DistributionFamily.valueOf("AUTO"),
+                         seed=-1, distribution="AUTO",
                          epochs=10.0, l1=0.0, l2=0.0, hidden=[200,200], reproducible=False, convertUnknownCategoricalLevelsToNa=False,
                          foldCol=None)
         kwargs = get_input_kwargs(self)
@@ -111,9 +109,6 @@ class H2ODeepLearning(H2ODeepLearningParams, JavaEstimator, JavaH2OMLReadable, J
                   seed=-1, distribution="AUTO", epochs=10.0, l1=0.0, l2=0.0, hidden=[200,200], reproducible=False, convertUnknownCategoricalLevelsToNa=False,
                   foldCol=None, **deprecatedArgs):
         kwargs = get_input_kwargs(self)
-
-        if "distribution" in kwargs:
-            kwargs["distribution"] = self._hc._jvm.hex.genmodel.utils.DistributionFamily.valueOf(kwargs["distribution"])
 
         # we need to convert double arguments manually to floats as if we assign integer to double, py4j thinks that
         # the whole type is actually int and we get class cast exception
@@ -208,7 +203,7 @@ class H2OXGBoost(H2OXGBoostParams, JavaEstimator, JavaH2OMLReadable, JavaMLWrita
 
         self._setDefault(modelId=None, splitRatio=1.0, labelCol="label", weightCol=None, featuresCols=[], allStringColumnsToCategorical=True, columnsToCategorical=[],
                          nfolds=0, keepCrossValidationPredictions=False, keepCrossValidationFoldAssignment=False, parallelizeCrossValidation=True,
-                         seed=-1, distribution=self._hc._jvm.hex.genmodel.utils.DistributionFamily.valueOf("AUTO"), convertUnknownCategoricalLevelsToNa=False,
+                         seed=-1, distribution="AUTO", convertUnknownCategoricalLevelsToNa=False,
                          quietMode=True, missingValuesHandling=None, ntrees=50, nEstimators=0, maxDepth=6, minRows=1.0, minChildWeight=1.0,
                          learnRate=0.3, eta=0.3, learnRateAnnealing=1.0, sampleRate=1.0, subsample=1.0, colSampleRate=1.0, colSampleByLevel=1.0,
                          colSampleRatePerTree=1.0, colsampleBytree=1.0, maxAbsLeafnodePred=0.0, maxDeltaStep=0.0, scoreTreeInterval=0,
@@ -241,9 +236,6 @@ class H2OXGBoost(H2OXGBoostParams, JavaEstimator, JavaH2OMLReadable, JavaMLWrita
                   normalizeType="tree", rateDrop=0.0, oneDrop=False, skipDrop=0.0, gpuId=0, backend="auto",
                   foldCol=None, **deprecatedArgs):
         kwargs = get_input_kwargs(self)
-
-        if "distribution" in kwargs:
-            kwargs["distribution"] = self._hc._jvm.hex.genmodel.utils.DistributionFamily.valueOf(kwargs["distribution"])
 
         if "treeMethod" in kwargs:
             kwargs["treeMethod"] = self._hc._jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.TreeMethod.valueOf(kwargs["treeMethod"])
@@ -296,7 +288,7 @@ class H2OGLM(H2OGLMParams, JavaEstimator, JavaH2OMLReadable, JavaMLWritable):
 
         self._setDefault(modelId=None, splitRatio=1.0, labelCol="label", weightCol=None,  featuresCols=[], allStringColumnsToCategorical=True, columnsToCategorical=[],
                          nfolds=0, keepCrossValidationPredictions=False, keepCrossValidationFoldAssignment=False, parallelizeCrossValidation=True,
-                         seed=-1, distribution=self._hc._jvm.hex.genmodel.utils.DistributionFamily.valueOf("AUTO"),
+                         seed=-1, distribution="AUTO",
                          convertUnknownCategoricalLevelsToNa=False,
                          standardize=True, family=self._hc._jvm.hex.glm.GLMModel.GLMParameters.Family.valueOf("gaussian"),
                          link=self._hc._jvm.hex.glm.GLMModel.GLMParameters.Link.valueOf("family_default"),
@@ -321,9 +313,6 @@ class H2OGLM(H2OGLMParams, JavaEstimator, JavaH2OMLReadable, JavaMLWritable):
                   gradientEpsilon=-1.0, objReg=-1.0, computePValues=False, removeCollinearCols=False,
                   interactions=None, interactionPairs=None, earlyStopping=True, foldCol=None, **deprecatedArgs):
         kwargs = get_input_kwargs(self)
-
-        if "distribution" in kwargs:
-            kwargs["distribution"] = self._hc._jvm.hex.genmodel.utils.DistributionFamily.valueOf(kwargs["distribution"])
 
         if "family" in kwargs:
             kwargs["family"] = self._hc._jvm.hex.glm.GLMModel.GLMParameters.Family.valueOf(kwargs["family"])

--- a/py/py_sparkling/ml/util.py
+++ b/py/py_sparkling/ml/util.py
@@ -1,5 +1,11 @@
 from pyspark.ml.util import JavaMLReader, MLReadable
+from pysparkling.context import H2OContext
+from pyspark.sql import SparkSession
 
+def getValidatedEnumValue(enumClass, name, nullEnabled = False):
+    jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
+    package = getattr(jvm.org.apache.spark.ml.h2o.param, "H2OAlgoParamsHelper$")
+    return package.__getattr__("MODULE$").getValidatedEnumValue(enumClass, name, nullEnabled)
 
 def get_correct_case_enum(enum_values, enum_single_value):
     for a in enum_values:

--- a/py/pysparkling/ml/params.py
+++ b/py/pysparkling/ml/params.py
@@ -166,7 +166,9 @@ class H2OAlgorithmParams(H2OCommonParams):
 
     def setDistribution(self, value):
         assert_is_type(value, Enum("AUTO", "bernoulli", "quasibinomial", "modified_huber", "multinomial", "ordinal", "gaussian", "poisson", "gamma", "tweedie", "huber", "laplace", "quantile"))
-        return self._set(distribution=value)
+        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
+        correct_case_value = get_correct_case_enum(jvm.hex.genmodel.utils.DistributionFamily.values(), value)
+        return self._set(distribution=correct_case_value)
 
 
 class H2OSharedTreeParams(H2OAlgorithmParams):

--- a/py/pysparkling/ml/params.py
+++ b/py/pysparkling/ml/params.py
@@ -1,10 +1,10 @@
-from pyspark.ml.param import *
 from h2o.utils.typechecks import assert_is_type, Enum
-from pysparkling.context import H2OContext
-from pyspark.sql import SparkSession
 from py4j.java_gateway import JavaObject
-from py_sparkling.ml.util import get_correct_case_enum, get_enum_array_from_str_array, getValidatedEnumValue
-import warnings
+from pyspark.ml.param import *
+from pyspark.sql import SparkSession
+
+from py_sparkling.ml.util import get_enum_array_from_str_array, getValidatedEnumValue
+from pysparkling.context import H2OContext
 
 
 class H2OCommonParams(Params):
@@ -165,7 +165,8 @@ class H2OAlgorithmParams(H2OCommonParams):
         return self._set(parallelizeCrossValidation=value)
 
     def setDistribution(self, value):
-        return self._set(distribution=getValidatedEnumValue("hex.genmodel.utils.DistributionFamily", value))
+        validated = getValidatedEnumValue("hex.genmodel.utils.DistributionFamily", value)
+        return self._set(distribution=validated)
 
 
 class H2OSharedTreeParams(H2OAlgorithmParams):
@@ -266,10 +267,8 @@ class H2OSharedTreeParams(H2OAlgorithmParams):
         return self._set(minSplitImprovement=value)
 
     def setHistogramType(self, value):
-        assert_is_type(value, None, Enum("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.tree.SharedTreeModel.SharedTreeParameters.HistogramType.values(), value)
-        return self._set(histogramType=jvm.hex.tree.SharedTreeModel.SharedTreeParameters.HistogramType.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.tree.SharedTreeModel.SharedTreeParameters.HistogramType", value, nullEnabled=True)
+        return self._set(histogramType=validated)
 
     def setR2Stopping(self, value):
         assert_is_type(value, int, float)
@@ -556,11 +555,8 @@ class H2OAutoMLParams(H2OCommonParams):
         return self._set(stoppingTolerance=value)
 
     def setStoppingMetric(self, value):
-        # H2O typechecks does not check for case sensitivity
-        assert_is_type(value, Enum("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.ScoreKeeper.StoppingMetric.values(), value)
-        return self._set(stoppingMetric=jvm.hex.ScoreKeeper.StoppingMetric.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.ScoreKeeper.StoppingMetric", value)
+        return self._set(stoppingMetric=validated)
 
     def setSortMetric(self, value):
         assert_is_type(value, None, "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "mean_per_class_error")
@@ -780,13 +776,8 @@ class H2OXGBoostParams(H2OAlgorithmParams):
         return self._set(quietMode=value)
 
     def setMissingValuesHandling(self, value):
-        if value is not None:
-            assert_is_type(value, None, Enum("MeanImputation", "Skip"))
-            jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-            correct_case_value = get_correct_case_enum(jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.MissingValuesHandling.values(), value)
-            return self._set(missingValuesHandling=jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.MissingValuesHandling.valueOf(correct_case_value))
-        else:
-            return self._set(missingValuesHandling=None)
+        validated = getValidatedEnumValue("hex.tree.xgboost.XGBoostModel.XGBoostParameters.MissingValuesHandling", value, nullEnabled=True)
+        return self._set(missingValuesHandling=validated)
 
     def setNtrees(self, value):
         assert_is_type(value, int)
@@ -893,28 +884,20 @@ class H2OXGBoostParams(H2OAlgorithmParams):
         return self._set(minDataInLeaf=value)
 
     def setTreeMethod(self, value):
-        assert_is_type(value, Enum("auto", "exact", "approx", "hist"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.TreeMethod.values(), value)
-        return self._set(treeMethod=jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.TreeMethod.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.tree.xgboost.XGBoostModel.XGBoostParameters.TreeMethod", value)
+        return self._set(treeMethod=validated)
 
     def setGrowPolicy(self, value):
-        assert_is_type(value, Enum("depthwise", "lossguide"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.GrowPolicy.values(), value)
-        return self._set(growPolicy=jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.GrowPolicy.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.tree.xgboost.XGBoostModel.XGBoostParameters.GrowPolicy", value)
+        return self._set(growPolicy=validated)
 
     def setBooster(self, value):
-        assert_is_type(value, Enum("gbtree", "gblinear", "dart"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.Booster.values(), value)
-        return self._set(booster=jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.Booster.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.tree.xgboost.XGBoostModel.XGBoostParameters.Booster", value)
+        return self._set(booster=validated)
 
     def setDmatrixType(self, value):
-        assert_is_type(value, Enum("auto", "dense", "sparse"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.DMatrixType.values(), value)
-        return self._set(dmatrixType=jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.DMatrixType.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.tree.xgboost.XGBoostModel.XGBoostParameters.DMatrixType", value)
+        return self._set(dmatrixType=validated)
 
     def setRegLambda(self, value):
         assert_is_type(value, int, float)
@@ -925,16 +908,12 @@ class H2OXGBoostParams(H2OAlgorithmParams):
         return self._set(regAlpha=value)
 
     def setSampleType(self, value):
-        assert_is_type(value, Enum("uniform", "weighted"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.DartSampleType.values(), value)
-        return self._set(sampleType=jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.DartSampleType.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.tree.xgboost.XGBoostModel.XGBoostParameters.DartSampleType", value)
+        return self._set(sampleType=validated)
 
     def setNormalizeType(self, value):
-        assert_is_type(value, Enum("tree", "forest"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.DartNormalizeType.values(), value)
-        return self._set(normalizeType=jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.DartNormalizeType.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.tree.xgboost.XGBoostModel.XGBoostParameters.DartNormalizeType", value)
+        return self._set(normalizeType=validated)
 
     def setRateDrop(self, value):
         assert_is_type(value, int, float)
@@ -953,10 +932,8 @@ class H2OXGBoostParams(H2OAlgorithmParams):
         return self._set(gpuId=value)
 
     def setBackend(self, value):
-        assert_is_type(value, Enum("auto", "gpu", "cpu"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.Backend.values(), value)
-        return self._set(backend=jvm.hex.tree.xgboost.XGBoostModel.XGBoostParameters.Backend.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.tree.xgboost.XGBoostModel.XGBoostParameters.Backend", value)
+        return self._set(backend=validated)
 
 
 class H2OGLMParams(H2OAlgorithmParams):
@@ -1081,22 +1058,16 @@ class H2OGLMParams(H2OAlgorithmParams):
         return self._set(standardize=value)
 
     def setFamily(self, value):
-        assert_is_type(value, Enum("gaussian", "binomial", "quasibinomial", "poisson", "gamma", "multinomial", "tweedie", "ordinal"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.glm.GLMModel.GLMParameters.Family.values(), value)
-        return self._set(family=jvm.hex.glm.GLMModel.GLMParameters.Family.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.glm.GLMModel.GLMParameters.Family", value)
+        return self._set(family=validated)
 
     def setLink(self, value):
-        assert_is_type(value, Enum("family_default", "identity", "logit", "log", "inverse", "tweedie", "multinomial", "ologit", "oprobit", "ologlog"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.glm.GLMModel.GLMParameters.Link.values(), value)
-        return self._set(link=jvm.hex.glm.GLMModel.GLMParameters.Link.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.glm.GLMModel.GLMParameters.Link", value)
+        return self._set(link=validated)
 
     def setSolver(self, value):
-        assert_is_type(value, Enum("AUTO", "IRLSM", "L_BFGS", "COORDINATE_DESCENT_NAIVE", "COORDINATE_DESCENT", "GRADIENT_DESCENT_LH", "GRADIENT_DESCENT_SQERR"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.glm.GLMModel.GLMParameters.Solver.values(), value)
-        return self._set(solver=jvm.hex.glm.GLMModel.GLMParameters.Solver.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.glm.GLMModel.GLMParameters.Solver", value)
+        return self._set(solver=validated)
 
     def setTweedieVariancePower(self, value):
         assert_is_type(value, int, float)
@@ -1115,10 +1086,8 @@ class H2OGLMParams(H2OAlgorithmParams):
         return self._set(lambda_=value)
 
     def setMissingValuesHandling(self, value):
-        assert_is_type(value, Enum("MeanImputation", "Skip"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.deeplearning.DeepLearningModel.DeepLearningParameters.MissingValuesHandling.values(), value)
-        return self._set(missingValuesHandling=jvm.hex.deeplearning.DeepLearningModel.DeepLearningParameters.MissingValuesHandling.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.deeplearning.DeepLearningModel.DeepLearningParameters.MissingValuesHandling", value)
+        return self._set(missingValuesHandling=validated)
 
     def setPrior(self, value):
         assert_is_type(value, int, float)
@@ -1262,10 +1231,8 @@ class H2OGridSearchParams(H2OCommonParams):
         return self._set(hyperParameters=value)
 
     def setStrategy(self, value):
-        assert_is_type(value, Enum("Cartesian", "RandomDiscrete"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.grid.HyperSpaceSearchCriteria.Strategy.values(), value)
-        return self._set(link=jvm.hex.grid.HyperSpaceSearchCriteria.Strategy.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.grid.HyperSpaceSearchCriteria.Strategy", value)
+        return self._set(link=validated)
 
     def setMaxRuntimeSecs(self, value):
         assert_is_type(value, int, float)
@@ -1284,20 +1251,12 @@ class H2OGridSearchParams(H2OCommonParams):
         return self._set(stoppingTolerance=value)
 
     def setStoppingMetric(self, value):
-        # H2O typechecks does not check for case sensitivity
-        assert_is_type(value, Enum("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.ScoreKeeper.StoppingMetric.values(), value)
-        return self._set(stoppingMetric=jvm.hex.ScoreKeeper.StoppingMetric.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("hex.ScoreKeeper.StoppingMetric", value)
+        return self._set(stoppingMetric=validated)
 
     def setSelectBestModelBy(self, value):
-        # H2O typechecks does not check for case sensitivity
-        assert_is_type(value, None, Enum("MeanResidualDeviance", "R2", "ResidualDeviance", "ResidualDegreesOfFreedom", "NullDeviance",
-                                   "NullDegreesOfFreedom", "AIC", "AUC", "Gini", "F1", "F2",
-                                   "F0point5", "Precision", "Recall", "MCC", "Logloss", "Error", "MaxPerClassError", "Accuracy", "MSE", "RMSE"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.org.apache.spark.ml.h2o.algos.H2OGridSearchMetric.values(), value)
-        return self._set(selectBestModelBy=jvm.org.apache.spark.ml.h2o.algos.H2OGridSearchMetric.valueOf(correct_case_value))
+        validated = getValidatedEnumValue("org.apache.spark.ml.h2o.algos.H2OGridSearchMetric", value, nullEnabled=True)
+        return self._set(selectBestModelBy=validated)
 
     def setSelectBestModelDecreasing(self, value):
         assert_is_type(value, bool)

--- a/py/pysparkling/ml/params.py
+++ b/py/pysparkling/ml/params.py
@@ -3,7 +3,7 @@ from h2o.utils.typechecks import assert_is_type, Enum
 from pysparkling.context import H2OContext
 from pyspark.sql import SparkSession
 from py4j.java_gateway import JavaObject
-from py_sparkling.ml.util import get_correct_case_enum, get_enum_array_from_str_array
+from py_sparkling.ml.util import get_correct_case_enum, get_enum_array_from_str_array, getValidatedEnumValue
 import warnings
 
 
@@ -165,10 +165,7 @@ class H2OAlgorithmParams(H2OCommonParams):
         return self._set(parallelizeCrossValidation=value)
 
     def setDistribution(self, value):
-        assert_is_type(value, Enum("AUTO", "bernoulli", "quasibinomial", "modified_huber", "multinomial", "ordinal", "gaussian", "poisson", "gamma", "tweedie", "huber", "laplace", "quantile"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.genmodel.utils.DistributionFamily.values(), value)
-        return self._set(distribution=correct_case_value)
+        return self._set(distribution=getValidatedEnumValue("hex.genmodel.utils.DistributionFamily", value))
 
 
 class H2OSharedTreeParams(H2OAlgorithmParams):

--- a/py/pysparkling/ml/params.py
+++ b/py/pysparkling/ml/params.py
@@ -165,7 +165,7 @@ class H2OAlgorithmParams(H2OCommonParams):
         return self._set(parallelizeCrossValidation=value)
 
     def setDistribution(self, value):
-        assert_is_type(value, "AUTO", "bernoulli", "quasibinomial", "modified_huber", "multinomial", "ordinal", "gaussian", "poisson", "gamma", "tweedie", "huber", "laplace", "quantile")
+        assert_is_type(value, Enum("AUTO", "bernoulli", "quasibinomial", "modified_huber", "multinomial", "ordinal", "gaussian", "poisson", "gamma", "tweedie", "huber", "laplace", "quantile"))
         return self._set(distribution=value)
 
 

--- a/py/pysparkling/ml/params.py
+++ b/py/pysparkling/ml/params.py
@@ -3,7 +3,7 @@ from h2o.utils.typechecks import assert_is_type, Enum
 from pysparkling.context import H2OContext
 from pyspark.sql import SparkSession
 from py4j.java_gateway import JavaObject
-from py_sparkling.ml.util import get_correct_case_enum, get_enum_array_from_str_array, checkedAllowedEnumValues
+from py_sparkling.ml.util import get_correct_case_enum, get_enum_array_from_str_array
 import warnings
 
 
@@ -165,8 +165,7 @@ class H2OAlgorithmParams(H2OCommonParams):
         return self._set(parallelizeCrossValidation=value)
 
     def setDistribution(self, value):
-        checkedAllowedEnumValues(value, self._hc._jvm.hex.genmodel.utils.DistributionFamily)
-        assert_is_type(value, Enum("AUTO", "bernoulli", "quasibinomial", "modified_huber", "multinomial", "ordinal", "gaussian", "poisson", "gamma", "tweedie", "huber", "laplace", "quantile"))
+        assert_is_type(value, "AUTO", "bernoulli", "quasibinomial", "modified_huber", "multinomial", "ordinal", "gaussian", "poisson", "gamma", "tweedie", "huber", "laplace", "quantile")
         return self._set(distribution=value)
 
 

--- a/py/pysparkling/ml/params.py
+++ b/py/pysparkling/ml/params.py
@@ -3,7 +3,7 @@ from h2o.utils.typechecks import assert_is_type, Enum
 from pysparkling.context import H2OContext
 from pyspark.sql import SparkSession
 from py4j.java_gateway import JavaObject
-from py_sparkling.ml.util import get_correct_case_enum, get_enum_array_from_str_array
+from py_sparkling.ml.util import get_correct_case_enum, get_enum_array_from_str_array, checkedAllowedEnumValues
 import warnings
 
 
@@ -143,8 +143,7 @@ class H2OAlgorithmParams(H2OCommonParams):
         return self.getOrDefault(self.parallelizeCrossValidation)
 
     def getDistribution(self):
-        # Convert Java Enum to String so we can represent it in Python
-        return self.getOrDefault(self.distribution).toString()
+        return self.getOrDefault(self.distribution)
 
     ##
     # Setters
@@ -166,10 +165,9 @@ class H2OAlgorithmParams(H2OCommonParams):
         return self._set(parallelizeCrossValidation=value)
 
     def setDistribution(self, value):
-        assert_is_type(value, None, Enum("AUTO", "bernoulli", "quasibinomial", "modified_huber", "multinomial", "ordinal", "gaussian", "poisson", "gamma", "tweedie", "huber", "laplace", "quantile"))
-        jvm = H2OContext.getOrCreate(SparkSession.builder.getOrCreate(), verbose=False)._jvm
-        correct_case_value = get_correct_case_enum(jvm.hex.genmodel.utils.DistributionFamily.values(), value)
-        return self._set(distribution=jvm.hex.genmodel.utils.DistributionFamily.valueOf(correct_case_value))
+        checkedAllowedEnumValues(value, self._hc._jvm.hex.genmodel.utils.DistributionFamily)
+        assert_is_type(value, Enum("AUTO", "bernoulli", "quasibinomial", "modified_huber", "multinomial", "ordinal", "gaussian", "poisson", "gamma", "tweedie", "huber", "laplace", "quantile"))
+        return self._set(distribution=value)
 
 
 class H2OSharedTreeParams(H2OAlgorithmParams):


### PR DESCRIPTION
So far just on single parameter, just as a prototype. Once we have approved solution, we can apply the deprecation to rest of the code.

The benefit is simpler usage of API( no need to reference different namespaces) + simple code on both, scala + python side -> Which can lead to simpler code generation once we start generation these APIs for Python & R