### PR TITLE
[SW-1489] Use TypeConverters on AutoML pysparkling wrapper

### DIFF
--- a/py/ai/h2o/sparkling/ml/algos/H2OAutoML.py
+++ b/py/ai/h2o/sparkling/ml/algos/H2OAutoML.py
@@ -25,7 +25,6 @@ from pyspark.sql.dataframe import DataFrame
 from ai.h2o.sparkling import Initializer
 from ai.h2o.sparkling.ml.models import H2OMOJOModel
 from ai.h2o.sparkling.ml.params import H2OAutoMLParams
-from ai.h2o.sparkling.ml.utils import set_double_values, validateEnumValue, validateEnumValues
 from ai.h2o.sparkling.sparkSpecifics import get_input_kwargs
 
 
@@ -64,18 +63,9 @@ class H2OAutoML(H2OAutoMLParams, JavaEstimator, JavaMLReadable, JavaMLWritable):
 
         kwargs = get_input_kwargs(self)
 
-        validateEnumValues(self._H2OAutoMLParams__getAutomlAlgoEnum(), kwargs, "includeAlgos", nullEnabled=True)
-        validateEnumValues(self._H2OAutoMLParams__getAutomlAlgoEnum(), kwargs, "excludeAlgos", nullEnabled=True)
-        validateEnumValue(self._H2OAutoMLParams__getStoppingMetricEnum(), kwargs, "stoppingMetric")
-        validateEnumValue(self._H2OAutoMLParams__getSortMetricEnum(), kwargs, "sortMetric")
-
         if "projectName" in kwargs and kwargs["projectName"] is None:
             kwargs["projectName"] = ''.join(random.choice(string.ascii_letters) for i in range(30))
 
-        # we need to convert double arguments manually to floats as if we assign integer to double, py4j thinks that
-        # the whole type is actually int and we get class cast exception
-        double_types = ["maxRuntimeSecs", "stoppingTolerance", "splitRatio", "maxAfterBalanceSize"]
-        set_double_values(kwargs, double_types)
         return self._set(**kwargs)
 
     def _create_model(self, java_model):

--- a/py/ai/h2o/sparkling/ml/params/H2OAutoMLParams.py
+++ b/py/ai/h2o/sparkling/ml/params/H2OAutoMLParams.py
@@ -15,11 +15,11 @@
 # limitations under the License.
 #
 
-from h2o.utils.typechecks import assert_is_type
 from pyspark.ml.param import *
+from pyspark.ml.param import TypeConverters
 
 from ai.h2o.sparkling.ml.params.H2OCommonSupervisedParams import H2OCommonSupervisedParams
-from ai.h2o.sparkling.ml.utils import getValidatedEnumValue, getValidatedEnumValues, getDoubleArrayFromIntArray
+from ai.h2o.sparkling.ml.params.H2OTypeConverters import H2OTypeConverters
 
 
 class H2OAutoMLParams(H2OCommonSupervisedParams):
@@ -27,22 +27,26 @@ class H2OAutoMLParams(H2OCommonSupervisedParams):
     ##
     # Param definitions
     ##
