### PR TITLE
[SW-1714] Ensure download_h2o_logs works in the client-less approach

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.h2o
 
-import java.net.URI
 import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.spark._
@@ -31,7 +30,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.network.Security
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import water._
-import water.util.{LogArchiveContainer, PrettyPrint}
+import water.util.PrettyPrint
 
 import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.ClassTag

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.h2o
 
+import java.net.URI
 import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.spark._
@@ -30,7 +31,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.network.Security
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import water._
-import water.util.PrettyPrint
+import water.util.{LogArchiveContainer, PrettyPrint}
 
 import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.ClassTag
@@ -340,6 +341,8 @@ abstract class H2OContext private(val sparkSession: SparkSession, private val co
   }
 
   // scalastyle:on
+
+  def downloadH2OLogs(destination: String, logContainer: String = "ZIP"): String
 }
 
 object H2OContext extends Logging {
@@ -394,6 +397,12 @@ object H2OContext extends Logging {
         H2O.ABV.compiledOn()
       )
     }
+
+    override def downloadH2OLogs(destination: String, logContainer: String = "ZIP"): String = {
+      verifyLogContainer(logContainer)
+      H2O.downloadLogs(destination, logContainer).toString
+    }
+
   }
 
   private class H2OContextRestAPIBased(spark: SparkSession, conf: H2OConf) extends H2OContext(spark, conf) with H2OContextRestAPIUtils {
@@ -450,6 +459,11 @@ object H2OContext extends Logging {
         cloudV3.compiled_by,
         cloudV3.compiled_on
       )
+    }
+
+    override def downloadH2OLogs(destinationDir: String, logContainer: String = "ZIP"): String = {
+      verifyLogContainer(logContainer)
+      H2OContextRestAPIUtils.downloadLogs(destinationDir, logContainer, conf)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -342,7 +342,7 @@ abstract class H2OContext private(val sparkSession: SparkSession, private val co
 
   // scalastyle:on
 
-  def downloadH2OLogs(destination: String, logContainer: String = "ZIP"): String
+  def downloadH2OLogs(destinationDir: String, logContainer: String = "ZIP"): String
 }
 
 object H2OContext extends Logging {
@@ -398,9 +398,9 @@ object H2OContext extends Logging {
       )
     }
 
-    override def downloadH2OLogs(destination: String, logContainer: String = "ZIP"): String = {
+    override def downloadH2OLogs(destinationDir: String, logContainer: String = "ZIP"): String = {
       verifyLogContainer(logContainer)
-      H2O.downloadLogs(destination, logContainer).toString
+      H2O.downloadLogs(destinationDir, logContainer).toString
     }
 
   }

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextRestAPIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextRestAPIUtils.scala
@@ -52,10 +52,7 @@ trait H2OContextRestAPIUtils extends H2OContextUtils {
         val content = readStringURLContent(endpoint, s"3/Logs/download/$logContainer", conf)
         out.write(content)
       case "ZIP" =>
-        val content = readBinaryURLContent(endpoint, s"3/Logs/download/$logContainer", conf)
-        val bos = new BufferedOutputStream(new FileOutputStream(file))
-        Stream.continually(bos.write(content))
-        bos.close()
+        downloadBinaryURLContent(endpoint, s"3/Logs/download/$logContainer", conf, file)
     }
     file.getAbsolutePath
   }
@@ -123,11 +120,11 @@ trait H2OContextRestAPIUtils extends H2OContextUtils {
     content
   }
 
