### PR TITLE
[SW-1619]    Upgrade Spark 2.3 to 2.3.4

### DIFF
--- a/gradle-spark2.3.properties
+++ b/gradle-spark2.3.properties
@@ -1,4 +1,4 @@
-sparkVersion=2.3.3
+sparkVersion=2.3.4
 minSupportedJavaVersion=1.8
 supportedEmrVersion=emr-5.19.0
 unsupportedMinorSparkVersions=


### PR DESCRIPTION
After this change is merged, we need to trigger build of a new docker image and update the version in both master and rel branch to ensure our tests are using the docker with the upgraded spark.