### PR TITLE
[SW-1616] Benchmarks: Automatic Cluster Shutdown after Timeout

### DIFF
--- a/benchmarks/src/main/terraform/aws/modules/emr_benchmarks_deployment/variables.tf
+++ b/benchmarks/src/main/terraform/aws/modules/emr_benchmarks_deployment/variables.tf
@@ -16,7 +16,7 @@ variable "aws_emr_version" {
   default = "SUBST_EMR_VERSION"
 }
 variable "aws_emr_timeout" {
-  default = "5 hours"
+  default = "4 hours"
 }
 variable "aws_core_instance_count" {
   default = "2"

--- a/benchmarks/src/main/terraform/aws/modules/emr_benchmarks_deployment/variables.tf
+++ b/benchmarks/src/main/terraform/aws/modules/emr_benchmarks_deployment/variables.tf
@@ -15,6 +15,9 @@ variable "aws_region" {
 variable "aws_emr_version" {
   default = "SUBST_EMR_VERSION"
 }
+variable "aws_emr_timeout" {
+  default = "5 hours"
+}
 variable "aws_core_instance_count" {
   default = "2"
 }

--- a/benchmarks/src/main/terraform/aws/variables.tf
+++ b/benchmarks/src/main/terraform/aws/variables.tf
@@ -16,6 +16,9 @@ variable "aws_availability_zone" {
 variable "aws_emr_version" {
   default = "SUBST_EMR_VERSION"
 }
+variable "aws_emr_timeout" {
+  default = "5 hours"
+}
 variable "aws_core_instance_count" {
   default = "2"
 }

--- a/benchmarks/src/main/terraform/aws/variables.tf
+++ b/benchmarks/src/main/terraform/aws/variables.tf
@@ -17,7 +17,7 @@ variable "aws_emr_version" {
   default = "SUBST_EMR_VERSION"
 }
 variable "aws_emr_timeout" {
-  default = "5 hours"
+  default = "4 hours"
 }
 variable "aws_core_instance_count" {
   default = "2"


### PR DESCRIPTION
- In case of a jenkins pipeline gets shooted down
- Tested locally with a timeout set to 10 minutes