### PR TITLE
[SW-1655] Always require IP:Port of the external cluster in manual start mode.

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -195,13 +195,10 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
         hc._conf.setClientIp(clientIp.get)
       }
     } else {
-      // manual mode, check if the user specified the cluster representative
-      if (hc._conf.h2oCluster.isDefined) {
         val clientIp = NetworkUtils.indentifyClientIp(hc._conf.h2oClusterHost.get)
         if (clientIp.isDefined && hc._conf.clientIp.isEmpty && hc._conf.clientNetworkMask.isEmpty) {
           hc._conf.setClientIp(clientIp.get)
         }
-      }
     }
 
     if (hc._conf.clientIp.isEmpty) {
@@ -388,6 +385,10 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Exter
           s"""Cluster name has to be specified when using the external H2O cluster mode in the manual start mode.
              |It can be set either on the configuration object or via '${SharedBackendConf.PROP_CLOUD_NAME._1}'
              |spark configuration property""".stripMargin)
+      }
+
+      if (conf.h2oCluster.isEmpty) {
+        throw new IllegalArgumentException("H2O Cluster endpoint has to be specified!")
       }
     }
     conf


### PR DESCRIPTION
Currently, in manual cluster mode, it is optional to specify the H2OCluster endpoint. If it is not specified, H2O tries to find the cluster using broadcast search. In rest API based solution, we always need  to know the endpoint of the cluster.

This change accomplishes that, but also in the client based solution, not just rest api based to ensure unified behaviour. In my opinion it is better to be more explicit in manual mode. Anyway, we are planning to make Scala also rest API based at some point.

What we just need to do is to deprecate the behaviour and warn the users that endpoint will be always required. After we discuss this, I can create JIRA in our Major release which would accomplish this deprecation so we don't forget about that.