### PR TITLE
[SW-1688] Fix docker image generation for Scala Sparkling Water in Kuberntes Environment

### DIFF
--- a/kubernetes/build.gradle
+++ b/kubernetes/build.gradle
@@ -30,7 +30,7 @@ task copyDist(type: Copy, dependsOn: ":sparkling-water-dist:dist") {
 task createScalaDockerfile(type: Dockerfile, dependsOn: [buildSparkImages, copyDist]) {
     destFile = outputFileScala
     from "spark:${sparkVersion}"
-    copyFile("sparkling-water/assembly/build/libs/sparkling-water-assembly_2.11-${version}-all.jar", "/opt/spark/jars")
+    copyFile("sparkling-water/assembly/build/libs/sparkling-water-assembly_2.11-${version}-all.jar", "/opt/spark/jars/sparkling-water-assembly_2.11-${version}-all.jar")
 }
 
 task buildScalaImage(type: Exec, dependsOn: createScalaDockerfile) {


### PR DESCRIPTION
Previously, we replaced the jars folder by the sparkling water zip file, this way we copy the file to the folder