### PR TITLE
[SW-1667] Enable Users to Specify Block Size of Communication in External Backend

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -60,6 +60,8 @@ trait ExternalBackendConf extends SharedBackendConf {
   def externalH2ODriverPort = sparkConf.getOption(PROP_EXTERNAL_DRIVER_PORT._1)
   def externalH2ODriverPortRange = sparkConf.getOption(PROP_EXTERNAL_DRIVER_PORT_RANGE._1)
   def externalExtraMemoryPercent = sparkConf.getInt(PROP_EXTERNAL_EXTRA_MEMORY_PERCENT._1, PROP_EXTERNAL_EXTRA_MEMORY_PERCENT._2)
+  def externalCommunicationBlockSizeAsBytes: Long = sparkConf.getSizeAsBytes(PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._1, PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._2)
+  def externalCommunicationBlockSize: String = sparkConf.get(PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._1, PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._2)
 
   /** Setters */
 
@@ -124,6 +126,7 @@ trait ExternalBackendConf extends SharedBackendConf {
   def setExternalH2ODriverPort(port: Int): H2OConf = set(PROP_EXTERNAL_DRIVER_PORT._1, port.toString)
   def setExternalH2ODriverPortRange(portRange: String): H2OConf = set(PROP_EXTERNAL_DRIVER_PORT_RANGE._1, portRange)
   def setExternalExtraMemoryPercent(memoryPercent: Int): H2OConf = set(PROP_EXTERNAL_EXTRA_MEMORY_PERCENT._1, memoryPercent.toString)
+  def setExternalCommunicationBlockSize(blockSize: String): H2OConf = set(PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._1, blockSize)
 
   def externalConfString: String =
     s"""Sparkling Water configuration:
@@ -210,7 +213,7 @@ object ExternalBackendConf {
   val PROP_EXTERNAL_KERBEROS_PRINCIPAL = ("spark.ext.h2o.external.kerberos.principal", None)
 
   /**
-    * Kerberos principal
+    * Path to Kerberos key tab
     */
   val PROP_EXTERNAL_KERBEROS_KEYTAB = ("spark.ext.h2o.external.kerberos.keytab", None)
 
@@ -218,5 +221,10 @@ object ExternalBackendConf {
     * Impersonated Hadoop user
     */
   val PROP_EXTERNAL_RUN_AS_USER = ("spark.ext.h2o.external.run.as.user", None)
+
+  /**
+    * The size of blocks representing data traffic from Spark nodes to H2O-3 nodes.
+    */
+  val PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE = ("spark.ext.h2o.external.communication.blockSize", "1m")
 
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -60,7 +60,9 @@ trait ExternalBackendConf extends SharedBackendConf {
   def externalH2ODriverPort = sparkConf.getOption(PROP_EXTERNAL_DRIVER_PORT._1)
   def externalH2ODriverPortRange = sparkConf.getOption(PROP_EXTERNAL_DRIVER_PORT_RANGE._1)
   def externalExtraMemoryPercent = sparkConf.getInt(PROP_EXTERNAL_EXTRA_MEMORY_PERCENT._1, PROP_EXTERNAL_EXTRA_MEMORY_PERCENT._2)
-  def externalCommunicationBlockSizeAsBytes: Long = sparkConf.getSizeAsBytes(PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._1, PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._2)
+  def externalCommunicationBlockSizeAsBytes: Long = sparkConf.getSizeAsBytes(
+    PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._1,
+    PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._2)
   def externalCommunicationBlockSize: String = sparkConf.get(PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._1, PROP_EXTERNAL_COMMUNICATION_BLOCK_SIZE._2)
 
   /** Setters */

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalWriteConverterCtx.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalWriteConverterCtx.scala
@@ -27,9 +27,9 @@ import org.apache.spark.sql.types._
 import water._
 import water.fvec.Frame
 
-class ExternalWriteConverterCtx(nodeDesc: NodeDesc, writeTimeout: Int, driverTimeStamp: Short) extends WriteConverterCtx {
+class ExternalWriteConverterCtx(nodeDesc: NodeDesc, writeTimeout: Int, driverTimeStamp: Short, blockSize: Long) extends WriteConverterCtx {
 
-  private val externalFrameWriter = ExternalFrameWriterClient.create(nodeDesc.hostname, nodeDesc.port, driverTimeStamp, writeTimeout)
+  private val externalFrameWriter = ExternalFrameWriterClient.create(nodeDesc.hostname, nodeDesc.port, driverTimeStamp, writeTimeout, blockSize)
 
   override def closeChunks(numRows: Int): Unit = {
     externalFrameWriter.close()

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -328,6 +328,10 @@ External backend configuration properties
 |                                                       |                | specifies memory for internal JVM   |
 |                                                       |                | use outside of Java heap.           |
 +-------------------------------------------------------+----------------+-------------------------------------+
+| ``spark.ext.h2o.external.communication.blockSize``    | ``1m``         | The size of blocks representing     |
+|                                                       |                | data traffic from Spark nodes to    |
+|                                                       |                | H2O-3 nodes.                        |
++-------------------------------------------------------+----------------+-------------------------------------+
 
 --------------
 

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -330,7 +330,11 @@ External backend configuration properties
 +-------------------------------------------------------+----------------+-------------------------------------+
 | ``spark.ext.h2o.external.communication.blockSize``    | ``1m``         | The size of blocks representing     |
 |                                                       |                | data traffic from Spark nodes to    |
-|                                                       |                | H2O-3 nodes.                        |
+|                                                       |                | H2O-3 nodes. The value must be      |
+|                                                       |                | represented in the same format as   |
+|                                                       |                | JVM memory strings with a size unit |
+|                                                       |                | suffix "k", "m" or "g" (e.g.        |
+|                                                       |                | ``450k``, ``3m``)                   |
 +-------------------------------------------------------+----------------+-------------------------------------+
 
 --------------

--- a/gradle/conf/scalastyle-config.xml
+++ b/gradle/conf/scalastyle-config.xml
@@ -83,7 +83,7 @@
  <!-- </check> -->
  <check customId="rddtype" level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
   <parameters>
-   <parameter name="maxParameters"><![CDATA[12]]></parameter>
+   <parameter name="maxParameters"><![CDATA[13]]></parameter>
   </parameters>
  </check>
  <!-- <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true"> -->


### PR DESCRIPTION
This PR requires https://github.com/h2oai/h2o-3/pull/3931 to be a part of a released version of H2O-3 for successful build.