-    ignoredCols = Param(Params._dummy(), "ignoredCols", "Ignored column names")
-    includeAlgos = Param(Params._dummy(), "includeAlgos", "Algorithms to include when using automl")
-    excludeAlgos = Param(Params._dummy(), "excludeAlgos", "Algorithms to exclude when using automl")
+    ignoredCols = Param(Params._dummy(), "ignoredCols", "Ignored column names", TypeConverters.toListString)
+    includeAlgos = Param(Params._dummy(), "includeAlgos", "Algorithms to include when using automl",
+                         H2OTypeConverters.toEnumListString("ai.h2o.automl.Algo", nullEnabled=True))
+    excludeAlgos = Param(Params._dummy(), "excludeAlgos", "Algorithms to exclude when using automl",
+                         H2OTypeConverters.toEnumListString("ai.h2o.automl.Algo", nullEnabled=True))
     projectName = Param(Params._dummy(), "projectName", "identifier for models that should be grouped together in the leaderboard" +
-                        " (e.g., airlines and iris)")
-    maxRuntimeSecs = Param(Params._dummy(), "maxRuntimeSecs", "Maximum time in seconds for automl to be running")
-    stoppingRounds = Param(Params._dummy(), "stoppingRounds", "Stopping rounds")
-    stoppingTolerance = Param(Params._dummy(), "stoppingTolerance", "Stopping tolerance")
-    stoppingMetric = Param(Params._dummy(), "stoppingMetric", "Stopping metric")
-    sortMetric = Param(Params._dummy(), "sortMetric", "Sort metric for the AutoML leaderboard")
-    balanceClasses = Param(Params._dummy(), "balanceClasses", "Balance classes")
-    classSamplingFactors = Param(Params._dummy(), "classSamplingFactors", "Class sampling factors")
-    maxAfterBalanceSize = Param(Params._dummy(), "maxAfterBalanceSize", "Max after balance size")
-    keepCrossValidationPredictions = Param(Params._dummy(), "keepCrossValidationPredictions", "Keep cross validation predictions")
-    keepCrossValidationModels = Param(Params._dummy(), "keepCrossValidationModels", "Keep cross validation models")
-    maxModels = Param(Params._dummy(), "maxModels", "Max models to train in AutoML")
+                        " (e.g., airlines and iris)", TypeConverters.toString)
+    maxRuntimeSecs = Param(Params._dummy(), "maxRuntimeSecs", "Maximum time in seconds for automl to be running", TypeConverters.toFloat)
+    stoppingRounds = Param(Params._dummy(), "stoppingRounds", "Stopping rounds", TypeConverters.toInt)
+    stoppingTolerance = Param(Params._dummy(), "stoppingTolerance", "Stopping tolerance", TypeConverters.toFloat)
+    stoppingMetric = Param(Params._dummy(), "stoppingMetric", "Stopping metric",
+                           H2OTypeConverters.toEnumString("hex.ScoreKeeper$StoppingMetric"))
+    sortMetric = Param(Params._dummy(), "sortMetric", "Sort metric for the AutoML leaderboard",
+                       H2OTypeConverters.toEnumString("ai.h2o.sparkling.ml.algos.H2OAutoMLSortMetric"))
+    balanceClasses = Param(Params._dummy(), "balanceClasses", "Balance classes", TypeConverters.toBoolean)
+    classSamplingFactors = Param(Params._dummy(), "classSamplingFactors", "Class sampling factors", TypeConverters.toListFloat)
+    maxAfterBalanceSize = Param(Params._dummy(), "maxAfterBalanceSize", "Max after balance size", TypeConverters.toFloat)
+    keepCrossValidationPredictions = Param(Params._dummy(), "keepCrossValidationPredictions", "Keep cross validation predictions", TypeConverters.toBoolean)
+    keepCrossValidationModels = Param(Params._dummy(), "keepCrossValidationModels", "Keep cross validation models", TypeConverters.toBoolean)
+    maxModels = Param(Params._dummy(), "maxModels", "Max models to train in AutoML", TypeConverters.toInt)
 
     ##
     # Getters
@@ -54,20 +58,10 @@ class H2OAutoMLParams(H2OCommonSupervisedParams):
         return self.getOrDefault(self.tryMutations)
 
     def getExcludeAlgos(self):
-        # Convert Java Array[String] to Python
-        algos = self.getOrDefault(self.excludeAlgos)
-        if algos is None:
-            return None
-        else:
-            return [algo for algo in algos]
+        return self.getOrDefault(self.excludeAlgos)
 
     def getIncludeAlgos(self):
-        # Convert Java Array[String] to Python
-        algos = self.getOrDefault(self.includeAlgos)
-        if algos is None:
-            return None
-        else:
-            return [algo for algo in algos]
+        return self.getOrDefault(self.includeAlgos)
 
     def getProjectName(self):
         return self.getOrDefault(self.projectName)
@@ -109,74 +103,49 @@ class H2OAutoMLParams(H2OCommonSupervisedParams):
     # Setters
     ##
     def setIgnoredCols(self, value):
-        assert_is_type(value, [str])
         return self._set(ignoredCols=value)
 
     def setTryMutations(self, value):
-        assert_is_type(value, bool)
         return self._set(tryMutations=value)
 
     def setIncludeAlgos(self, value):
-        validated = getValidatedEnumValues(self.__getAutomlAlgoEnum(), value, nullEnabled=True)
-        return self._set(includeAlgos=validated)
+        return self._set(includeAlgos=value)
 
     def setExcludeAlgos(self, value):
-        validated = getValidatedEnumValues(self.__getAutomlAlgoEnum(), value, nullEnabled=True)
-        return self._set(excludeAlgos=validated)
-
-    def __getAutomlAlgoEnum(self):
-        return "ai.h2o.automl.Algo"
+        return self._set(excludeAlgos=value)
 
     def setProjectName(self, value):
-        assert_is_type(value, None, str)
         return self._set(projectName=value)
 
     def setMaxRuntimeSecs(self, value):
-        assert_is_type(value, int, float)
-        return self._set(maxRuntimeSecs=float(value))
+        return self._set(maxRuntimeSecs=value)
 
     def setStoppingRounds(self, value):
-        assert_is_type(value, int)
         return self._set(stoppingRounds=value)
 
     def setStoppingTolerance(self, value):
-        assert_is_type(value, int, float)
-        return self._set(stoppingTolerance=float(value))
+        return self._set(stoppingTolerance=value)
 
     def setStoppingMetric(self, value):
