### PR TITLE
[SW-1690] Create script to generate kubernetes docker images

### DIFF
--- a/bin/build-kubernetes-images.sh
+++ b/bin/build-kubernetes-images.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Current dir
+TOPDIR=$(cd "$(dirname "$0")/.." || exit; pwd)
+
+source "$TOPDIR/bin/sparkling-env.sh"
+
+( cd "$SPARK_HOME" && docker-image-tool.sh -t "$SPARK_VERSION" build )
+
+echo "Creating Working Directory"
+WORKDIR=$(mktemp -d)
+echo "Working directory created: $WORKDIR"
+
+K8DIR="$TOPDIR/kubernetes"
+cp "$K8DIR/Dockerfile-Python" "$WORKDIR"
+cp "$K8DIR/Dockerfile-R" "$WORKDIR"
+cp "$K8DIR/Dockerfile-Scala" "$WORKDIR"
+
+echo "Bulding Docker Image for Sparkling Water(Scala) ..."
+cp "$FAT_JAR_FILE" "$WORKDIR"
+docker build -t "sparkling-water-scala:$VERSION" -f "$WORKDIR/Dockerfile-Scala" "$WORKDIR"
+echo "Done!"
+
+echo "Bulding Docker Image for PySparkling(Python) ..."
+cp "$PY_ZIP_FILE" "$WORKDIR"
+docker build -t "sparkling-water-python:$VERSION" -f "$WORKDIR/Dockerfile-Python" "$WORKDIR"
+echo "Done!"
+
+echo "Bulding Docker Image for RSparkling(R) ..."
+cp "$TOPDIR/rsparkling_$VERSION.tar.gz" "$WORKDIR"
+docker build -t "sparkling-water-r:$VERSION" -f "$WORKDIR/Dockerfile-R" "$WORKDIR"
+echo "Done!"
+
+echo "Cleaning up temporary directories"
+rm -rf "$WORKDIR"
+
+echo "All done! You can find your images by running: docker images"

--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -140,7 +140,7 @@ VERSION=$(grep version "$PROP_FILE" | grep -v '#' | sed -e "s/.*=//" )
 H2O_VERSION=$(grep h2oMajorVersion "$PROP_FILE" | sed -e "s/.*=//")
 H2O_BUILD=$(grep h2oBuild "$PROP_FILE" | sed -e "s/.*=//")
 H2O_NAME=$(grep h2oMajorName "$PROP_FILE" | sed -e "s/.*=//")
