### PR TITLE
[SW-1966] Fix intermittent error coming from SparklyR in our tests

### DIFF
--- a/r/src/tests/testthat/testConversions.R
+++ b/r/src/tests/testthat/testConversions.R
@@ -10,6 +10,8 @@ config <- c(config, list(
   "sparklyr.gateway.connect.timeout" = 240,
   "sparklyr.gateway.start.timeout" = 240,
   "sparklyr.backend.timeout" = 240,
+  "sparklyr.connect.timeout" <- 60 * 5,
+  "config$sparklyr.log.console" <- TRUE,
   "spark.ext.h2o.external.start.mode" = "auto",
   "spark.ext.h2o.external.disable.version.check" = "true"
 ))


### PR DESCRIPTION
See https://github.com/sparklyr/sparklyr/issues/1984

It makes sense that it is timeout issue as when it fails, it always does so on the first test