### PR TITLE
[SW-1901] Sequential grid search should be default

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
@@ -410,7 +410,7 @@ trait H2OGridSearchParams extends H2OCommonSupervisedParams {
     stoppingTolerance -> 0.001,
     stoppingMetric -> ScoreKeeper.StoppingMetric.AUTO.name(),
     selectBestModelBy -> H2OGridSearchMetric.AUTO.name(),
-    parallelism -> 0
+    parallelism -> 1
   )
 
   //

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OGridSearch.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OGridSearch.py
@@ -37,7 +37,7 @@ class H2OGridSearch(H2OGridSearchParams, H2OSupervisedAlgoBase):
                  stoppingTolerance=0.001,
                  stoppingMetric="AUTO",
                  selectBestModelBy="AUTO",
-                 parallelism=0,
+                 parallelism=1,
                  labelCol="label",
                  foldCol=None,
                  weightCol=None,


### PR DESCRIPTION
After discussing with @michalkurka grid search should use sequential model building by default as parallel building requires more memory (and might require additional tweaking)