### PR TITLE
[SW-1600] Fix IIOB when using calibrated probabilities on MOJO

### DIFF
--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionBinomial.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionBinomial.scala
@@ -30,7 +30,7 @@ trait H2OMOJOPredictionBinomial {
     // calibrateClassProbabilities returns false if model does not support calibrated probabilities,
     // however it also accepts array of probabilities to calibrate. We are not interested in calibration,
     // but to call this method, we need to pass dummy array of size 2 with default values to 0.
-    predictWrapper.m.calibrateClassProbabilities(Array.fill[Double](2)(0))
+    predictWrapper.m.calibrateClassProbabilities(Array.fill[Double](3)(0))
   }
 
   def getBinomialPredictionUDF(): UserDefinedFunction = {


### PR DESCRIPTION
`calibrateClassProbabilities` expects an array of size 3, but its pasing in an array of size 2 for `supportsCalibratedProbabilities`, this causes an `java.lang.ArrayIndexOutOfBoundsException: 2` error when trying to score a mojo that was trained with the calibration option enabled.