### PR TITLE
[SW-1884] Deprecate externalWriteConfirmationTimeout option

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendConf.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.h2o.backends.external
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import org.apache.spark.h2o.H2OConf
 import org.apache.spark.h2o.backends.SharedBackendConf
 
@@ -35,6 +36,7 @@ trait ExternalBackendConf extends SharedBackendConf {
   def h2oClusterPort = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1).map(_.split(":")(1).toInt)
 
   def clusterSize = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_SIZE._1)
+  @DeprecatedMethod
   def externalWriteConfirmationTimeout = sparkConf.getInt(PROP_EXTERNAL_WRITE_TIMEOUT._1, PROP_EXTERNAL_WRITE_TIMEOUT._2)
   def clusterStartTimeout = sparkConf.getInt(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, PROP_EXTERNAL_CLUSTER_START_TIMEOUT._2)
   def clusterInfoFile = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_INFO_FILE._1)
@@ -84,6 +86,7 @@ trait ExternalBackendConf extends SharedBackendConf {
   }
 
   def setClusterSize(clusterSize: Int) = set(PROP_EXTERNAL_CLUSTER_SIZE._1, clusterSize.toString)
+  @DeprecatedMethod
   def setExternalWriteConfirmationTimeout(timeout: Int) = set(PROP_EXTERNAL_WRITE_TIMEOUT._1, timeout.toString)
   def setClusterStartTimeout(clusterStartTimeout: Int) = set(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, clusterStartTimeout.toString)
   def setClusterConfigFile(path: String) = set(PROP_EXTERNAL_CLUSTER_INFO_FILE._1, path)

--- a/py/src/ai/h2o/sparkling/H2OConf.py
+++ b/py/src/ai/h2o/sparkling/H2OConf.py
@@ -353,6 +353,8 @@ class H2OConf(object):
         return self
 
     def set_external_write_confirmation_timeout(self, timeout):
+        warnings.warn("Method 'set_external_write_confirmation_timeout' is deprecated without replacement and will be removed"
+                      " in the next major release")
         self._jconf.setExternalWriteConfirmationTimeout(timeout)
         return self
 
@@ -634,6 +636,8 @@ class H2OConf(object):
         return self._jconf.clientCheckRetryTimeout()
 
     def external_write_confirmation_timeout(self):
+        warnings.warn("Method 'external_write_confirmation_timeout' is deprecated without replacement and will be removed"
+                      " in the next major release")
         return self._jconf.externalWriteConfirmationTimeout()
 
     def cluster_start_timeout(self):


### PR DESCRIPTION
Deprecate so we can remove in 3.28.1.1 as this option won't be necessary anymore