### PR TITLE
[SW-1937] Move RestAPIUtils to ai.h2o.sparkling package

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/frame/H2OChunk.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/frame/H2OChunk.scala
@@ -20,9 +20,9 @@ package ai.h2o.sparkling.frame
 import java.io.InputStream
 
 import ai.h2o.sparkling.extensions.rest.api.Paths
-import ai.h2o.sparkling.utils.Base64Encoding
+import ai.h2o.sparkling.utils.{Base64Encoding, RestApiUtils}
 import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.backends.external.{RestApiUtils, RestCommunication}
+import org.apache.spark.h2o.backends.external.RestCommunication
 import org.apache.spark.h2o.utils.NodeDesc
 
 

--- a/core/src/main/scala/ai/h2o/sparkling/frame/H2OFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/frame/H2OFrame.scala
@@ -20,8 +20,8 @@ package ai.h2o.sparkling.frame
 import java.text.MessageFormat
 import java.util
 
-import org.apache.spark.h2o.backends.external.RestApiUtils.{getClusterEndpoint, update}
-import org.apache.spark.h2o.backends.external.{RestApiUtils, RestCommunication}
+import ai.h2o.sparkling.utils.RestApiUtils._
+import org.apache.spark.h2o.backends.external.RestCommunication
 import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.api.schemas3.FrameChunksV3.FrameChunkV3
@@ -90,7 +90,7 @@ object H2OFrame extends RestCommunication {
       Seq((classOf[FrameV3], "chunk_summary"), (classOf[FrameV3], "distribution_summary")))
     val frame = frames.frames(0)
     val frameChunks = query[FrameChunksV3](endpoint, s"/3/FrameChunks/$frameId", conf)
