### PR TITLE
[SW-1732] Implement shutdown hook to ensure H2O will go down on normal stop of Spark

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -108,6 +108,8 @@ abstract class H2OContext private(val sparkSession: SparkSession, private val co
     * otherwise it creates new H2O cluster living in Spark
     */
   def init(): H2OContext = {
+    // The lowest priority used by Spark is 25 (removing temp dirs). We need to perform cleaning up of H2O
+    // resources before Spark does as we run as embedded application inside the Spark
     ShutdownHookManager.addShutdownHook(10) { () =>
       logWarning("Spark shutdown hook called, stopping H2OContext!")
       stop(stopSparkContext = false, stopJvm = false)

--- a/core/src/main/scala/org/apache/spark/h2o/backends/SparklingBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SparklingBackend.scala
@@ -24,8 +24,6 @@ trait SparklingBackend {
 
   def init(conf: H2OConf): Array[NodeDesc]
 
-  def stop(stopSparkContext: Boolean)
-
   def backendUIInfo: Seq[(String, String)]
 
   def epilog: String

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -34,17 +34,6 @@ class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend
 
   override def backendUIInfo: Seq[(String, String)] = Seq()
 
-  override def stop(stopSparkContext: Boolean): Unit = {
-    if (stopSparkContext) hc.sparkContext.stop()
-    H2O.orderlyShutdown(5000)
-    // Stop h2o when running standalone pysparkling scripts, only in client deploy mode
-    //, so the user does not need explicitly close h2o.
-    // In driver mode the application would call exit which is handled by Spark AM as failure
-    if (hc.sparkContext.conf.get("spark.submit.deployMode", "client") != "cluster") {
-      H2O.exit(0)
-    }
-  }
-
   /** Initialize Sparkling H2O and start H2O cloud. */
   override def init(conf: H2OConf): Array[NodeDesc] = {
     logInfo(s"Starting H2O services: " + conf)

--- a/py/examples/scripts/H2OContextInitDemo.py
+++ b/py/examples/scripts/H2OContextInitDemo.py
@@ -1,13 +1,8 @@
 from pysparkling import *
 from pyspark.sql import SparkSession
-import h2o
 
 # Initiate SparkSession
 spark = SparkSession.builder.appName("App name").getOrCreate()
 
 # Initiate H2OContext
 hc = H2OContext.getOrCreate(spark)
-
-# Stop H2O and Spark services
-h2o.cluster().shutdown()
-spark.stop()


### PR DESCRIPTION
Depends on https://github.com/h2oai/h2o-3/pull/4110 (H2O 3.26.0.12)

No need for hacky stopping, tested on YARN in both internal & external backend