### PR TITLE
[SW-1597] Add a note informing that terraform template is available only for Spark 2.4

### DIFF
--- a/doc/build.gradle
+++ b/doc/build.gradle
@@ -25,7 +25,8 @@ task substitute() {
     doLast {
         def siteDir = "${buildDir}/site"
 
-        def (first, second, minorVersion) = version.tokenize(".")
+        def swOnlyVersion = version.tokenize("-")[0]
+        def (first, second, minorVersion) = swOnlyVersion.tokenize(".")
         def majorVersion = "${first}.${second}"
 
         new File(siteDir).eachFileRecurse(FILES) {
@@ -33,6 +34,7 @@ task substitute() {
                 def contents = file(it).getText('UTF-8')
                 contents = contents
                         .replaceAll("SUBST_SW_VERSION", version)
+                        .replaceAll("SUBST_SW_ONLY_VERSION", swOnlyVersion)
                         .replaceAll("SUBST_SW_MAJOR_VERSION", majorVersion)
                         .replaceAll("SUBST_SW_MINOR_VERSION", minorVersion)
                         .replaceAll("SUBST_SPARK_VERSION", sparkVersion)

--- a/doc/build.gradle
+++ b/doc/build.gradle
@@ -34,7 +34,6 @@ task substitute() {
                 def contents = file(it).getText('UTF-8')
                 contents = contents
                         .replaceAll("SUBST_SW_VERSION", version)
-                        .replaceAll("SUBST_SW_ONLY_VERSION", swOnlyVersion)
                         .replaceAll("SUBST_SW_MAJOR_VERSION", majorVersion)
                         .replaceAll("SUBST_SW_MINOR_VERSION", minorVersion)
                         .replaceAll("SUBST_SPARK_VERSION", sparkVersion)
@@ -43,6 +42,7 @@ task substitute() {
                         .replaceAll("SUBST_H2O_RELEASE_NAME", h2oMajorName)
                         .replaceAll("SUBST_H2O_BUILD_NUMBER", h2oBuild)
                         .replaceAll("SUBST_MIN_SUPPORTED_JAVA", minSupportedJavaVersion)
+                        .replaceAll("SUBST_EMR_VERSION", supportedEmrVersion)
                 file(it).write(contents, 'UTF-8')
             }
         }

--- a/doc/src/site/sphinx/deployment/terraform_emr.rst
+++ b/doc/src/site/sphinx/deployment/terraform_emr.rst
@@ -1,7 +1,7 @@
 Start Sparkling Water on Amazon EMR using our Terraform Template
 ----------------------------------------------------------------
 
-**This terraform template supports only Sparkling Water builds for Apache Spark 2.4**
+**This terraform template supports only Sparkling Water builds for Apache Spark 2.4 and higher.**
 
 Sparkling Water comes with the pre-defined Terraform templates that can be used to
 deploy Sparkling Water to Amazon EMR.
@@ -37,10 +37,10 @@ Sparkling Water provides 3 templates/modules:
    - ``aws_vpc_id`` (mandatory) - ID of existing VPC
    - ``aws_subnet_id`` (mandatory) - ID of existing VPC subnet
    - ``aws_region`` (optional) - AWS region. Defaults to ``us-east-1``.
-   - ``aws_emr_version`` (optional) - EMR version. Defaults to ``emr-2.26.0``.
+   - ``aws_emr_version`` (optional) - EMR version. Defaults to ``SUBST_EMR_VERSION``.
    - ``aws_core_instance_count`` (optional) - Number of worker nodes. Defaults to ``2``.
    - ``aws_instance_type`` (optional) - type of EC2 instances. Defaults to ``m5.xlarge``.
-   - ``sw_version`` (optional) - Sparkling Water version. Defaults to ``SUBST_SW_ONLY_VERSION-2.4``.
+   - ``sw_version`` (optional) - Sparkling Water version. Defaults to ``SUBST_SW_VERSION``.
    - ``jupyter_name`` (optional) - User name for Jupyter Notebook. Defaults to ``admin``.
 
  - ``default`` module  (**/templates/build/terraform/aws**). This module is a combination of the two previous modules. It starts the network infrastructure and starts EMR with Sparkling Water on top of it.
@@ -51,10 +51,10 @@ Sparkling Water provides 3 templates/modules:
    - ``aws_secret_key`` (mandatory) - secret key to access AWS
    - ``aws_ssh_public_key`` (optional) - public key (to be able to access EC2 instances via ssh later)
    - ``aws_region`` (optional) - AWS region. Defaults to ``us-east-1``.
-   - ``aws_emr_version`` (optional) - EMR version. Defaults to ``emr-2.26.0``.
+   - ``aws_emr_version`` (optional) - EMR version. Defaults to ``SUBST_EMR_VERSION``.
    - ``aws_core_instance_count`` (optional) - Number of worker nodes. Defaults to ``2``.
    - ``aws_instance_type`` (optional) - type of EC2 instances. Defaults to ``m5.xlarge``.
-   - ``sw_version`` (optional) - Sparkling Water version. Defaults to ``SUBST_SW_ONLY_VERSION-2.4``.
+   - ``sw_version`` (optional) - Sparkling Water version. Defaults to ``SUBST_SW_VERSION``.
    - ``jupyter_name`` (optional) - User name for Jupyter Notebook. Defaults to ``admin``.
 
 

--- a/doc/src/site/sphinx/deployment/terraform_emr.rst
+++ b/doc/src/site/sphinx/deployment/terraform_emr.rst
@@ -1,6 +1,8 @@
 Start Sparkling Water on Amazon EMR using our Terraform Template
 ----------------------------------------------------------------
 
+**This terraform template supports only Sparkling Water builds for Apache Spark 2.4**
+
 Sparkling Water comes with the pre-defined Terraform templates that can be used to
 deploy Sparkling Water to Amazon EMR.
 
@@ -35,10 +37,10 @@ Sparkling Water provides 3 templates/modules:
    - ``aws_vpc_id`` (mandatory) - ID of existing VPC
    - ``aws_subnet_id`` (mandatory) - ID of existing VPC subnet
    - ``aws_region`` (optional) - AWS region. Defaults to ``us-east-1``.
-   - ``aws_emr_version`` (optional) - EMR version. Defaults to ``emr-2.20.0``.
+   - ``aws_emr_version`` (optional) - EMR version. Defaults to ``emr-2.26.0``.
    - ``aws_core_instance_count`` (optional) - Number of worker nodes. Defaults to ``2``.
-   - ``aws_instance_type`` (optional) - type of EC2 instances. Defaults to ``m3.xlarge``.
-   - ``sw_version`` (optional) - Sparkling Water version. Defaults to ``SUBST_SW_VERSION``.
+   - ``aws_instance_type`` (optional) - type of EC2 instances. Defaults to ``m5.xlarge``.
+   - ``sw_version`` (optional) - Sparkling Water version. Defaults to ``SUBST_SW_ONLY_VERSION-2.4``.
    - ``jupyter_name`` (optional) - User name for Jupyter Notebook. Defaults to ``admin``.
 
  - ``default`` module  (**/templates/build/terraform/aws**). This module is a combination of the two previous modules. It starts the network infrastructure and starts EMR with Sparkling Water on top of it.
@@ -49,10 +51,10 @@ Sparkling Water provides 3 templates/modules:
    - ``aws_secret_key`` (mandatory) - secret key to access AWS
    - ``aws_ssh_public_key`` (optional) - public key (to be able to access EC2 instances via ssh later)
    - ``aws_region`` (optional) - AWS region. Defaults to ``us-east-1``.
-   - ``aws_emr_version`` (optional) - EMR version. Defaults to ``emr-2.20.0``.
+   - ``aws_emr_version`` (optional) - EMR version. Defaults to ``emr-2.26.0``.
    - ``aws_core_instance_count`` (optional) - Number of worker nodes. Defaults to ``2``.
-   - ``aws_instance_type`` (optional) - type of EC2 instances. Defaults to ``m3.xlarge``.
-   - ``sw_version`` (optional) - Sparkling Water version. Defaults to ``SUBST_SW_VERSION``.
+   - ``aws_instance_type`` (optional) - type of EC2 instances. Defaults to ``m5.xlarge``.
+   - ``sw_version`` (optional) - Sparkling Water version. Defaults to ``SUBST_SW_ONLY_VERSION-2.4``.
    - ``jupyter_name`` (optional) - User name for Jupyter Notebook. Defaults to ``admin``.
 
 


### PR DESCRIPTION
- Spark 2.1, 2.2 -  JupyterHub available in EMR only with versions Spark 2.3+
- Livy 0.6 supporting Spark 2.2-2.4 - Only available in the EMR version with Spark 2.4