-    val clusterNodes = RestApiUtils.getNodes(RestApiUtils.getCloudInfoFromNode(endpoint, conf))
+    val clusterNodes = getNodes(getCloudInfoFromNode(endpoint, conf))
 
     H2OFrame(
       frameId = frame.frame_id.name,

--- a/core/src/main/scala/ai/h2o/sparkling/utils/H2OContextUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/utils/H2OContextUtils.scala
@@ -1,0 +1,48 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package ai.h2o.sparkling.utils
+
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+
+import org.apache.spark.h2o.H2OConf
+import org.apache.spark.h2o.backends.external.RestCommunication
+
+trait H2OContextUtils extends RestCommunication with RestApiUtils {
+
+  private def logFileName(): String = {
+    val pattern = "yyyyMMdd_hhmmss"
+    val formatter = new SimpleDateFormat(pattern)
+    val now = formatter.format(new Date)
+    s"h2ologs_$now"
+  }
+
+  def downloadLogs(destinationDir: String, logContainer: String, conf: H2OConf): String = {
+    val endpoint = RestApiUtils.getClusterEndpoint(conf)
+    val file = new File(destinationDir, s"${logFileName()}.${logContainer.toLowerCase}")
+    val logEndpoint = s"/3/Logs/download/$logContainer"
+    logContainer match {
+      case "LOG" =>
+        downloadStringURLContent(endpoint, logEndpoint, conf, file)
+      case "ZIP" =>
+        downloadBinaryURLContent(endpoint, logEndpoint, conf, file)
+    }
+    file.getAbsolutePath
+  }
+}

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -19,6 +19,7 @@ package org.apache.spark.h2o
 
 import java.util.concurrent.atomic.AtomicReference
 
+import ai.h2o.sparkling.utils.RestApiUtils
 import org.apache.spark._
 import org.apache.spark.h2o.backends.external._
 import org.apache.spark.h2o.backends.internal.InternalH2OBackend
@@ -467,7 +468,8 @@ object H2OContext extends Logging {
     override protected def getFlowEndpoint(): String = s"${getH2OEndpointIp()}:${getH2OEndpointPort()}${conf.contextPath.getOrElse("")}"
   }
 
-  private class H2OContextRestAPIBased(spark: SparkSession, conf: H2OConf) extends H2OContext(spark, conf) with RestApiUtils {
+  private class H2OContextRestAPIBased(spark: SparkSession, conf: H2OConf) extends H2OContext(spark, conf) with
+    ai.h2o.sparkling.utils.H2OContextUtils {
     private var flowIp: String = _
     private var flowPort: Int = _
     private var leaderNode: NodeDesc = _
@@ -479,7 +481,7 @@ object H2OContext extends Logging {
     override protected def getSelfNodeDesc(): Option[NodeDesc] = None
 
     override protected def getH2OClusterInfo(nodes: Array[NodeDesc]): H2OClusterInfo = {
-      val cloudV3 = getCloudInfo(conf)
+      val cloudV3 = getClusterInfo(conf)
       H2OClusterInfo(
         s"$flowIp:$flowPort",
         cloudV3.cloud_healthy,
@@ -500,7 +502,7 @@ object H2OContext extends Logging {
     }
 
     override protected def getH2OBuildInfo(nodes: Array[NodeDesc]): H2OBuildInfo = {
-      val cloudV3 = getCloudInfo(conf)
+      val cloudV3 = getClusterInfo(conf)
       H2OBuildInfo(
         cloudV3.version,
         cloudV3.branch_name,
@@ -564,7 +566,7 @@ object H2OContext extends Logging {
     }
 
   private def connectingToNewCluster(hc: H2OContext, newConf: H2OConf): Boolean = {
-    val newCloudV3 = RestApiUtils.getCloudInfo(newConf)
+    val newCloudV3 = RestApiUtils.getClusterInfo(newConf)
     val sameNodes = hc.getH2ONodes().map(_.ipPort()).sameElements(newCloudV3.nodes.map(_.ip_port))
     !sameNodes
   }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/external/ProxyStarter.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/external/ProxyStarter.scala
@@ -19,6 +19,7 @@ package org.apache.spark.h2o.backends.external
 
 import java.net._
 
+import ai.h2o.sparkling.utils.RestApiUtils
 import org.apache.spark.SparkEnv
 import org.apache.spark.expose.Logging
 import org.apache.spark.h2o.H2OConf

--- a/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/converters/WriteConverterCtxUtils.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.h2o.converters
 
+import ai.h2o.sparkling.utils.RestApiUtils
 import org.apache.spark.TaskContext
-import org.apache.spark.h2o.backends.external.{ExternalWriteConverterCtx, RestApiUtils}
+import org.apache.spark.h2o.backends.external.ExternalWriteConverterCtx
 import org.apache.spark.h2o.backends.internal.InternalWriteConverterCtx
 import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OContext, _}

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.ml.algos
 import ai.h2o.sparkling.frame.H2OFrame
 import ai.h2o.sparkling.ml.params.H2OCommonParams
 import ai.h2o.sparkling.ml.utils.SchemaUtils
+import ai.h2o.sparkling.utils.RestApiUtils
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.backends.external.RestApiUtils
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{Dataset, SparkSession}
 import water.support.H2OFrameSupport

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgorithm.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgorithm.scala
@@ -18,10 +18,10 @@ package ai.h2o.sparkling.ml.algos
 
 import ai.h2o.sparkling.ml.models.{H2OMOJOModel, H2OMOJOSettings}
 import ai.h2o.sparkling.ml.params.H2OAlgoCommonParams
+import ai.h2o.sparkling.utils.RestApiUtils
 import hex.Model
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.h2o._
-import org.apache.spark.h2o.backends.external.RestApiUtils
 import org.apache.spark.ml.Estimator
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util._

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OKMeans.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OKMeans.scala
@@ -18,10 +18,10 @@ package ai.h2o.sparkling.ml.algos
 
 import ai.h2o.sparkling.frame.{H2OColumnType, H2OFrame}
 import ai.h2o.sparkling.ml.params.{H2OAlgoParamsHelper, H2OAlgoUnsupervisedParams}
+import ai.h2o.sparkling.utils.RestApiUtils
 import hex.kmeans.KMeansModel.KMeansParameters
 import hex.kmeans.{KMeans, KMeansModel}
 import hex.schemas.GLMV3.GLMParametersV3
-import org.apache.spark.h2o.backends.external.RestApiUtils
 import org.apache.spark.h2o.{Frame, H2OContext}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.SparkSession

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OSupervisedAlgorithm.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OSupervisedAlgorithm.scala
@@ -19,10 +19,10 @@ package ai.h2o.sparkling.ml.algos
 import ai.h2o.sparkling.frame.{H2OColumnType, H2OFrame}
 import ai.h2o.sparkling.ml.models.H2OSupervisedMOJOModel
 import ai.h2o.sparkling.ml.params.H2OAlgoSupervisedParams
+import ai.h2o.sparkling.utils.RestApiUtils
 import hex.Model
 import hex.genmodel.utils.DistributionFamily
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.h2o.backends.external.RestApiUtils
 import org.apache.spark.h2o.{Frame, H2OBaseModel, H2OBaseModelBuilder}
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType


### PR DESCRIPTION
Refactoring ->

 -> Split RestApiUtils and move the methods where they actually belong and avoiding bloating of this class
 -> Move RestApiUtils to ai.h2o.sparkling package
 -> Rename getCloudInfo -> getClusterInfo to reflect H2O terminology