### PR TITLE
[SW-1551] Fix path to external jars generated by ./gradlew extendJar

### DIFF
--- a/assembly-h2o/build.gradle
+++ b/assembly-h2o/build.gradle
@@ -125,10 +125,7 @@ if (project.hasProperty("doExtend")) {
             attributes 'Main-Class': getJarMainClass(getOrDownloadOriginalJar())
         }
         configurations = [project.configurations.artifactsToMerge]
-        baseName = fileName
-        classifier = null
-        version = null
-
+        archiveBaseName = fileName
         finalizedBy "printExtendedJarLocation"
     }
 }


### PR DESCRIPTION
The version suffix was newly added even though we explicitly set `version = null`. To overcome this, we explicitly configure the full jar name instead of it's separate components. 