### PR TITLE
[SW-1915] Put sparkling water assembly jar into jars folder in the distribution archive instead into assembly/build/libs

### DIFF
--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -147,7 +147,7 @@ export SPARK_VERSION=$(grep sparkVersion "$PROP_FILE" | sed -e "s/.*=//")
 SCALA_VERSION=$(grep scalaBaseVersion "$PROP_FILE" | sed -e "s/.*=//" | cut -d . -f 1,2)
 # Fat jar for this distribution
 FAT_JAR="sparkling-water-assembly_$SCALA_VERSION-$VERSION-all.jar"
-export FAT_JAR_FILE="$TOPDIR/assembly/build/libs/$FAT_JAR"
+export FAT_JAR_FILE="$TOPDIR/jars/$FAT_JAR"
 export MAJOR_VERSION
 MAJOR_VERSION=$(echo "$VERSION" | cut -d . -f 1,2)
 export PATCH_VERSION

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -148,9 +148,10 @@ task copyFilesForZipDistribution {
 
         copySingle("r/build/", "rsparkling_${version}.tar.gz", "$zipDir")
         copySingle("assembly-extensions/build/libs/", "sparkling-water-assembly-extensions_$scalaBaseVersion-${version}-all.jar", "$zipDir/jars")
+        copySingle("assembly/build/libs/", "sparkling-water-assembly_$scalaBaseVersion-${version}-all.jar", "$zipDir/jars")
+
         createSupportedHadoopFile("$zipDir")
 
-        copyAndKeepPath("assembly/build/libs/sparkling-water-assembly_$scalaBaseVersion-${version}-all.jar", "$zipDir")
         copyAndKeepPath("py/build/dist/h2o_pysparkling_$sparkMajorVersion-${version}.zip", "$zipDir")
         copyAndKeepPath("LICENSE", "$zipDir")
         copyAndKeepPath("README.rst", "$zipDir")


### PR DESCRIPTION
@bilcus From major release 3.28.1.1 the location of assembly jar will be in `jars` folder directly, not sure if steam depends on this location so just making sure you know about it in advance :)