### PR TITLE
[SW-1743] Run rest api client tests only in external backend mode

### DIFF
--- a/py/build.gradle
+++ b/py/build.gradle
@@ -370,5 +370,8 @@ distPython.dependsOn createVersionFile
 
 build.dependsOn distPython
 test.dependsOn testPython
-test.dependsOn testPythonREST
+
+if (detectBackendClusterMode() == "external") {
+    test.dependsOn testPythonREST
+}
 integTest.dependsOn integTestPython


### PR DESCRIPTION
Right now clientless tests are also running in internal backend, causing test failures