-SPARK_VERSION=$(grep sparkVersion "$PROP_FILE" | sed -e "s/.*=//")
+export SPARK_VERSION=$(grep sparkVersion "$PROP_FILE" | sed -e "s/.*=//")
 SCALA_VERSION=$(grep scalaBaseVersion "$PROP_FILE" | sed -e "s/.*=//" | cut -d . -f 1,2)
 # Fat jar for this distribution
 FAT_JAR="sparkling-water-assembly_$SCALA_VERSION-$VERSION-all.jar"

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -118,7 +118,8 @@ def distTaskDependencies = [
         ":sparkling-water-examples:publish",
         ":sparkling-water-package:publish",
         ":sparkling-water-scoring:publish",
-        ":sparkling-water-utils:publish"
+        ":sparkling-water-utils:publish",
+        ":sparkling-water-kubernetes:buildDockerfiles"
 ]
 
 def copyAndSubstituteGradleProperties() {
@@ -153,6 +154,7 @@ task copyFilesForZipDistribution {
         copyAndKeepPath("README.rst", "$zipDir")
         copyAndSubstituteGradleProperties()
 
+        copyRecursive("kubernetes/build/", "$zipDir/kubernetes")
         copyRecursive("bin/", "$zipDir/bin")
         copyRecursive("doc/build/site/", "$zipDir/doc/build/site")
         copyRecursive("docker/", "$zipDir/docker")

--- a/kubernetes/build.gradle
+++ b/kubernetes/build.gradle
@@ -1,10 +1,8 @@
 apply plugin: 'base'
 apply plugin: 'com.bmuschko.docker-remote-api'
-apply from: "$rootDir/gradle/utils.gradle"
 
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 
-defaultTasks 'createDockerFiles'
 description = "Build docker images for Kubernetes with Sparkling Water"
 
 ext {
@@ -13,32 +11,13 @@ ext {
     outputFileScala = file("$buildDir/Dockerfile-Scala")
 }
 
-task buildSparkImages(dependsOn: checkSparkVersionTask) {
-    doLast {
-        exec {
-            workingDir sparkHome
-            commandLine getOsSpecificCommandLine(['./bin/docker-image-tool.sh', '-t', "$sparkVersion", "build"])
-        }
-    }
-}
-
-task copyDist(type: Copy, dependsOn: ":sparkling-water-dist:dist") {
-    from "$rootDir/dist/build/zip/sparkling-water-${version}"
-    into "$buildDir/sparkling-water"
-}
-
-task createScalaDockerfile(type: Dockerfile, dependsOn: [buildSparkImages, copyDist]) {
+task createScalaDockerfile(type: Dockerfile) {
     destFile = outputFileScala
     from "spark:${sparkVersion}"
-    copyFile("sparkling-water/assembly/build/libs/sparkling-water-assembly_2.11-${version}-all.jar", "/opt/spark/jars/sparkling-water-assembly_2.11-${version}-all.jar")
+    copyFile("sparkling-water-assembly_2.11-${version}-all.jar", "/opt/spark/jars/sparkling-water-assembly_2.11-${version}-all.jar")
 }
 
-task buildScalaImage(type: Exec, dependsOn: createScalaDockerfile) {
-    workingDir buildDir
-    commandLine getOsSpecificCommandLine(['docker', 'build', '-t', "sparkling-water-scala:${version}", '-f', outputFileScala, "."])
-}
-
-task createRDockerfile(type: Dockerfile, dependsOn: [buildSparkImages, copyDist]) {
+task createRDockerfile(type: Dockerfile) {
     destFile = outputFileR
     from "spark-r:${sparkVersion}"
     runCommand "apk add libc-dev linux-headers g++ libxml2-dev"
@@ -57,20 +36,10 @@ task createRDockerfile(type: Dockerfile, dependsOn: [buildSparkImages, copyDist]
     runCommand "cd /opt/spark/R/lib && R CMD INSTALL rsparkling_${version}.tar.gz"
 }
 
-task buildRImage(type: Exec, dependsOn: createRDockerfile) {
-    workingDir buildDir
-    commandLine getOsSpecificCommandLine(['docker', 'build', '-t', "sparkling-water-r:${version}", '-f', outputFileR, "."])
-}
-
-task createPythonDockerfile(type: Dockerfile, dependsOn: [buildSparkImages, copyDist]) {
+task createPythonDockerfile(type: Dockerfile) {
     destFile = outputFilePython
     from "spark-py:${sparkVersion}"
-    copyFile("sparkling-water/py/build/dist/h2o_pysparkling_${sparkMajorVersion}-${version}.zip", "/opt/spark/pyspark/python/lib/h2o_pysparkling_${sparkMajorVersion}-${version}.zip")
+    copyFile("h2o_pysparkling_${sparkMajorVersion}-${version}.zip", "/opt/spark/pyspark/python/lib/h2o_pysparkling_${sparkMajorVersion}-${version}.zip")
 }
 
-task buildPythonImage(type: Exec, dependsOn: createPythonDockerfile) {
-    workingDir buildDir
-    commandLine getOsSpecificCommandLine(['docker', 'build', '-t', "sparkling-water-python:${version}", '-f', outputFilePython, "."])
-}
-
-task buildKubernetesImages(dependsOn: [buildScalaImage, buildPythonImage, buildRImage])
+task buildDockerfiles(dependsOn: [createPythonDockerfile, createRDockerfile, createScalaDockerfile])

--- a/kubernetes/build.gradle
+++ b/kubernetes/build.gradle
@@ -32,7 +32,7 @@ task createRDockerfile(type: Dockerfile) {
                 R -e 'install.packages("sparklyr", repos = "http://cran.us.r-project.org")'
                 """
     runCommand "R -e \"install.packages('h2o', type = 'source', repos = 'http://h2o-release.s3.amazonaws.com/h2o/rel-${h2oMajorName}/${h2oBuild}/R')\""
-    copyFile("sparkling-water/rsparkling_${version}.tar.gz", "/opt/spark/R/lib/rsparkling_${version}.tar.gz")
+    copyFile("rsparkling_${version}.tar.gz", "/opt/spark/R/lib/rsparkling_${version}.tar.gz")
     runCommand "cd /opt/spark/R/lib && R CMD INSTALL rsparkling_${version}.tar.gz"
 }
 


### PR DESCRIPTION
Dockerfiles are created as part of the distribution and we provide the script for the users to build themselves the docker image for kubernetes from the downloaded distribution ( no requirement for using gradle)

Later, we can reuse this script for some automation and publishing the images to public docker hub, but for now I think it's enough 