### PR TITLE
[SW-1914] Copy extension jar to jars folder in distribution archive

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -147,10 +147,10 @@ task copyFilesForZipDistribution {
         }
 
         copySingle("r/build/", "rsparkling_${version}.tar.gz", "$zipDir")
+        copySingle("assembly-extensions/build/libs/", "sparkling-water-assembly-extensions_$scalaBaseVersion-${version}-all.jar", "$zipDir/jars")
         createSupportedHadoopFile("$zipDir")
 
         copyAndKeepPath("assembly/build/libs/sparkling-water-assembly_$scalaBaseVersion-${version}-all.jar", "$zipDir")
-        copyAndKeepPath("assembly-extensions/build/libs/sparkling-water-assembly-extensions_$scalaBaseVersion-${version}-all.jar", "$zipDir")
         copyAndKeepPath("py/build/dist/h2o_pysparkling_$sparkMajorVersion-${version}.zip", "$zipDir")
         copyAndKeepPath("LICENSE", "$zipDir")
         copyAndKeepPath("README.rst", "$zipDir")

--- a/dist/src/index.html
+++ b/dist/src/index.html
@@ -566,7 +566,7 @@
 
             <p>3. Set path to sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar which is bundled in Sparkling Water archive:</p>
             <p class="terminal">
-              SW_EXTENSIONS_ASSEMBLY=/path/to/sparkling-water-SUBST_SW_VERSION/sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar
+              SW_EXTENSIONS_ASSEMBLY=/path/to/sparkling-water-SUBST_SW_VERSION/jars/sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar
             </p>
 
             <p>4. Start H2O cluster on Hadoop:</p>

--- a/doc/src/site/sphinx/deployment/backends.rst
+++ b/doc/src/site/sphinx/deployment/backends.rst
@@ -185,7 +185,7 @@ Set path to sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar which i
 
 .. code:: bash
 
-    SW_EXTENSIONS_ASSEMBLY=/path/to/sparkling-water-SUBST_SW_VERSION/sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar
+    SW_EXTENSIONS_ASSEMBLY=/path/to/sparkling-water-SUBST_SW_VERSION/jars/sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar
 
 Start H2O cluster on Hadoop:
 
@@ -251,7 +251,7 @@ Set path to sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar which i
 
 .. code:: bash
 
-    SW_EXTENSIONS_ASSEMBLY=/path/to/sparkling-water-SUBST_SW_VERSION/sparkling-water-assembly-extensions_SUBST_SCALA_BASE_VERSION-SUBST_SW_VERSION-all.jar
+    SW_EXTENSIONS_ASSEMBLY=/path/to/sparkling-water-SUBST_SW_VERSION/jars/sparkling-water-assembly-extensions_SUBST_SCALA_BASE_VERSION-SUBST_SW_VERSION-all.jar
 
 To start an external H2O cluster, run:
 

--- a/doc/src/site/sphinx/install/install_and_start.rst
+++ b/doc/src/site/sphinx/install/install_and_start.rst
@@ -141,7 +141,7 @@ The H2O cluster needs to be started with a corresponding H2O, which can be downl
 
 .. code:: bash
 
-    SW_EXTENSIONS_ASSEMBLY=/path/to/sparkling-water-SUBST_SW_VERSION/sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar
+    SW_EXTENSIONS_ASSEMBLY=/path/to/sparkling-water-SUBST_SW_VERSION/jars/sparkling-water-assembly-extensions-SUBST_SW_VERSION-all.jar
 
 4. Start an H2O cluster on Hadoop
 


### PR DESCRIPTION
I have discovered that all documentation mentions that location of extension assembly jar is in the root of distribution archive, however the file is being copied into `sparkling-water-extensions/build/lib` which is a bug.

I have tried to fix the doc + copy the file into newly created `jars` folder to avoid complicated directory structure inside the sw distribution. I would like to put there also the original assembly jar, but created another JIRA for it https://0xdata.atlassian.net/browse/SW-1915