### PR TITLE
[SW-1623]  Fix tests causing intermittent NPE in PySparkling with rollups on external backend

### DIFF
--- a/examples/scripts/hamOrSpam.script.scala
+++ b/examples/scripts/hamOrSpam.script.scala
@@ -141,7 +141,9 @@ def isSpam(msg: String,
     hashingTF.transform (
       tokenize (msgRdd))).map(v => ("?", v)).toDF("target", "fv")
   val msgTable: H2OFrame = h2oContext.asH2OFrame(msgVector)
-  msgTable.remove(0) // remove first column
+  H2OFrameSupport.withLockAndUpdate(msgTable) {
+    _.remove(0) // remove first column
+  }
   val prediction = dlModel.score(msgTable)
   //println(prediction)
   prediction.vecs()(1).at(0) < hamThreshold

--- a/examples/src/main/scala/org/apache/spark/examples/h2o/HamOrSpamDemo.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/h2o/HamOrSpamDemo.scala
@@ -180,7 +180,9 @@ object HamOrSpamDemo extends SparkContextSupport with ModelMetricsSupport with H
       hashingTF.transform(
         tokenize(msgRdd))).map(v => SMS("?", v)).toDF
     val msgTable: H2OFrame = msgVector
-    msgTable.remove(0) // remove first column
+    H2OFrameSupport.withLockAndUpdate(msgTable) {
+      _.remove(0) // remove first column
+    }
     val prediction = dlModel.score(msgTable)
     //println(prediction)
     prediction.vecs()(1).at(0) < hamThreshold


### PR DESCRIPTION
The failing tests has to ensure that frame updates are inside **withLockAndUpdate** block