### PR TITLE
[SW-1583] Add missing namedMojoOutputParameter to PySparkling Algo constructors

### DIFF
--- a/py/src/ai/h2o/sparkling/ml/algos/H2OAutoML.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OAutoML.py
@@ -56,7 +56,8 @@ class H2OAutoML(H2OAutoMLParams, H2OAlgoBase):
                  withDetailedPredictionCol=False,
                  featuresCols=[],
                  convertUnknownCategoricalLevelsToNa=False,
-                 convertInvalidNumbersToNa=False):
+                 convertInvalidNumbersToNa=False,
+                 namedMojoOutputColumns=True):
         Initializer.load_sparkling_jar()
         super(H2OAutoML, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2OAutoML", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2ODRF.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2ODRF.py
@@ -61,7 +61,8 @@ class H2ODRF(H2ODRFParams, H2OAlgoBase):
                  withDetailedPredictionCol=False,
                  featuresCols=[],
                  convertUnknownCategoricalLevelsToNa=False,
-                 convertInvalidNumbersToNa=False):
+                 convertInvalidNumbersToNa=False,
+                 namedMojoOutputColumns=True):
         Initializer.load_sparkling_jar()
         super(H2ODRF, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2ODRF", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2ODeepLearning.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2ODeepLearning.py
@@ -50,7 +50,8 @@ class H2ODeepLearning(H2ODeepLearningParams, H2OAlgoBase):
                  withDetailedPredictionCol=False,
                  featuresCols=[],
                  convertUnknownCategoricalLevelsToNa=False,
-                 convertInvalidNumbersToNa=False):
+                 convertInvalidNumbersToNa=False,
+                 namedMojoOutputColumns=True):
         Initializer.load_sparkling_jar()
         super(H2ODeepLearning, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2ODeepLearning", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OGBM.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OGBM.py
@@ -64,7 +64,8 @@ class H2OGBM(H2OGBMParams, H2OAlgoBase):
                  withDetailedPredictionCol=False,
                  featuresCols=[],
                  convertUnknownCategoricalLevelsToNa=False,
-                 convertInvalidNumbersToNa=False):
+                 convertInvalidNumbersToNa=False,
+                 namedMojoOutputColumns=True):
         Initializer.load_sparkling_jar()
         super(H2OGBM, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2OGBM", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OKMeans.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OKMeans.py
@@ -50,7 +50,8 @@ class H2OKMeans(H2OKMeansParams, H2OAlgoBase):
                  withDetailedPredictionCol=False,
                  featuresCols=[],
                  convertUnknownCategoricalLevelsToNa=False,
-                 convertInvalidNumbersToNa=False):
+                 convertInvalidNumbersToNa=False,
+                 namedMojoOutputColumns=True):
         Initializer.load_sparkling_jar()
         super(H2OKMeans, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2OKMeans", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
@@ -85,7 +85,8 @@ class H2OXGBoost(H2OXGBoostParams, H2OAlgoBase):
                  withDetailedPredictionCol=False,
                  featuresCols=[],
                  convertUnknownCategoricalLevelsToNa=False,
-                 convertInvalidNumbersToNa=False):
+                 convertInvalidNumbersToNa=False,
+                 namedMojoOutputColumns=True):
         Initializer.load_sparkling_jar()
         super(H2OXGBoost, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2OXGBoost", self.uid)


### PR DESCRIPTION
H2OGLM has it added as part of https://github.com/h2oai/sparkling-water/pull/1493/files