### PR TITLE
[SW-1549] Upgrade default instances in terraform templates to M5.xlarge

### DIFF
--- a/templates/src/terraform/aws/modules/emr/variables.tf
+++ b/templates/src/terraform/aws/modules/emr/variables.tf
@@ -19,7 +19,7 @@ variable "aws_core_instance_count" {
   default = "2"
 }
 variable "aws_instance_type" {
-  default = "m3.xlarge"
+  default = "m5.xlarge"
 }
 variable "sw_version" {
   default = "SUBST_SW_VERSION"

--- a/templates/src/terraform/aws/variables.tf
+++ b/templates/src/terraform/aws/variables.tf
@@ -20,7 +20,7 @@ variable "aws_core_instance_count" {
   default = "2"
 }
 variable "aws_instance_type" {
-  default = "m3.xlarge"
+  default = "m5.xlarge"
 }
 variable "sw_version" {
   default = "SUBST_SW_VERSION"


### PR DESCRIPTION
from https://aws.amazon.com/emr/pricing/:

m5.xlarge (current generation)
- Amazon EC2 Price: $0.192 per Hour 
- Amazon EMR Price: $0.048 per Hour

m3.xlarge (previous generation)
- Amazon EC2 Price: $0.266 per Hour 
- Amazon EMR Price: $0.07 per Hour



