### PR TITLE
[SW-1870] Use internal secure connections by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/SharedBackendConf.scala
@@ -326,7 +326,7 @@ object SharedBackendConf {
   val PROP_FLOW_EXTRA_HTTP_HEADERS = ("spark.ext.h2o.flow.extra.http.headers", None)
 
   /** Secure internal connections by automatically generated credentials */
-  val PROP_INTERNAL_SECURE_CONNECTIONS = ("spark.ext.h2o.internal_secure_connections", false)
+  val PROP_INTERNAL_SECURE_CONNECTIONS = ("spark.ext.h2o.internal_secure_connections", true)
 
   /** IP of H2O client node */
   val PROP_CLIENT_IP = ("spark.ext.h2o.client.ip", None)

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -155,7 +155,7 @@ Configuration properties independent of selected backend
 |                                                    |                | special characters when passing        |
 |                                                    |                | the parameter from a command line.     |
 +----------------------------------------------------+----------------+----------------------------------------+
-| ``spark.ext.h2o.internal_secure_connections``      | ``false``      | Enables secure communications among    |
+| ``spark.ext.h2o.internal_secure_connections``      | ``true``       | Enables secure communications among    |
 |                                                    |                | H2O nodes. The security is based on    |
 |                                                    |                | automatically generated keystore       |
 |                                                    |                | and truststore. This is equivalent for |


### PR DESCRIPTION
The end-user should not observe any difference as this is all automatically handled