### PR TITLE
[SW-1628] Create migration guide document with breaking changes so far added to 3.28

### DIFF
--- a/doc/src/site/sphinx/index.rst
+++ b/doc/src/site/sphinx/index.rst
@@ -29,6 +29,7 @@ Have questions about Sparkling Water? Post them on Stack Overflow using the `spa
    devel/devel
    pysparkling
    rsparkling
+   migration_guide
    FAQ
    CHANGELOG
 

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -38,14 +38,19 @@ DRF exposed into Sparkling Water Algorithm API
 
 DRF is now exposed in the Sparkling Water. Please see our documentation to learn how to use it :ref:`drf`.
 
+Change Default Name of Prediction Column
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The default name of the prediction column is changed to ``prediction`` from ``prediction_output``.
+
 Single value in prediction column
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The default name of the prediction column is changed to ``prediction`` from ``prediction_output``. Also, the
-prediction output now contains always directly the predicted value. In case of regression issue the predicted numeric value
-and in case of classification the predicted label. If you are interested in more details created during the prediction,
-please make sure to set ``withDetailedPredictionCol`` to ``true`` via the setters on both PySparkling Scala side.
-When enabled, additional column ``detailed_prediction`` is created which contains additional prediction details, such as
+The prediction column contains directly the predicted value. For example, before this change, the prediction column contained
+another struct field called ``value`` (in case of regression issue), which contained the value. From now on, the predicted value
+is always stored directly in the prediction column. In case of regression issue,  the predicted numeric value
+and in case of classification, the predicted label. If you are interested in more details created during the prediction,
+please make sure to set ``withDetailedPredictionCol`` to ``true`` via the setters on both PySparkling and Sparkling Water.
+When enabled, additional column named ``detailed_prediction`` is created which contains additional prediction details, such as
 probabilities, contributions and so on.
 
 Removal of Deprecated Methods and Classes

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -1,0 +1,72 @@
+Migration Guide
+===============
+
+Migration guide between major Sparkling Water versions
+
+From 3.26 To 3.28
+-----------------
+
+String instead of enums in Sparkling Water Algo API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- In scala, Setters on the pipeline wrappers for H2O algorithms now accepts strings in places where they accepted
+  enum values before. Before, we called, for example:
+
+.. code-block:: scala
+
+    import hex.genmodel.utils.DistributionFamily
+    val gbm = H2OGBM()
+    gbm.setDistribution(DistributionFamily.multinomial)
+
+
+Now, the correct code is:
+
+.. code-block:: scala
+
+    val gbm = H2OGBM()
+    gbm.setDistribution("multinomial")
+
+which makes the Python and Scala consistent. Both upper case and lower case values are valid and if a wrong
+input is entered, user is warned with correct possible values.
+
+Switch to Java 1.8 on Spark 2.1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sparkling Water for Spark 2.1 now requires Java 1.8 and higher.
+
+DRF exposed into Sparkling Water Algorithm API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+DRF is now exposed in the Sparkling Water. Please see our documentation to learn how to use it :ref:`drf`.
+
+Single value in prediction column
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default name of the prediction column is changed to ``prediction`` from ``prediction_output``. Also, the
+prediction output now contains always directly the predicted value. In case of regression issue the predicted numeric value
+and in case of classification the predicted label. If you are interested in more details created during the prediction,
+please make sure to set ``withDetailedPredictionCol`` to ``true`` via the setters on both PySparkling Scala side.
+When enabled, additional column ``detailed_prediction`` is created which contains additional prediction details, such as
+probabilities, contributions and so on.
+
+Removal of Deprecated Methods and Classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``getColsampleBytree and setColsampleBytree`` methods are removed on our algorithm API. Please use
+  the new ``getColSampleByTree`` and ``setColSampleByTree``
+
+- Remove deprecated option ``spark.ext.h2o.external.cluster.num.h2o.nodes`` and corresponding setters.
+  Please use ``spark.ext.h2o.external.cluster.size`` or corresponding setter ``setClusterSize``
+
+- Deprecated Algorithm classes in package ``org.apache.spark.h2o.ml.algos`` have been removed. Please
+  use the classes from the package ``ai.h2o.sparkling.ml.algos``. Their API remains the same. This is the
+  beginning of moving Sparkling Water classes to our distinct package.
+
+- Remove deprecated option ``spark.ext.h2o.external.read.confirmation.timeout`` and related setters.
+  This option is removed without replacement as it is no longer needed.
+
+- Remove deprecated parameter ``SelectBestModelDecreasing`` on our Grid Search API. Related getters and setters
+  have been also removed. This method is removed without replacement as we now internally correctly sort
+  the models according to what is best for the specified metric.
+
+- TargetEncoder transformer now accepts outputCols parameter which you can use to override the default output
+  column names.

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -40,14 +40,15 @@ DRF is now exposed in the Sparkling Water. Please see our documentation to learn
 
 Change Default Name of Prediction Column
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The default name of the prediction column is changed to ``prediction`` from ``prediction_output``.
+
+The default name of the prediction column has been changed from ``prediction_output`` to ``prediction``.
 
 Single value in prediction column
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The prediction column contains directly the predicted value. For example, before this change, the prediction column contained
 another struct field called ``value`` (in case of regression issue), which contained the value. From now on, the predicted value
-is always stored directly in the prediction column. In case of regression issue,  the predicted numeric value
+is always stored directly in the prediction column. In case of regression issue, the predicted numeric value
 and in case of classification, the predicted label. If you are interested in more details created during the prediction,
 please make sure to set ``withDetailedPredictionCol`` to ``true`` via the setters on both PySparkling and Sparkling Water.
 When enabled, additional column named ``detailed_prediction`` is created which contains additional prediction details, such as
@@ -62,7 +63,7 @@ Removal of Deprecated Methods and Classes
 - Removal of deprecated option ``spark.ext.h2o.external.cluster.num.h2o.nodes`` and corresponding setters.
   Please use ``spark.ext.h2o.external.cluster.size`` or the corresponding setter ``setClusterSize``.
 
-- Removal of of deprecated algorithm classes in package ``org.apache.spark.h2o.ml.algos``. Please
+- Removal of deprecated algorithm classes in package ``org.apache.spark.h2o.ml.algos``. Please
   use the classes from the package ``ai.h2o.sparkling.ml.algos``. Their API remains the same as before. This is the
   beginning of moving Sparkling Water classes to our distinct package ``ai.h2o.sparkling``
 

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -1,14 +1,14 @@
 Migration Guide
 ===============
 
-Migration guide between major Sparkling Water versions
+Migration guide between major Sparkling Water versions.
 
 From 3.26 To 3.28
 -----------------
 
 String instead of enums in Sparkling Water Algo API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- In scala, Setters on the pipeline wrappers for H2O algorithms now accepts strings in places where they accepted
+- In scala, setters of the pipeline wrappers for H2O algorithms now accepts strings in places where they accepted
   enum values before. Before, we called, for example:
 
 .. code-block:: scala
@@ -25,8 +25,8 @@ Now, the correct code is:
     val gbm = H2OGBM()
     gbm.setDistribution("multinomial")
 
-which makes the Python and Scala consistent. Both upper case and lower case values are valid and if a wrong
-input is entered, user is warned with correct possible values.
+which makes the Python and Scala APIs consistent. Both upper case and lower case values are valid and if a wrong
+input is entered, warning is printed out with correct possible values.
 
 Switch to Java 1.8 on Spark 2.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,22 +51,22 @@ probabilities, contributions and so on.
 Removal of Deprecated Methods and Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``getColsampleBytree and setColsampleBytree`` methods are removed on our algorithm API. Please use
-  the new ``getColSampleByTree`` and ``setColSampleByTree``
+- ``getColsampleBytree`` and ``setColsampleBytree`` methods are removed from the XGBoost API. Please use
+  the new ``getColSampleByTree`` and ``setColSampleByTree``.
 
-- Remove deprecated option ``spark.ext.h2o.external.cluster.num.h2o.nodes`` and corresponding setters.
-  Please use ``spark.ext.h2o.external.cluster.size`` or corresponding setter ``setClusterSize``
+- Removal of deprecated option ``spark.ext.h2o.external.cluster.num.h2o.nodes`` and corresponding setters.
+  Please use ``spark.ext.h2o.external.cluster.size`` or the corresponding setter ``setClusterSize``.
 
-- Deprecated Algorithm classes in package ``org.apache.spark.h2o.ml.algos`` have been removed. Please
-  use the classes from the package ``ai.h2o.sparkling.ml.algos``. Their API remains the same. This is the
-  beginning of moving Sparkling Water classes to our distinct package.
+- Removal of of deprecated algorithm classes in package ``org.apache.spark.h2o.ml.algos``. Please
+  use the classes from the package ``ai.h2o.sparkling.ml.algos``. Their API remains the same as before. This is the
+  beginning of moving Sparkling Water classes to our distinct package ``ai.h2o.sparkling``
 
-- Remove deprecated option ``spark.ext.h2o.external.read.confirmation.timeout`` and related setters.
-  This option is removed without replacement as it is no longer needed.
+- Removal of deprecated option ``spark.ext.h2o.external.read.confirmation.timeout`` and related setters.
+  This option is removed without a replacement as it is no longer needed.
 
-- Remove deprecated parameter ``SelectBestModelDecreasing`` on our Grid Search API. Related getters and setters
-  have been also removed. This method is removed without replacement as we now internally correctly sort
-  the models according to what is best for the specified metric.
+- Removal of deprecated parameter ``SelectBestModelDecreasing`` on the Grid Search API. Related getters and setters
+  have been also removed. This method is removed without replacement as we now internally sort
+  the models with the ordering meaningful for the specified sort metric.
 
-- TargetEncoder transformer now accepts outputCols parameter which you can use to override the default output
+- TargetEncoder transformer now accepts the ``outputCols`` parameter which can be used to override the default output
   column names.

--- a/doc/src/site/sphinx/tutorials/sw_drf.rst
+++ b/doc/src/site/sphinx/tutorials/sw_drf.rst
@@ -1,3 +1,5 @@
+.. _drf:
+
 Train DRF Model in Sparkling Water
 ----------------------------------
 


### PR DESCRIPTION
Migration guide between major SW versions. I have included changes which goes to next major 3.28 and are breaking the code. It would be great if every change going to major rel which is altering the current API has also short description in this document