### PR TITLE
[SW-1706] Put h2o-security package into sparkling water assembly

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -38,6 +38,8 @@ dependencies {
         exclude(group: "net.java.dev.jets3t", module: "jets3t")
         exclude(group: "commons-collections", module: "commons-collections")
     }
+    compile "ai.h2o:h2o-security:${h2oVersion}"
+
     // H2O Native Hive Support
     compile "ai.h2o:h2o-hive:${h2oVersion}"
     // H2O algorithms


### PR DESCRIPTION
Depends on the upgrade to H2O 3.26.0.11

The dependency is in the assembly automatically as we include all transitive dependencies