-        validated = getValidatedEnumValue(self.__getStoppingMetricEnum(), value)
-        return self._set(stoppingMetric=validated)
-
-    def __getStoppingMetricEnum(self):
-        return "hex.ScoreKeeper$StoppingMetric"
+        return self._set(stoppingMetric=value)
 
     def setSortMetric(self, value):
-        validated = getValidatedEnumValue(self.__getSortMetricEnum(), value)
-        return self._set(sortMetric=validated)
-
-    def __getSortMetricEnum(self):
-        return "ai.h2o.sparkling.ml.algos.H2OAutoMLSortMetric"
+        return self._set(sortMetric=value)
 
     def setBalanceClasses(self, value):
-        assert_is_type(value, bool)
         return self._set(balanceClasses=value)
 
     def setClassSamplingFactors(self, value):
-        assert_is_type(value, [int, float])
-        return self._set(classSamplingFactors=getDoubleArrayFromIntArray(array))
+        return self._set(classSamplingFactors=value)
 
     def setMaxAfterBalanceSize(self, value):
-        assert_is_type(value, int, float)
-        return self._set(maxAfterBalanceSize=float(value))
+        return self._set(maxAfterBalanceSize=value)
 
     def setKeepCrossValidationPredictions(self, value):
-        assert_is_type(value, bool)
         return self._set(keepCrossValidationPredictions=value)
 
     def setKeepCrossValidationModels(self, value):
-        assert_is_type(value, bool)
         return self._set(keepCrossValidationModels=value)
 
     def setMaxModels(self, value):
-        assert_is_type(value, int)
         return self._set(maxModels=value)

--- a/py/ai/h2o/sparkling/ml/params/H2OCommonParams.py
+++ b/py/ai/h2o/sparkling/ml/params/H2OCommonParams.py
@@ -17,7 +17,6 @@
 
 from h2o.utils.typechecks import assert_is_type
 from pyspark.ml.param import *
-from pyspark.ml.param import TypeConverters
 
 from ai.h2o.sparkling.ml.params.H2OMOJOAlgoSharedParams import H2OMOJOAlgoSharedParams
 

--- a/py/ai/h2o/sparkling/ml/params/H2OCommonParams.py
+++ b/py/ai/h2o/sparkling/ml/params/H2OCommonParams.py
@@ -17,6 +17,7 @@
 
 from h2o.utils.typechecks import assert_is_type
 from pyspark.ml.param import *
+from pyspark.ml.param import TypeConverters
 
 from ai.h2o.sparkling.ml.params.H2OMOJOAlgoSharedParams import H2OMOJOAlgoSharedParams
 
@@ -28,7 +29,7 @@ class H2OCommonParams(H2OMOJOAlgoSharedParams):
     weightCol = Param(Params._dummy(), "weightCol", "Weight column name")
     splitRatio = Param(Params._dummy(), "splitRatio",
                        "Accepts values in range [0, 1.0] which determine how large part of dataset is used for training and for validation. "
-                       "For example, 0.8 -> 80% training 20% validation.")
+                       "For example, 0.8 -> 80% training 20% validation.", TypeConverters.toFloat)
     seed = Param(Params._dummy(), "seed", "Used to specify seed to reproduce the model run")
     nfolds = Param(Params._dummy(), "nfolds", "Number of fold columns")
 
@@ -76,8 +77,7 @@ class H2OCommonParams(H2OMOJOAlgoSharedParams):
         return self._set(weightCol=value)
 
     def setSplitRatio(self, value):
-        assert_is_type(value, int, float)
-        return self._set(splitRatio=float(value))
+        return self._set(splitRatio=value)
 
     def setSeed(self, value):
         assert_is_type(value, int)

--- a/py/ai/h2o/sparkling/ml/params/H2OTypeConverters.py
+++ b/py/ai/h2o/sparkling/ml/params/H2OTypeConverters.py
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.ml.param import TypeConverters
+from pyspark.ml.util import _jvm
+
+
+class H2OTypeConverters(object):
+
+    @staticmethod
+    def toEnumListString(enumClass, nullEnabled=False):
+        def convert(value):
+            package = getattr(_jvm().ai.h2o.sparkling.ml.params, "H2OAlgoParamsHelper$")
+            return [e for e in
+                    package.__getattr__("MODULE$").getValidatedEnumValues(enumClass, TypeConverters.toListString(value),
+                                                                          nullEnabled)]
+
+        return convert
+
+    @staticmethod
+    def toEnumString(enumClass):
+        def convert(value):
+            package = getattr(_jvm().ai.h2o.sparkling.ml.params, "H2OAlgoParamsHelper$")
+            return package.__getattr__("MODULE$").getValidatedEnumValue(enumClass, TypeConverters.toString(value))
+
+        return convert


### PR DESCRIPTION
Also fixes bug in H2OAutoML constructor. `ClassSamplingFactors` was not converted to double values