### PR TITLE
[SW-1959] Remove Compiler Warning in HasQuantileAlpha.scala

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/HasQuantileAlpha.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/HasQuantileAlpha.scala
@@ -17,7 +17,7 @@
 
 package ai.h2o.sparkling.ml.params
 
-import org.apache.spark.ml.param.{DoubleParam, Params}
+import org.apache.spark.ml.param._
 
 trait HasQuantileAlpha extends Params {
   private val quantileAlpha = new DoubleParam(


### PR DESCRIPTION
This PR should remove the below compiler warning:
```
.../HasQuantileAlpha.scala:20: imported `DoubleParam' is permanently hidden by definition of object DoubleParam in package paramsimport org.apache.spark.ml.param.{DoubleParam, Params}
```