### PR TITLE
[SW-1681] Change sw version to include also patch within one h2o version

### DIFF
--- a/doc/build.gradle
+++ b/doc/build.gradle
@@ -25,17 +25,11 @@ task substitute() {
     doLast {
         def siteDir = "${buildDir}/site"
 
-        def swOnlyVersion = version.tokenize("-")[0]
-        def (first, second, minorVersion) = swOnlyVersion.tokenize(".")
-        def majorVersion = "${first}.${second}"
-
         new File(siteDir).eachFileRecurse(FILES) {
             if (it.name.endsWith('.html')) {
                 def contents = file(it).getText('UTF-8')
                 contents = contents
                         .replaceAll("SUBST_SW_VERSION", version)
-                        .replaceAll("SUBST_SW_MAJOR_VERSION", majorVersion)
-                        .replaceAll("SUBST_SW_MINOR_VERSION", minorVersion)
                         .replaceAll("SUBST_SPARK_VERSION", sparkVersion)
                         .replaceAll("SUBST_SPARK_MAJOR_VERSION", sparkMajorVersion)
                         .replaceAll("SUBST_H2O_VERSION", h2oVersion)

--- a/doc/src/site/sphinx/deployment/sw_azure_dbc.rst
+++ b/doc/src/site/sphinx/deployment/sw_azure_dbc.rst
@@ -19,7 +19,7 @@ To start Sparkling Water ``H2OContext`` on Databricks Azure, the steps are:
 
 3.  Add Sparkling Water dependency
 
-    In order to create the Java library in Databricks, go to **Libraries**, select **Maven** as the library source and type the following into the coordinates field: ``sparkling-water-package_2.11:SUBST_SW_MINOR_VERSION``.
+    In order to create the Java library in Databricks, go to **Libraries**, select **Maven** as the library source and type the following into the coordinates field: ``ai.h2o:sparkling-water-package_2.11:SUBST_SW_VERSION``.
 
     .. figure:: ../images/databricks_sw_maven.png
         :alt: Uploading Sparkling Water assembly JAR

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -81,3 +81,14 @@ Removal of Deprecated Methods and Classes
   ``lambdaValue``. On Both PySparkling and Sparkling Water ``H2OGLM`` API, we removed methods ``getAlpha`` in favor of
   ``getAlphaValue``, ``getLambda`` in favor of ``getLambdaValue``, ``setAlpha`` in favor of ``setAlphaValue`` and
   ``setLambda`` in favor of ``setLambdaValue``. These changes ensure the consistency across Python and Scala APIs.
+
+Change of Versioning Scheme
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Version of Sparkling Water is changed to the following pattern: ``H2OVersion-SWPatchVersion-SparkVersion``, where:
+``H2OVersion`` is full H2O Version which is integrated with this Sparkling Water. ``SWPatchVersion`` is used to specify
+patch version and ``SparkVersion`` is Spark version. This change of scheme allows us to do releases of Sparkling Water
+without the need of releasing H2O if there is only change on Sparkling Water side. In that case we just increment the
+``SWPatchVersion``. The new version therefore looks, for example, like ``3.26.0.9-2-2.4``. This version tells us this
+Sparkling Water is integrating H2O ``3.26.0.9``, it is second release with ``3.26.0.9`` version and is for Spark ``2.4``.
+

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -86,9 +86,9 @@ Change of Versioning Scheme
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Version of Sparkling Water is changed to the following pattern: ``H2OVersion-SWPatchVersion-SparkVersion``, where:
-``H2OVersion`` is full H2O Version which is integrated with this Sparkling Water. ``SWPatchVersion`` is used to specify
-patch version and ``SparkVersion`` is Spark version. This change of scheme allows us to do releases of Sparkling Water
-without the need of releasing H2O if there is only change on Sparkling Water side. In that case we just increment the
+``H2OVersion`` is full H2O Version which is integrated to Sparkling Water. ``SWPatchVersion`` is used to specify
+a patch version and ``SparkVersion`` is a Spark version. This change of scheme allows us to do releases of Sparkling Water
+without the need of releasing H2O if there is only change on the Sparkling Water side. In that case, we just increment the
 ``SWPatchVersion``. The new version therefore looks, for example, like ``3.26.0.9-2-2.4``. This version tells us this
-Sparkling Water is integrating H2O ``3.26.0.9``, it is second release with ``3.26.0.9`` version and is for Spark ``2.4``.
+Sparkling Water is integrating H2O ``3.26.0.9``, it is the second release with ``3.26.0.9`` version and is for Spark ``2.4``.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ supportedSparkVersions=2.1 2.2 2.3 2.4
 # Select for which Spark version is Sparkling Water built by default
 spark=2.4
 # Sparkling Water Version
-version=3.28.1-SNAPSHOT
+version=3.28.0.1-1-SNAPSHOT

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -8,7 +8,6 @@ apply plugin: 'net.researchgate.release'
 
 release {
     tagTemplate = 'RELEASE-$version'
-    // Safe point - do releases only from release branch - can be deleted in future
     failOnUnversionedFiles = false
     failOnCommitNeeded = false
     preCommitText = ":tada: "

--- a/jenkins/Jenkinsfile-release
+++ b/jenkins/Jenkinsfile-release
@@ -5,7 +5,8 @@
 properties(
         [
                 parameters(
-                        [       booleanParam(name: 'updateChangeLog', defaultValue: true, description: "Update change log"),
+                        [       booleanParam(name: 'wasH2OUpgraded', defaultValue: true, description: "True if H2O was upgraded in this release or not"),
+                                booleanParam(name: 'updateChangeLog', defaultValue: true, description: "Update change log"),
                                 string(name: 'releaseFor', defaultValue: 'all', description: "For which Spark Major version" +
                                         " do a release. By default, do release for all supported released versions"),
                                 booleanParam(name: 'buildConda', defaultValue: true, description: 'Build Conda'),
@@ -90,21 +91,32 @@ String getVersionNoSuffix() {
 
 String getNextVersionNoSuffix(params) {
     def majorVersion = getMajorVersion(params)
+    def minorVersion = getMinorVersion(params)
     def patchVersion = getPatchVersion(params)
-    return "${majorVersion}.${patchVersion.toInteger() + 1}-SNAPSHOT"
+    if (params.wasH2OUpgraded.toBoolean()) {
+        return "${majorVersion}.${minorVersion.toInteger() + 1}-1-SNAPSHOT"
+    } else {
+        return "${majorVersion}.${minorVersion}-${patchVersion.toInteger() + 1}-SNAPSHOT"
+    }
 }
 
 
 String getMajorVersion(params) {
     def v = getVersion(params)
-    def split = v.split("\\.")
-    return "${split[0]}.${split[1]}".toString()
+    def split = v.split("-")[0].split("\\.")
+    return "${split[0]}.${split[1]}.${split[2]}".toString()
+}
+
+String getMinorVersion(params) {
+    def v = getVersion(params)
+    def split = v.split("-")[0].split("\\.")
+    return "${split[3]}".toString()
 }
 
 String getPatchVersion(params) {
     def v = getVersion(params)
     def split = v.split("-")
-    return "${split[0].split("\\.")[2]}"
+    return "${split[1]}".toString()
 }
 
 def prepareReleaseNotes(sparkMajorVersions) {

--- a/jenkins/sparklingWaterPipeline.groovy
+++ b/jenkins/sparklingWaterPipeline.groovy
@@ -11,15 +11,17 @@ def getS3Path(config) {
 String getNightlyVersion(config) {
     def sparkMajorVersion = config.sparkMajorVersion
     def version = readFile("gradle.properties").split("\n").find() { line -> line.startsWith("version") }.split("=")[1]
-    def h2oPart = version.split("-")[0].toString()
-    def swPatch = version.split("-")[1].toString()
+    def versionParts = version.split("-")
+    def h2oPart = versionParts[0]
+    def swPatch = versionParts[1]
     def swNightlyBuildNumber
     try {
         def lastVersion = "https://h2o-release.s3.amazonaws.com/sparkling-water/spark-${config.sparkMajorVersion}/${getS3Path(config)}latest".toURL().getText().toString()
-        def lastH2OPart = lastVersion.split("-")[0].toString()
-        def lastSWPart = lastVersion.split("-")[1]
+        def lastVersionParts = lastVersion.split("-")
+        def lastH2OPart = lastVersionParts[0]
+        def lastSWPart = lastVersionParts[1]
         if (lastSWPart.contains(".")) {
-            def lastSWPatch = lastSWPart.split("\\.")[0].toString()
+            def lastSWPatch = lastSWPart.split("\\.")[0]
             if (lastH2OPart != h2oPart || lastSWPatch != swPatch) {
                 swNightlyBuildNumber = 1 // reset the nightly build number
             } else {

--- a/jenkins/sparklingWaterPipeline.groovy
+++ b/jenkins/sparklingWaterPipeline.groovy
@@ -21,11 +21,13 @@ String getNightlyVersion(config) {
         def lastH2OPart = lastVersionParts[0]
         def lastSWPart = lastVersionParts[1]
         if (lastSWPart.contains(".")) {
-            def lastSWPatch = lastSWPart.split("\\.")[0]
+            def lastSWParts = lastSWPart.split("\\.")
+            def lastSWPatch = lastSWParts[0]
+            def lastSWBuild = lastSWParts[1]
             if (lastH2OPart != h2oPart || lastSWPatch != swPatch) {
                 swNightlyBuildNumber = 1 // reset the nightly build number
             } else {
-                swNightlyBuildNumber = lastSWPatch.toInteger() + 1
+                swNightlyBuildNumber = lastSWBuild.toInteger() + 1
             }
         } else {
             swNightlyBuildNumber = 1

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -127,7 +127,7 @@ def copyPySetup() {
         filter {
             it.replaceAll("SUBST_SPARK_MAJOR_VERSION", sparkMajorVersion)
                     .replaceAll("SUBST_SPARK_VERSION", sparkVersion)
-                    .replaceAll("SUBST_SW_VERSION", version.substring(0, version.lastIndexOf("-").replace("_")))
+                    .replaceAll("SUBST_SW_VERSION", version.substring(0, version.lastIndexOf("-").replace("-", "_")))
                     .replaceAll("SUBST_SPARK_MAJOR_VERSION", sparkMajorVersion)
         }
         into pkgDir

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -166,7 +166,7 @@ def copyPySetup() {
         filter {
             it.replaceAll("SUBST_SPARK_MAJOR_VERSION", sparkMajorVersion)
                     .replaceAll("SUBST_SPARK_VERSION", sparkVersion)
-                    .replaceAll("SUBST_SW_VERSION", version.substring(0, version.lastIndexOf("-")))
+                    .replaceAll("SUBST_SW_VERSION", version.substring(0, version.lastIndexOf("-")).replace("-", "_"))
         }
         into condaDir
     }

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -127,7 +127,7 @@ def copyPySetup() {
         filter {
             it.replaceAll("SUBST_SPARK_MAJOR_VERSION", sparkMajorVersion)
                     .replaceAll("SUBST_SPARK_VERSION", sparkVersion)
-                    .replaceAll("SUBST_SW_VERSION", version.substring(0, version.lastIndexOf("-").replace("-", "_")))
+                    .replaceAll("SUBST_SW_VERSION", version.substring(0, version.lastIndexOf("-")).replace("-", "_"))
                     .replaceAll("SUBST_SPARK_MAJOR_VERSION", sparkMajorVersion)
         }
         into pkgDir

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -127,7 +127,7 @@ def copyPySetup() {
         filter {
             it.replaceAll("SUBST_SPARK_MAJOR_VERSION", sparkMajorVersion)
                     .replaceAll("SUBST_SPARK_VERSION", sparkVersion)
-                    .replaceAll("SUBST_SW_VERSION", version.substring(0, version.lastIndexOf("-")))
+                    .replaceAll("SUBST_SW_VERSION", version.substring(0, version.lastIndexOf("-").replace("_")))
                     .replaceAll("SUBST_SPARK_MAJOR_VERSION", sparkMajorVersion)
         }
         into pkgDir

--- a/py/src/ai/h2o/sparkling/VersionComponents.py
+++ b/py/src/ai/h2o/sparkling/VersionComponents.py
@@ -21,14 +21,15 @@ class VersionComponents(object):
 
     @staticmethod
     def parseFromSparklingWaterVersion(version):
-        match = re.search(r"^((\d+\.\d+)\.(\d+))(-(\d+))?-(\d+\.\d+)$", version)
+        match = re.search(r"^((\d+\.\d+\.\d+)\.(\d+)-(\d+))(\.(\d+))?-(\d+\.\d+)$", version)
         result = VersionComponents()
         result.fullVersion = match.group(0)
         result.sparklingVersion = match.group(1)
         result.sparklingMajorVersion = match.group(2)
         result.sparklingMinorVersion = match.group(3)
-        result.nightlyVersion = match.group(5)
-        result.sparkMajorMinorVersion = match.group(6)
+        result.sparklingPatchVersion = match.group(4)
+        result.nightlyVersion = match.group(6)
+        result.sparkMajorMinorVersion = match.group(7)
         return result
 
     @staticmethod

--- a/py/tests/unit/simple/test_version_components.py
+++ b/py/tests/unit/simple/test_version_components.py
@@ -19,26 +19,28 @@ from ai.h2o.sparkling.VersionComponents import VersionComponents
 
 
 def testVersionComponentsCanBeParsedFromRegularVersion():
-    version = "3.26.2-2.4"
+    version = "3.26.0.2-2-2.4"
     components = VersionComponents.parseFromSparklingWaterVersion(version)
 
     assert components.fullVersion == version
-    assert components.sparklingVersion == "3.26.2"
-    assert components.sparklingMajorVersion == "3.26"
+    assert components.sparklingVersion == "3.26.0.2-2"
+    assert components.sparklingMajorVersion == "3.26.0"
     assert components.sparklingMinorVersion == "2"
+    assert components.sparklingPatchVersion == "2"
     assert components.nightlyVersion is None
     assert components.sparkMajorMinorVersion == "2.4"
 
 
 def testVersionComponentsCanBeParsedFromNightlyVersion():
-    version = "3.28.1-14-2.3"
+    version = "3.28.0.1-1.14-2.3"
 
     components = VersionComponents.parseFromSparklingWaterVersion(version)
 
     assert components.fullVersion == version
-    assert components.sparklingVersion == "3.28.1"
-    assert components.sparklingMajorVersion == "3.28"
+    assert components.sparklingVersion == "3.28.0.1-1"
+    assert components.sparklingMajorVersion == "3.28.0"
     assert components.sparklingMinorVersion == "1"
+    assert components.sparklingPatchVersion == "1"
     assert components.nightlyVersion == "14"
     assert components.sparkMajorMinorVersion == "2.3"
 


### PR DESCRIPTION
Versions will be:

Normal: 3.26.0.9-1-2.4
where 3.26.0.9 is H2O version, -1 is iteration within the single h2o version and -2.4 is spark version.

For nightlies, the format is: 3.26.0.9-1.1-2.4, where almost everything is same as ^ except the `1.1` represents the iteration and the nightly build number after the dot.