-  private def readBinaryURLContent(endpoint: URI, suffix: String, conf: H2OConf): Array[Byte] = {
+  private def downloadBinaryURLContent(endpoint: URI, suffix: String, conf: H2OConf, file: File): Unit = {
     val response = readURLContent(endpoint, suffix, conf)
-    val content = IOUtils.toByteArray(response)
-    response.close()
-    content
+    val output = new BufferedOutputStream(new FileOutputStream(file))
+    IOUtils.copy(response, output)
+    output.close()
   }
 
   // Method using the resulting source is responsible for closing it

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextRestAPIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextRestAPIUtils.scala
@@ -46,13 +46,12 @@ trait H2OContextRestAPIUtils extends H2OContextUtils {
   def downloadLogs(destinationDir: String, logContainer: String, conf: H2OConf): String = {
     val endpoint = getClusterEndpoint(conf)
     val file = new File(destinationDir, s"${logFileName()}.${logContainer.toLowerCase}")
+    val logEndpoint = s"3/Logs/download/$logContainer"
     logContainer match {
       case "LOG" =>
-        val out = new java.io.FileWriter(file)
-        val content = readStringURLContent(endpoint, s"3/Logs/download/$logContainer", conf)
-        out.write(content)
+        downloadStringURLContent(endpoint, logEndpoint, conf, file)
       case "ZIP" =>
-        downloadBinaryURLContent(endpoint, s"3/Logs/download/$logContainer", conf, file)
+        downloadBinaryURLContent(endpoint, logEndpoint, conf, file)
     }
     file.getAbsolutePath
   }
@@ -123,6 +122,13 @@ trait H2OContextRestAPIUtils extends H2OContextUtils {
   private def downloadBinaryURLContent(endpoint: URI, suffix: String, conf: H2OConf, file: File): Unit = {
     val response = readURLContent(endpoint, suffix, conf)
     val output = new BufferedOutputStream(new FileOutputStream(file))
+    IOUtils.copy(response, output)
+    output.close()
+  }
+
+  private def downloadStringURLContent(endpoint: URI, suffix: String, conf: H2OConf, file: File): Unit = {
+    val response = readURLContent(endpoint, suffix, conf)
+    val output = new java.io.FileWriter(file)
     IOUtils.copy(response, output)
     output.close()
   }

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextRestAPIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextRestAPIUtils.scala
@@ -133,7 +133,6 @@ trait H2OContextRestAPIUtils extends H2OContextUtils {
     output.close()
   }
 
-  // Method using the resulting source is responsible for closing it
   private def readURLContent(endpoint: URI, suffix: String, conf: H2OConf): InputStream = {
     try {
       val connection = new URL(s"$endpoint/$suffix").openConnection

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextRestAPIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextRestAPIUtils.scala
@@ -17,14 +17,17 @@
 
 package org.apache.spark.h2o.utils
 
+import java.io.{BufferedOutputStream, File, FileOutputStream, InputStream}
 import java.net.{URI, URL}
+import java.text.SimpleDateFormat
+import java.util.Date
 
 import com.google.gson.Gson
+import org.apache.commons.io.IOUtils
 import org.apache.http.client.utils.URIBuilder
 import org.apache.spark.h2o.H2OConf
 import water.api.schemas3.CloudV3
 
-import scala.io.Source
 
 trait H2OContextRestAPIUtils extends H2OContextUtils {
 
@@ -40,6 +43,29 @@ trait H2OContextRestAPIUtils extends H2OContextUtils {
     getCloudInfoFromNode(endpoint, conf)
   }
 
+  def downloadLogs(destinationDir: String, logContainer: String, conf: H2OConf): String = {
+    val endpoint = getClusterEndpoint(conf)
+    val file = new File(destinationDir, s"${logFileName()}.${logContainer.toLowerCase}")
+    logContainer match {
+      case "LOG" =>
+        val out = new java.io.FileWriter(file)
+        val content = readStringURLContent(endpoint, s"3/Logs/download/$logContainer", conf)
+        out.write(content)
+      case "ZIP" =>
+        val content = readBinaryURLContent(endpoint, s"3/Logs/download/$logContainer", conf)
+        val bos = new BufferedOutputStream(new FileOutputStream(file))
+        Stream.continually(bos.write(content))
+        bos.close()
+    }
+    file.getAbsolutePath
+  }
+
+  private def logFileName(): String = {
+    val pattern = "yyyyMMdd_hhmmss"
+    val formatter = new SimpleDateFormat(pattern)
+    val now = formatter.format(new Date)
+    s"h2ologs_$now"
+  }
 
   def getCloudInfo(conf: H2OConf): CloudV3 = {
     val endpoint = getClusterEndpoint(conf)
@@ -86,11 +112,26 @@ trait H2OContextRestAPIUtils extends H2OContextUtils {
   }
 
   private def getCloudInfoFromNode(endpoint: URI, conf: H2OConf): CloudV3 = {
-    val content = readURLContent(endpoint, "3/Cloud", conf)
+    val content = readStringURLContent(endpoint, "3/Cloud", conf)
     new Gson().fromJson(content, classOf[CloudV3])
   }
 
-  private def readURLContent(endpoint: URI, suffix: String, conf: H2OConf): String = {
+  private def readStringURLContent(endpoint: URI, suffix: String, conf: H2OConf): String = {
+    val response = readURLContent(endpoint, suffix, conf)
+    val content = IOUtils.toString(response)
+    response.close()
+    content
+  }
+
+  private def readBinaryURLContent(endpoint: URI, suffix: String, conf: H2OConf): Array[Byte] = {
+    val response = readURLContent(endpoint, suffix, conf)
+    val content = IOUtils.toByteArray(response)
+    response.close()
+    content
+  }
+
+  // Method using the resulting source is responsible for closing it
+  private def readURLContent(endpoint: URI, suffix: String, conf: H2OConf): InputStream = {
     try {
       val connection = new URL(s"$endpoint/$suffix").openConnection
       val field = conf.getClass.getDeclaredField("nonJVMClientCreds")
@@ -101,10 +142,7 @@ trait H2OContextRestAPIUtils extends H2OContextUtils {
         val basicAuth = "Basic " + javax.xml.bind.DatatypeConverter.printBase64Binary(userpass.getBytes)
         connection.setRequestProperty("Authorization", basicAuth)
       }
-      val response = Source.fromInputStream(connection.getInputStream)
-      val content = response.mkString
-      response.close()
-      content
+      connection.getInputStream
     } catch {
       case cause: Exception =>
         throw new H2OClusterNodeNotReachableException(

--- a/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/utils/H2OContextUtils.scala
@@ -137,23 +137,10 @@ private[spark] trait H2OContextUtils extends Logging {
     }
   }
 
-  /**
-    * @param destination directory where the logs will be downloaded
-    */
-  def downloadH2OLogs(destination: URI, logContainer: LogArchiveContainer): URI = {
-    H2O.downloadLogs(destination, logContainer)
-  }
-
-  def downloadH2OLogs(destination: URI, logContainer: String): URI = {
-    H2O.downloadLogs(destination, logContainer)
-  }
-
-  def downloadH2OLogs(destination: String, logContainer: LogArchiveContainer): String = {
-    H2O.downloadLogs(destination, logContainer).toString
-  }
-
-  def downloadH2OLogs(destination: String, logContainer: String = "ZIP"): String = {
-    H2O.downloadLogs(destination, logContainer).toString
+  protected def verifyLogContainer(logContainer: String): Unit = {
+    if (!Seq("ZIP", "LOG").contains(logContainer)) {
+      throw new IllegalArgumentException(s"Supported LOG container is either LOG or ZIP, specified was: $logContainer")
+    }
   }
 
   def importHiveTable(database: String = HiveTableImporter.DEFAULT_DATABASE, table: String,


### PR DESCRIPTION
PySparkling has method download_h2o_logs which needs to work also in the client-less approach

After this, the conversions should be the last bit to do for the first stage of the client less approach(without the algo api)

