### PR TITLE
[SW-1567] Upgrade version of h2o docker image from 58 to the 64

### DIFF
--- a/jenkins/build.gradle
+++ b/jenkins/build.gradle
@@ -12,7 +12,7 @@ ext {
 
 task createDockerfile(type: Dockerfile) {
     destFile = outputFile
-    from 'harbor.h2o.ai/opsh2oai/h2o-3-hadoop-hdp-2.2:58'
+    from 'harbor.h2o.ai/opsh2oai/h2o-3-hadoop-hdp-2.2:64'
 
     environmentVariable("LANG", "'C.UTF-8'")
     runCommand "locale"

--- a/jenkins/docker/regular-tests/Jenkinsfile-build-docker
+++ b/jenkins/docker/regular-tests/Jenkinsfile-build-docker
@@ -38,7 +38,7 @@ node('docker && !mr-0xc8') {
         dir("jenkins/docker/regular-tests") {
             sh """
                cp -R ../conf conf
-               docker pull harbor.h2o.ai/opsh2oai/h2o-3-hadoop-hdp-2.2:58
+               docker pull harbor.h2o.ai/opsh2oai/h2o-3-hadoop-hdp-2.2:64
                docker build -t harbor.h2o.ai/opsh2oai/sparkling_water_tests:${nextVersion} -f Dockerfile .
                """
         }


### PR DESCRIPTION
Talked to @honzasterba and @michal-raska . A lot of fixes have been done since version 58 so it's possible the upgrade might help is with hang of hadoop infra in docker.

Note: After merging this, the BUILD_DOCKER job needs to be triggered in jenkins and sw docker image number incremented after successful run 