### PR TITLE
[SW-1713] Refactor internal & external backend utils to have the same structure

### DIFF
--- a/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/Runner.scala
+++ b/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/Runner.scala
@@ -153,7 +153,7 @@ object Runner {
     }
     outputDir.mkdirs()
     val sparkMaster = spark.conf.get("spark.master")
-    val outputFile = new File(outputDir, s"${sparkMaster}_${hc._conf.backendClusterMode}_${batch.name}.txt")
+    val outputFile = new File(outputDir, s"${sparkMaster}_${hc.getConf.backendClusterMode}_${batch.name}.txt")
     val outputStream = new FileOutputStream(outputFile)
     try {
       batch.benchmarks.foreach(_.exportMeasurements(outputStream))

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -485,7 +485,7 @@ object H2OContext extends Logging {
     !sameNodes
   }
 
-  private def checkConf(conf: H2OConf): H2OConf = {
+  private def checkAndUpdateConf(conf: H2OConf): H2OConf = {
     if (conf.runsInExternalClusterMode) {
       ExternalH2OBackend.checkAndUpdateConf(conf)
     } else {
@@ -500,7 +500,7 @@ object H2OContext extends Logging {
     * @return H2O Context
     */
   def getOrCreate(sparkSession: SparkSession, conf: H2OConf): H2OContext = synchronized {
-    val checkedConf = checkConf(conf)
+    val checkedConf = checkAndUpdateConf(conf)
     val isRestApiBasedClient = conf.getBoolean(SharedBackendConf.PROP_REST_API_BASED_CLIENT._1,
       SharedBackendConf.PROP_REST_API_BASED_CLIENT._2)
     val isExternalBackend = conf.runsInExternalClusterMode

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -493,9 +493,9 @@ object H2OContext extends Logging {
     */
   def getOrCreate(sparkSession: SparkSession, conf: H2OConf): H2OContext = synchronized {
     val checkedConf = if (conf.runsInExternalClusterMode) {
-      InternalH2OBackend.checkAndUpdateConf(conf)
-    } else {
       ExternalH2OBackend.checkAndUpdateConf(conf)
+    } else {
+      InternalH2OBackend.checkAndUpdateConf(conf)
     }
     val isRestApiBasedClient = checkedConf.getBoolean(SharedBackendConf.PROP_REST_API_BASED_CLIENT._1,
       SharedBackendConf.PROP_REST_API_BASED_CLIENT._2)

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendUtils.scala
@@ -19,11 +19,11 @@ package org.apache.spark.h2o.backends
 
 import java.io.File
 
-import org.apache.spark.{SparkContext, SparkEnv, SparkFiles}
 import org.apache.spark.h2o.H2OConf
 import org.apache.spark.h2o.utils.AzureDatabricksUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
+import org.apache.spark.{SparkContext, SparkEnv, SparkFiles}
 
 /**
   * Shared functions which can be used by both backends
@@ -91,7 +91,7 @@ private[backends] trait SharedBackendUtils extends Logging with Serializable {
     }
 
     if (!conf.clientWebEnabled) {
-      val f = new File(SharedBackendUtils.createTempDir(), "dummy")
+      val f = new File(createTempDir(), "dummy")
       f.createNewFile()
       f.deleteOnExit()
       conf.setHashLoginEnabled()
@@ -217,9 +217,6 @@ private[backends] trait SharedBackendUtils extends Logging with Serializable {
       ll.map(v => if (v._2 < mll.get._2) minLogLevel else logLevel).getOrElse(minLogLevel)
     }
   }
-}
-
-object SharedBackendUtils extends SharedBackendUtils {
 
   def saveFlatFileAsFile(content: String): File = {
     val tmpDir = createTempDir()
@@ -232,5 +229,4 @@ object SharedBackendUtils extends SharedBackendUtils {
     }
     flatFile
   }
-
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SparklingBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SparklingBackend.scala
@@ -22,14 +22,7 @@ import org.apache.spark.h2o.utils.NodeDesc
 
 trait SparklingBackend {
 
-  def init(): Array[NodeDesc]
-
-  /**
-    * Check Spark and H2O environment on particular backend, update it if necessary and and warn about possible problems
-    *
-    * @param conf H2O Configuration
-    */
-  def checkAndUpdateConf(conf: H2OConf): H2OConf
+  def init(conf: H2OConf): Array[NodeDesc]
 
   def stop(stopSparkContext: Boolean)
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendUtils.scala
@@ -17,18 +17,13 @@
 
 package org.apache.spark.h2o.backends.external
 
-import org.apache.spark.SparkEnv
 import org.apache.spark.h2o.H2OConf
 import org.apache.spark.h2o.backends.{ArgumentBuilder, SharedBackendUtils}
-import org.apache.spark.h2o.utils.NodeDesc
 import water.{ExternalFrameUtils, H2O, Paxos}
 
-/**
-  * Various helper methods used in the external backend
-  */
-private[external] trait ExternalBackendUtils extends SharedBackendUtils {
+private[backends] trait ExternalBackendUtils extends SharedBackendUtils {
 
-  protected def waitForCloudSize(expectedSize: Int, timeoutInMilliseconds: Long): Int = {
+  protected[backends] def waitForCloudSize(expectedSize: Int, timeoutInMilliseconds: Long): Int = {
     val start = System.currentTimeMillis()
     while (System.currentTimeMillis() - start < timeoutInMilliseconds) {
       if (H2O.CLOUD.size() >= expectedSize && Paxos._commonKnowledge) {
@@ -49,41 +44,11 @@ private[external] trait ExternalBackendUtils extends SharedBackendUtils {
     */
   override def getH2OClientArgs(conf: H2OConf): Seq[String] = {
     new ArgumentBuilder()
-      .add("-flatfile", conf.h2oCluster.map(clusterStr => SharedBackendUtils.saveFlatFileAsFile(clusterStr).getAbsolutePath))
+      .add("-flatfile", conf.h2oCluster.map(clusterStr => saveFlatFileAsFile(clusterStr).getAbsolutePath))
       .add(super.getH2OClientArgs(conf))
       .addIf("-watchdog_client", conf.isAutoClusterStartUsed)
       .buildArgs()
   }
-
-  /** Check Spark and H2O environment, update it if necessary and and warn about possible problems.
-    *
-    * This method checks the environments for generic configuration which does not depend on particular backend used
-    * In order to check the configuration for specific backend, method checkAndUpdateConf on particular backend has to be
-    * called.
-    *
-    * This method has to be called at the start of each method which override this one
-    *
-    * @param conf H2O Configuration to check
-    * @return checked and updated configuration
-    * */
-  override def checkAndUpdateConf(conf: H2OConf): H2OConf = {
-    super.checkAndUpdateConf(conf)
-
-    // Increase locality timeout since h2o-specific tasks can be long computing
-    if (conf.getInt("spark.locality.wait", 3000) <= 3000) {
-      logWarning(s"Increasing 'spark.locality.wait' to value 30000")
-      conf.set("spark.locality.wait", "30000")
-    }
-
-    // to mimic the previous behaviour, set the client ip like this only in manual cluster mode when using multi-cast
-    if (conf.clientIp.isEmpty && conf.isManualClusterStartUsed && conf.h2oCluster.isEmpty) {
-      conf.setClientIp(getHostname(SparkEnv.get))
-    }
-    conf
-  }
-}
-
-object ExternalBackendUtils extends ExternalBackendUtils {
 
   def prepareExpectedTypes(classes: Array[Class[_]]): Array[Byte] = {
     classes.map { clazz =>
@@ -114,5 +79,4 @@ object ExternalBackendUtils extends ExternalBackendUtils {
       }
     }
   }
-
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalWriteConverterCtx.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalWriteConverterCtx.scala
@@ -94,7 +94,7 @@ class ExternalWriteConverterCtx(nodeDesc: NodeDesc, writeTimeout: Int, driverTim
 }
 
 
-object ExternalWriteConverterCtx extends ExternalBackendUtils {
+object ExternalWriteConverterCtx {
 
   import scala.language.postfixOps
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -73,7 +73,7 @@ object InternalH2OBackend extends InternalBackendUtils {
 
     conf.getOption("spark.executor.instances").foreach(v => conf.set("spark.ext.h2o.cluster.size", v))
 
-    if (!conf.contains("spark.scheduler.minRegisteredResourcesRatio") && SparkSession.builder().getOrCreate().sparkContext.isLocal) {
+    if (!conf.contains("spark.scheduler.minRegisteredResourcesRatio") && !SparkSession.builder().getOrCreate().sparkContext.isLocal) {
       logWarning("The property 'spark.scheduler.minRegisteredResourcesRatio' is not specified!\n" +
         "We recommend to pass `--conf spark.scheduler.minRegisteredResourcesRatio=1`")
       // Setup the property but at this point it does not make good sense

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/SpreadRDDBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/SpreadRDDBuilder.scala
@@ -107,7 +107,7 @@ class SpreadRDDBuilder(@transient private val hc: H2OContext,
   private def isBackendReady() = sc.schedulerBackend.isReady()
 }
 
-object RpcReferenceCache {
+object RpcReferenceCache extends SharedBackendUtils {
   private object Lock
   private val rpcServiceName = s"sparkling-water-h2o-start-${SparkEnv.get.executorId}"
   private val rpcEndpointName = "h2o"
@@ -122,7 +122,7 @@ object RpcReferenceCache {
 
   private def startEndpointOnH2OWorker(conf: SparkConf): RpcEndpointRef = {
     val securityMgr = SparkEnv.get.securityManager
-    val rpcEnv = RpcEnv.create(rpcServiceName, SharedBackendUtils.getHostname(SparkEnv.get), 0, conf, securityMgr)
+    val rpcEnv = RpcEnv.create(rpcServiceName, getHostname(SparkEnv.get), 0, conf, securityMgr)
     val endpoint = new H2ORpcEndpoint(rpcEnv)
     rpcEnv.setupEndpoint(rpcEndpointName, endpoint)
   }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ODataFrame.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ODataFrame.scala
@@ -19,7 +19,7 @@ package org.apache.spark.h2o.converters
 
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.backends.external.ExternalBackendUtils
+import org.apache.spark.h2o.backends.external.{ExternalBackendUtils, ExternalH2OBackend}
 import org.apache.spark.h2o.utils.ReflectionUtils
 import org.apache.spark.h2o.utils.SupportedTypes._
 import org.apache.spark.rdd.RDD
@@ -66,7 +66,7 @@ class H2ODataFrame[T <: water.fvec.Frame](@transient val frame: T,
     if (isExternalBackend) {
       // prepare expected type selected columns in the same order as are selected columns
       val javaClasses = selectedColumnIndices.map{ idx => ReflectionUtils.supportedType(frame.vec(idx)).javaClass }
-      Option(ExternalBackendUtils.prepareExpectedTypes(javaClasses))
+      Option(ExternalH2OBackend.prepareExpectedTypes(javaClasses))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDD.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/H2ORDD.scala
@@ -21,11 +21,11 @@ package org.apache.spark.h2o.converters
 import java.lang.reflect.Constructor
 
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.backends.external.{ExternalBackendUtils, ExternalReadConverterCtx, ExternalWriteConverterCtx}
+import org.apache.spark.h2o.backends.external.ExternalH2OBackend
 import org.apache.spark.h2o.utils.ProductType
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, TaskContext}
-import water.{ExternalFrameUtils, H2O}
+import water.H2O
 import water.fvec.Frame
 import water.support.H2OFrameSupport
 
@@ -113,7 +113,7 @@ class H2ORDD[A <: Product: TypeTag: ClassTag, T <: Frame] private(@(transient @p
     // there is no need to prepare expected types in internal backend
     if (isExternalBackend) {
       // prepare expected types for selected columns in the same order ar are selected columns(
-      Option(ExternalBackendUtils.prepareExpectedTypes(productType.memberClasses))
+      Option(ExternalH2OBackend.prepareExpectedTypes(productType.memberClasses))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/SparkDataFrameConverter.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.h2o.converters
 
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.backends.external.{ExternalBackendUtils, ExternalWriteConverterCtx}
+import org.apache.spark.h2o.backends.external.{ExternalBackendUtils, ExternalH2OBackend, ExternalWriteConverterCtx}
 import org.apache.spark.h2o.converters.WriteConverterCtxUtils.UploadPlan
 import org.apache.spark.h2o.utils.ReflectionUtils
 import org.apache.spark.internal.Logging
@@ -74,7 +74,7 @@ private[h2o] object SparkDataFrameConverter extends Logging {
       val internalJavaClasses = flatDataFrame.schema.map { f =>
         ExternalWriteConverterCtx.internalJavaClassOf(f.dataType)
       }.toArray
-      ExternalBackendUtils.prepareExpectedTypes(internalJavaClasses)
+      ExternalH2OBackend.prepareExpectedTypes(internalJavaClasses)
     }
 
     val blockSize = hc.getConf.externalCommunicationBlockSizeAsBytes

--- a/core/src/test/scala/org/apache/spark/h2o/backends/SharedBackendUtilsTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/backends/SharedBackendUtilsTestSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.h2o.backends
 
 import org.scalatest.{FunSuite, Matchers}
 
-class SharedBackendUtilsTestSuite extends FunSuite with Matchers {
+class SharedBackendUtilsTestSuite extends FunSuite with Matchers with SharedBackendUtils {
 
   private val expectedHttpHeaderArgs = Seq(
     "-add_http_header", "X-Request-ID", "f058ebd6-02f7-4d3f-942e-904344e8cde5",
@@ -35,7 +35,7 @@ class SharedBackendUtilsTestSuite extends FunSuite with Matchers {
         |Content-Security-Policy-Report-Only: default-src 'none'; style-src cdn.example.com:8080; report-uri /_/csp-reports
       """.stripMargin
 
-    val result = SharedBackendUtils.parseStringToHttpHeaderArgs(input)
+    val result = parseStringToHttpHeaderArgs(input)
 
     result shouldEqual expectedHttpHeaderArgs
   }
@@ -48,7 +48,7 @@ class SharedBackendUtilsTestSuite extends FunSuite with Matchers {
         |Content-Security-Policy-Report-Only:default-src 'none'; style-src cdn.example.com:8080; report-uri /_/csp-reports
       """.stripMargin
 
-    val result = SharedBackendUtils.parseStringToHttpHeaderArgs(input)
+    val result = parseStringToHttpHeaderArgs(input)
 
     result shouldEqual expectedHttpHeaderArgs
   }
@@ -69,7 +69,7 @@ class SharedBackendUtilsTestSuite extends FunSuite with Matchers {
         |
       """.stripMargin
 
-    val result = SharedBackendUtils.parseStringToHttpHeaderArgs(input)
+    val result = parseStringToHttpHeaderArgs(input)
 
     result shouldEqual expectedHttpHeaderArgs
   }
@@ -82,7 +82,7 @@ class SharedBackendUtilsTestSuite extends FunSuite with Matchers {
         |
       """.stripMargin
 
-    val result = SharedBackendUtils.parseStringToHttpHeaderArgs(input)
+    val result = parseStringToHttpHeaderArgs(input)
 
     result shouldEqual Seq.empty[String]
   }
@@ -90,7 +90,7 @@ class SharedBackendUtilsTestSuite extends FunSuite with Matchers {
   test("parseStringToHttpArgs parses empty string") {
     val input = ""
 
-    val result = SharedBackendUtils.parseStringToHttpHeaderArgs(input)
+    val result = parseStringToHttpHeaderArgs(input)
 
     result shouldEqual Seq.empty[String]
   }

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -126,7 +126,7 @@ class H2OContext(object):
     def __default_h2o_connect(h2o_context, **kwargs):
         if "https" in kwargs:
             warnings.warn("https argument is automatically set up and the specified value will be ignored.")
-        schema = h2o_context._jhc.h2oContext()._conf().getScheme()
+        schema = h2o_context._jhc.h2oContext().getConf().getScheme()
         kwargs["https"] = False
         if schema == "https":
             kwargs["https"] = True


### PR DESCRIPTION
-> Better `conf` on H2OContext -> fixes bug where we were setting wrong conf instance on ExternalH2OBackend which was leading to error when obtaining cluster details via rest api as the clusterEndpoint was empty even though set before
-> Avoid unnecessary complexity in classes related to backends, simplify and unify them

This change does not introduce any breaking behaviour

The tests for rest api solution still fails due to missing conversions but fails as expected. Before this change we failed with exception whilst getting connection to the cluster