### PR TITLE
[SW-1902] Remove SPARK_LOG_DIR, SPARK_WORKER_DIR and SPARK_LOCAL_DIRS and use default Spark values

### DIFF
--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -164,12 +164,6 @@ AVAILABLE_H2O_DRIVERS=$( [ -f "$TOPDIR/h2o_drivers.txt" ] && cat "$TOPDIR/h2o_dr
 export DEFAULT_MASTER="local[*]"
 export DEFAULT_DRIVER_MEMORY=2G
 
-# Setup loging and outputs
-tmpdir="${TMPDIR:-"/tmp/"}/$USER/"
-export SPARK_LOG_DIR="${tmpdir}spark/logs"
-export SPARK_WORKER_DIR="${tmpdir}spark/work"
-export SPARK_LOCAL_DIRS="${tmpdir}spark/work"
-
 export S3_RELEASE_BUCKET="https://h2o-release.s3.amazonaws.com/sparkling-water"
 
 function checkFatJarExists() {


### PR DESCRIPTION
We should use Spark values actually. It will be easier to find logs as default spark log dir is in $SPARK_HOME/work