### PR TITLE
[SW-1943] Remove unnecessary ExternalH2OBackend.verifyH2OClientCloudUp(conf, nodes) check

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalBackendUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.h2o.backends.external
 
-import org.apache.spark.h2o.{H2OConf, H2OContext}
+import org.apache.spark.h2o.H2OContext
 import org.apache.spark.h2o.backends.SharedBackendUtils
 import org.apache.spark.h2o.utils.NodeDesc
 import water.api.RestAPIManager
@@ -76,31 +76,6 @@ private[backends] trait ExternalBackendUtils extends SharedBackendUtils {
 
     RestAPIManager(hc).registerAll()
     H2O.startServingRestApi()
-  }
-
-  protected[backends] def verifyH2OClientCloudUp(conf: H2OConf, nodes: Array[NodeDesc]): Unit = {
-    val cloudMembers = H2O.CLOUD.members()
-    if (cloudMembers.isEmpty) {
-      if (conf.isManualClusterStartUsed) {
-        throw new H2OClusterNotRunning(
-          s"""
-             |External H2O cluster is not running or could not be connected to. Provided configuration:
-             |  cluster name            : ${conf.cloudName.get}
-             |  cluster representative  : ${conf.h2oCluster.getOrElse("Using multi-cast discovery!")}
-             |  cluster start timeout   : ${conf.clusterStartTimeout} sec
-             |
-             |It is possible that in case you provided only the cluster name, h2o is not able to cloud up
-             |because multi-cast communication is limited in your network. In that case, please consider starting the
-             |external H2O cluster with flatfile and set the following configuration '${ExternalBackendConf.PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1}'
-        """.stripMargin)
-      } else {
-        throw new H2OClusterNotRunning("Problem with connecting to external H2O cluster started on yarn." +
-          "Please check the YARN logs.")
-      }
-    }
-    if (cloudMembers.size != nodes.length) {
-      throw new RuntimeException("Invalid number of discovered H2O nodes.")
-    }
   }
 
   protected[backends] def launchShellCommand(cmdToLaunch: Seq[String]): Int = {

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -66,7 +66,6 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Loggi
     val nodes = getAndVerifyWorkerNodes(conf)
     if (!isRestApiBasedClient(hc)) {
       ExternalH2OBackend.startH2OClient(hc, nodes)
-      ExternalH2OBackend.verifyH2OClientCloudUp(conf, nodes)
     }
     nodes
   }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ExternalH2OBackend.scala
@@ -21,6 +21,8 @@ package org.apache.spark.h2o.backends.external
 import java.io.{File, FileInputStream, FileOutputStream}
 import java.util.Properties
 
+import ai.h2o.sparkling.utils.ScalaUtils._
+import org.apache.commons.io.IOUtils
 import org.apache.spark.expose.Logging
 import org.apache.spark.h2o.backends.{ArgumentBuilder, SharedBackendConf, SparklingBackend}
 import org.apache.spark.h2o.ui.SparklingWaterHeartbeatEvent
@@ -32,9 +34,6 @@ import water.init.NetworkUtils
 import water.util.PrettyPrint
 
 import scala.io.Source
-import scala.util.control.NoStackTrace
-import ai.h2o.sparkling.utils.ScalaUtils._
-import org.apache.commons.io.IOUtils
 
 
 class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Logging with RestApiUtils {
@@ -367,5 +366,3 @@ object ExternalH2OBackend extends ExternalBackendUtils {
   // Name of the environmental property, which may contain path to the external H2O driver
   val ENV_H2O_DRIVER_JAR = "H2O_DRIVER_JAR"
 }
-
-class H2OClusterNotRunning(msg: String) extends Exception(msg) with NoStackTrace


### PR DESCRIPTION
This check does not bring any additional value as we already check the cluster size in `      ExternalH2OBackend.startH2OClient(hc, nodes)`