### PR TITLE
[SW-1598] Deprecate cases in H2OMojoPrediction where the prediction column does not directly contain the predicted value.

### DIFF
--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionAnomaly.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionAnomaly.scala
@@ -25,6 +25,8 @@ import org.apache.spark.sql.{Column, Row}
 trait H2OMOJOPredictionAnomaly extends H2OMOJOPredictionUtils {
   self: H2OMOJOModel =>
   def getAnomalyPredictionUDF(): UserDefinedFunction = {
+    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+      " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted score.")
     udf[Base, Row] { r: Row =>
       val pred = easyPredictModelWrapper.predictAnomalyDetection(RowConverter.toH2ORowData(r))
       Base(pred.score, pred.normalizedScore)

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionAnomaly.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionAnomaly.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.{Column, Row}
 trait H2OMOJOPredictionAnomaly extends H2OMOJOPredictionUtils {
   self: H2OMOJOModel =>
   def getAnomalyPredictionUDF(): UserDefinedFunction = {
-    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+    logWarning("Starting from the next major release, the content of 'prediction' column will be generated to " +
       " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted score.")
     udf[Base, Row] { r: Row =>
       val pred = easyPredictModelWrapper.predictAnomalyDetection(RowConverter.toH2ORowData(r))

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionAutoEncoder.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionAutoEncoder.scala
@@ -26,7 +26,7 @@ trait H2OMOJOPredictionAutoEncoder {
   self: H2OMOJOModel =>
 
   def getAutoEncoderPredictionUDF(): UserDefinedFunction = {
-    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+    logWarning("Starting from the next major release, the content of 'prediction' column will be generated to " +
       " 'detailed_prediction' instead. The 'prediction' column will contain directly the original input the" +
       " way AutoEncoder model sees it (1-hot encoded categorical values) .")
     udf[Base, Row] { r: Row =>

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionAutoEncoder.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionAutoEncoder.scala
@@ -26,6 +26,9 @@ trait H2OMOJOPredictionAutoEncoder {
   self: H2OMOJOModel =>
 
   def getAutoEncoderPredictionUDF(): UserDefinedFunction = {
+    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+      " 'detailed_prediction' instead. The 'prediction' column will contain directly the original input the" +
+      " way AutoEncoder model sees it (1-hot encoded categorical values) .")
     udf[Base, Row] { r: Row =>
       val pred = easyPredictModelWrapper.predictAutoEncoder(RowConverter.toH2ORowData(r))
       Base(pred.original, pred.reconstructed)

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionBinomial.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionBinomial.scala
@@ -34,7 +34,7 @@ trait H2OMOJOPredictionBinomial {
   }
 
   def getBinomialPredictionUDF(): UserDefinedFunction = {
-    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+    logWarning("Starting from the next major release, the content of 'prediction' column will be generated to " +
       " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted label.")
     if (supportsCalibratedProbabilities(easyPredictModelWrapper)) {
       if (getWithDetailedPredictionCol()) {

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionDimReduction.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionDimReduction.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.{Column, Row}
 trait H2OMOJOPredictionDimReduction {
   self: H2OMOJOModel =>
   def getDimReductionPredictionUDF(): UserDefinedFunction = {
-    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+    logWarning("Starting from the next major release, the content of 'prediction' column will be generated to " +
       " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted dimensions.")
     udf[Base, Row] { r: Row =>
       val pred = easyPredictModelWrapper.predictDimReduction(RowConverter.toH2ORowData(r))

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionDimReduction.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionDimReduction.scala
@@ -25,6 +25,8 @@ import org.apache.spark.sql.{Column, Row}
 trait H2OMOJOPredictionDimReduction {
   self: H2OMOJOModel =>
   def getDimReductionPredictionUDF(): UserDefinedFunction = {
+    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+      " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted dimensions.")
     udf[Base, Row] { r: Row =>
       val pred = easyPredictModelWrapper.predictDimReduction(RowConverter.toH2ORowData(r))
       Base(pred.dimensions)

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionMultinomial.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionMultinomial.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{Column, Row}
 trait H2OMOJOPredictionMultinomial {
   self: H2OMOJOModel =>
   def getMultinomialPredictionUDF(): UserDefinedFunction = {
-    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+    logWarning("Starting from the next major release, the content of 'prediction' column will be generated to " +
       " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted label.")
     udf[Base, Row] { r: Row =>
       val pred = easyPredictModelWrapper.predictMultinomial(RowConverter.toH2ORowData(r))

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionRegression.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionRegression.scala
@@ -26,7 +26,7 @@ trait H2OMOJOPredictionRegression {
   self: H2OMOJOModel =>
 
   def getRegressionPredictionUDF(): UserDefinedFunction = {
-    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+    logWarning("Starting from the next major release, the content of 'prediction' column will be generated to " +
       " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted value.")
     if (getWithDetailedPredictionCol()) {
       udf[WithContributions, Row] { r: Row =>

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionWordEmbedding.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionWordEmbedding.scala
@@ -28,7 +28,7 @@ trait H2OMOJOPredictionWordEmbedding {
   self: H2OMOJOModel =>
 
   def getWordEmbeddingPredictionUDF(): UserDefinedFunction = {
-    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+    logWarning("Starting from the next major release, the content of 'prediction' column will be generated to " +
       " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted word embeddings.")
     udf[Base, Row] { r: Row =>
       val pred = easyPredictModelWrapper.predictWord2Vec(RowConverter.toH2ORowData(r))

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionWordEmbedding.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionWordEmbedding.scala
@@ -28,6 +28,8 @@ trait H2OMOJOPredictionWordEmbedding {
   self: H2OMOJOModel =>
 
   def getWordEmbeddingPredictionUDF(): UserDefinedFunction = {
+    logWarning("Starting from next major release, the content of 'prediction' column will be generated to " +
+      " 'detailed_prediction' instead. The 'prediction' column will contain directly the predicted word embeddings.")
     udf[Base, Row] { r: Row =>
       val pred = easyPredictModelWrapper.predictWord2Vec(RowConverter.toH2ORowData(r))
       Base(pred.wordEmbeddings)


### PR DESCRIPTION
The other algos have it deprecated already. Starting from next release, the predicted column will contain the most important prediction output, the rest will be in detailed_prediction