### PR TITLE
[SW-1642] Prevent sending empty partitions when converting Spark Data frame to H2OFrame

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -53,8 +53,9 @@ private[h2o] object SparkDataFrameConverter extends Logging {
     import ai.h2o.sparkling.ml.utils.SchemaUtils._
 
     val flatDataFrameOriginal = flattenDataFrame(dataFrame)
-    val flatDataFrame = if (flatDataFrameOriginal.count() < flatDataFrameOriginal.rdd.partitions.length) {
-      flatDataFrameOriginal.coalesce(flatDataFrameOriginal.rdd.partitions.length)
+    val numPartitions = flatDataFrameOriginal.rdd.partitions.length
+    val flatDataFrame = if (flatDataFrameOriginal.count() < numPartitions) {
+      flatDataFrameOriginal.coalesce(numPartitions)
     } else {
       flatDataFrameOriginal
     }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -52,7 +52,12 @@ private[h2o] object SparkDataFrameConverter extends Logging {
   def toH2OFrame(hc: H2OContext, dataFrame: DataFrame, frameKeyName: Option[String]): H2OFrame = {
     import ai.h2o.sparkling.ml.utils.SchemaUtils._
 
-    val flatDataFrame = flattenDataFrame(dataFrame)
+    val flatDataFrameOriginal = flattenDataFrame(dataFrame)
+    val flatDataFrame = if (flatDataFrameOriginal.count() < flatDataFrameOriginal.rdd.partitions.length) {
+      flatDataFrameOriginal.coalesce(flatDataFrameOriginal.rdd.partitions.length)
+    } else {
+      flatDataFrameOriginal
+    }
     val dfRdd = flatDataFrame.rdd
     val keyName = frameKeyName.getOrElse("frame_rdd_" + dfRdd.id + Key.rand())
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -52,13 +52,7 @@ private[h2o] object SparkDataFrameConverter extends Logging {
   def toH2OFrame(hc: H2OContext, dataFrame: DataFrame, frameKeyName: Option[String]): H2OFrame = {
     import ai.h2o.sparkling.ml.utils.SchemaUtils._
 
-    val flatDataFrameOriginal = flattenDataFrame(dataFrame)
-    val numPartitions = flatDataFrameOriginal.rdd.partitions.length
-    val flatDataFrame = if (flatDataFrameOriginal.count() < numPartitions) {
-      flatDataFrameOriginal.repartition(numPartitions)
-    } else {
-      flatDataFrameOriginal
-    }
+    val flatDataFrame = flattenDataFrame(dataFrame)
     val dfRdd = flatDataFrame.rdd
     val keyName = frameKeyName.getOrElse("frame_rdd_" + dfRdd.id + Key.rand())
 

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -96,7 +96,7 @@ private[h2o] object SparkDataFrameConverter extends Logging {
   private[this]
   def perSQLPartition(elemMaxSizes: Array[Int], elemStartIndices: Array[Int], vecIndices: Array[Int])
                      (keyName: String, expectedTypes: Array[Byte], uploadPlan: Option[UploadPlan],
-                      writeTimeout: Int, driverTimeStamp: Short, sparse: Array[Boolean])
+                      writeTimeout: Int, driverTimeStamp: Short, sparse: Array[Boolean], partitions: Seq[Int])
                      (context: TaskContext, it: Iterator[Row]): (Int, Long) = {
 
     val (iterator, dataSize) = WriteConverterCtxUtils.bufferedIteratorWithSize(uploadPlan, it)
@@ -106,7 +106,7 @@ private[h2o] object SparkDataFrameConverter extends Logging {
       (elemStartIndices(vecIdx), elemMaxSizes(vecIdx))
     }).toMap
     // Creates array of H2O NewChunks; A place to record all the data in this partition
-    con.createChunk(keyName, dataSize, expectedTypes, context.partitionId(), vecIndices.map(elemMaxSizes(_)), sparse, vecStartSize)
+    con.createChunk(keyName, dataSize, expectedTypes, partitions.indexOf(context.partitionId()), vecIndices.map(elemMaxSizes(_)), sparse, vecStartSize)
 
     var localRowIdx = 0
     iterator.foreach { row =>

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -55,7 +55,7 @@ private[h2o] object SparkDataFrameConverter extends Logging {
     val flatDataFrameOriginal = flattenDataFrame(dataFrame)
     val numPartitions = flatDataFrameOriginal.rdd.partitions.length
     val flatDataFrame = if (flatDataFrameOriginal.count() < numPartitions) {
-      flatDataFrameOriginal.coalesce(numPartitions)
+      flatDataFrameOriginal.repartition(numPartitions)
     } else {
       flatDataFrameOriginal
     }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
@@ -101,7 +101,7 @@ object WriteConverterCtxUtils {
 
     val operation: SparkJob[T] = func(keyName, expectedTypes, uploadPlan, writeTimeout, H2O.SELF.getTimestamp(), sparse)
     val nonEmptyPartitions = rdd.mapPartitionsWithIndex{
-      case (idx, it) => if (it.isEmpty) Iterator.single(idx) else Iterator.empty
+      case (idx, it) => if (it.nonEmpty) Iterator.single(idx) else Iterator.empty
     }.collect().toSeq
     val rows = hc.sparkContext.runJob(rdd, operation, nonEmptyPartitions) // eager, not lazy, evaluation
     val res = new Array[Long](rdd.partitions.length)

--- a/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
@@ -99,7 +99,7 @@ object WriteConverterCtxUtils {
       rddInput
     }
 
-    val nonEmptyPartitions = rdd.mapPartitionsWithIndex{
+    val nonEmptyPartitions = rdd.mapPartitionsWithIndex {
       case (idx, it) => if (it.nonEmpty) Iterator.single(idx) else Iterator.empty
     }.collect().toSeq.sorted
     val operation: SparkJob[T] = func(keyName, expectedTypes, uploadPlan, writeTimeout, H2O.SELF.getTimestamp(), sparse, nonEmptyPartitions)

--- a/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
@@ -104,7 +104,7 @@ object WriteConverterCtxUtils {
     }.collect().toSeq.sorted
     val operation: SparkJob[T] = func(keyName, expectedTypes, uploadPlan, writeTimeout, H2O.SELF.getTimestamp(), sparse, nonEmptyPartitions)
     val rows = hc.sparkContext.runJob(rdd, operation, nonEmptyPartitions) // eager, not lazy, evaluation
-    val res = new Array[Long](rdd.partitions.length)
+    val res = new Array[Long](nonEmptyPartitions.size)
     rows.foreach { case (cidx, nrows) => res(cidx) = nrows }
     // Add Vec headers per-Chunk, and finalize the H2O Frame
 

--- a/examples/src/integTest/scala/water/sparkling/itest/local/PubDev928Suite.scala
+++ b/examples/src/integTest/scala/water/sparkling/itest/local/PubDev928Suite.scala
@@ -84,7 +84,6 @@ object PubDev928Test extends SparkContextSupport with IntegTestStopper {
     for (i <- 0 until av.nChunks()) {
       println(av.chunkForChunkIdx(i).len())
     }
-    assert((0 until av.nChunks()).exists(idx => av.chunkForChunkIdx(idx).len() == 0), "At least on chunk with 0-rows has to exist!")
 
     // And run scoring on dataset which contains at least one chunk with zero-lines
     import h2oContext.implicits._

--- a/gradle/conf/scalastyle-config.xml
+++ b/gradle/conf/scalastyle-config.xml
@@ -83,7 +83,7 @@
  <!-- </check> -->
  <check customId="rddtype" level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
   <parameters>
-   <parameter name="maxParameters"><![CDATA[11]]></parameter>
+   <parameter name="maxParameters"><![CDATA[12]]></parameter>
   </parameters>
  </check>
  <!-- <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true"> -->


### PR DESCRIPTION
This one is finally fixing the missing chunk issue (EDIT, not yet :( )

Explanation here https://0xdata.atlassian.net/browse/PUBDEV-6904, I have put the fix into H2O so it can again receive and confirm empty chunks but also ensured that we do not send empty chunks for conversions as there is no value in that.