### PR TITLE
[SW-1699] Replace H2O Logging by Spark Logging in H2OContext

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -31,7 +31,8 @@ import org.apache.spark.network.Security
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import water._
 import water.api.schemas3.CloudV3
-import water.util.{Log, PrettyPrint}
+import water.util.PrettyPrint
+
 import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -115,10 +116,10 @@ abstract class H2OContext private(val sparkSession: SparkSession, conf: H2OConf)
     */
   def init(): H2OContext = {
     // Use H2O's logging as H2O info log level is default
-    Log.info("Sparkling Water version: " + BuildInfo.SWVersion)
-    Log.info("Spark version: " + sparkContext.version)
-    Log.info("Integrated H2O version: " + BuildInfo.H2OVersion)
-    Log.info("The following Spark configuration is used: \n    " + _conf.getAll.mkString("\n    "))
+    logInfo("Sparkling Water version: " + BuildInfo.SWVersion)
+    logInfo("Spark version: " + sparkContext.version)
+    logInfo("Integrated H2O version: " + BuildInfo.H2OVersion)
+    logInfo("The following Spark configuration is used: \n    " + _conf.getAll.mkString("\n    "))
     if (!isRunningOnCorrectSpark(sparkContext)) {
       throw new WrongSparkVersion(s"You are trying to use Sparkling Water built for Spark ${BuildInfo.buildSparkMajorVersion}," +
         s" but your $$SPARK_HOME(=${sparkContext.getSparkHome().getOrElse("SPARK_HOME is not defined!")}) property" +

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -115,7 +115,6 @@ abstract class H2OContext private(val sparkSession: SparkSession, conf: H2OConf)
     * otherwise it creates new H2O cluster living in Spark
     */
   def init(): H2OContext = {
-    // Use H2O's logging as H2O info log level is default
     logInfo("Sparkling Water version: " + BuildInfo.SWVersion)
     logInfo("Spark version: " + sparkContext.version)
     logInfo("Integrated H2O version: " + BuildInfo.H2OVersion)


### PR DESCRIPTION
Replace remaining places where we use H2O logging in H2OContext.

Ultimately, after we have one backend where driver does not use H2O, we need to use Spark logging everywhere 
See https://0xdata.atlassian.net/browse/SW-1699