### PR TITLE
[SW-1490] Immutable projectName on H2OAutoML

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
@@ -54,12 +54,6 @@ class H2OAutoML(override val uid: String) extends Estimator[H2OMOJOModel]
   override def fit(dataset: Dataset[_]): H2OMOJOModel = {
     val spec = new AutoMLBuildSpec
 
-    // override the buildSpec with the configuration specified directly on the estimator
-    if (getProjectName() == null) {
-      // generate random name to generate fresh leaderboard (the default behaviour)
-      setProjectName(Random.alphanumeric.take(30).mkString)
-    }
-
     val (train, valid) = prepareDatasetForFitting(dataset)
     spec.input_spec.training_frame = train._key
     spec.input_spec.validation_frame = valid.map(_._key).orNull
@@ -78,7 +72,8 @@ class H2OAutoML(override val uid: String) extends Estimator[H2OMOJOModel]
     spec.input_spec.sort_metric = if (sortMetric == "AUTO") null else sortMetric
     spec.build_models.exclude_algos = if (getExcludeAlgos() == null) null else Array(getExcludeAlgos().map(Algo.valueOf): _*)
     spec.build_models.include_algos = if (getIncludeAlgos() == null) null else Array(getIncludeAlgos().map(Algo.valueOf): _*)
-    spec.build_control.project_name = getProjectName()
+    val projectName = getProjectName()
+    spec.build_control.project_name = if (projectName == null) Random.alphanumeric.take(30).mkString else projectName
     spec.build_control.stopping_criteria.set_seed(getSeed())
     spec.build_control.stopping_criteria.set_max_runtime_secs(getMaxRuntimeSecs())
     spec.build_control.stopping_criteria.set_stopping_rounds(getStoppingRounds())

--- a/py/ai/h2o/sparkling/ml/algos/H2OAutoMLExtensions.py
+++ b/py/ai/h2o/sparkling/ml/algos/H2OAutoMLExtensions.py
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql.dataframe import DataFrame
+
+
+class H2OAutoMLExtensions(object):
+
+    def leaderboard(self):
+        leaderboard_java = self._java_obj.leaderboard()
+        if leaderboard_java.isDefined():
+            return DataFrame(leaderboard_java.get(), self._hc._sql_context)
+        else:
+            return None


### PR DESCRIPTION
This change has more actually multiple motivations:

- Immutability -> don't change user specified value on the estimator
- Keep all the logic in Scala wrapper, have PySparkling just as dummy client. 
- Keep the client simply and generic so we can later generate all algos with the same generator
- Move special methods which need to be on H2OAutoML to Extension class. The generator can check if the extension class exists and make sure the Algo, in this case H2OAutoML, will extend from it. The Extensions methods can't be generated so that is why I extracted them.

