### PR TITLE
[SW-1975] Move spark.ext.h2o.hdfs_conf Property among Properties of Internal Backend

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/shared/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/shared/SharedBackendConf.scala
@@ -17,13 +17,7 @@
 
 package ai.h2o.sparkling.backend.shared
 
-import java.io.{File, FileWriter}
-
 import ai.h2o.sparkling.macros.DeprecatedMethod
-import ai.h2o.sparkling.utils.ScalaUtils._
-import org.apache.hadoop.conf.Configuration
-import org.apache.spark.SparkEnv
-import org.apache.spark.expose.Utils
 import org.apache.spark.h2o.H2OConf
 
 import scala.collection.JavaConverters._
@@ -107,8 +101,6 @@ trait SharedBackendConf {
 
   def isInternalSecureConnectionsEnabled: Boolean = sparkConf.getBoolean(PROP_INTERNAL_SECURE_CONNECTIONS._1,
     PROP_INTERNAL_SECURE_CONNECTIONS._2)
-
-  def hdfsConf: Option[String] = sparkConf.getOption(PROP_HDFS_CONF._1)
 
   /** H2O Client parameters */
   def flowDir: Option[String] = sparkConf.getOption(PROP_FLOW_DIR._1)
@@ -239,18 +231,6 @@ trait SharedBackendConf {
 
   def setNodeBasePort(port: Int): H2OConf = set(PROP_NODE_PORT_BASE._1, port.toString)
 
-  def setHdfsConf(path: String): H2OConf = set(PROP_HDFS_CONF._1, path)
-
-  def setHdfsConf(conf: Configuration): H2OConf = {
-    val sparkTmpDir = new File(Utils.getLocalDir(SparkEnv.get.conf))
-    val hdfsConfigTempFile = File.createTempFile("hdfs_conf", ".xml", sparkTmpDir)
-    hdfsConfigTempFile.deleteOnExit()
-    withResource(new FileWriter(hdfsConfigTempFile)) { fileWriter =>
-      conf.writeXml(fileWriter)
-    }
-    set(PROP_HDFS_CONF._1, hdfsConfigTempFile.getAbsolutePath)
-  }
-
   def setMojoDestroyTimeout(timeoutInMilliseconds: Int): H2OConf = set(PROP_MOJO_DESTROY_TIMEOUT._1, timeoutInMilliseconds.toString)
 
   def setNodeExtraProperties(extraProperties: String): H2OConf = set(PROP_NODE_EXTRA_PROPERTIES._1, extraProperties)
@@ -308,7 +288,7 @@ trait SharedBackendConf {
   def setClientExtraProperties(extraProperties: String): H2OConf = set(PROP_CLIENT_EXTRA_PROPERTIES._1, extraProperties)
 
 
-  private[backend] def getFileProperties: Seq[(String, _)] = Seq(PROP_JKS, PROP_LOGIN_CONF, PROP_SSL_CONF, PROP_HDFS_CONF)
+  private[backend] def getFileProperties: Seq[(String, _)] = Seq(PROP_JKS, PROP_LOGIN_CONF, PROP_SSL_CONF)
 }
 
 object SharedBackendConf {
@@ -478,7 +458,4 @@ object SharedBackendConf {
 
   /** Extra properties passed to H2O client during startup. */
   val PROP_CLIENT_EXTRA_PROPERTIES: (String, None.type) = ("spark.ext.h2o.client.extra", None)
-
-  /** Path to whole Hadoop configuration serialized into XML readable by org.hadoop.Configuration class */
-  val PROP_HDFS_CONF: (String, None.type) = ("spark.ext.h2o.hdfs_conf", None)
 }

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -224,13 +224,6 @@ Configuration properties independent of selected backend
 |                                                    |                | corresponding parameters in Sparkling  |
 |                                                    |                | Water.                                 |
 +----------------------------------------------------+----------------+----------------------------------------+
-| ``spark.ext.h2o.hdfs_conf``            | ``sc.hadoopConfiguration`` | Either a string with the Path to a file|
-|                                                    |                | with Hadoop HDFS configuration or the  |
-|                                                    |                | org.apache.hadoop.conf.Configuration   |
-|                                                    |                | object. Useful for HDFS credentials    |
-|                                                    |                | settings and other HDFS-related        |
-|                                                    |                | configurations.                        |
-+----------------------------------------------------+----------------+----------------------------------------+
 
 --------------
 
@@ -268,6 +261,13 @@ Internal backend configuration properties
 | ``spark.ext.h2o.node.enable.web``                  | ``false``      | Enable or disable web on H2O worker    |
 |                                                    |                | nodes. It is disabled by default for   |
 |                                                    |                | security reasons.                      |
++----------------------------------------------------+----------------+----------------------------------------+
+| ``spark.ext.h2o.hdfs_conf``            | ``sc.hadoopConfiguration`` | Either a string with the Path to a file|
+|                                                    |                | with Hadoop HDFS configuration or the  |
+|                                                    |                | org.apache.hadoop.conf.Configuration   |
+|                                                    |                | object. Useful for HDFS credentials    |
+|                                                    |                | settings and other HDFS-related        |
+|                                                    |                | configurations.                        |
 +----------------------------------------------------+----------------+----------------------------------------+
 | **H2O nodes parameters**                           |                |                                        |
 +----------------------------------------------------+----------------+----------------------------------------+

--- a/py/src/ai/h2o/sparkling/InternalBackendConf.py
+++ b/py/src/ai/h2o/sparkling/InternalBackendConf.py
@@ -74,6 +74,9 @@ class InternalBackendConf(SharedBackendConfUtils):
     def nodeIcedDir(self):
         return self._get_option(self._jconf.nodeIcedDir())
 
+    def hdfsConf(self):
+        return self._get_option(self._jconf.hdfsConf())
+
     #
     # Setters
     #
@@ -140,4 +143,8 @@ class InternalBackendConf(SharedBackendConfUtils):
 
     def setNodeIcedDir(self, dir):
         self._jconf.setNodeIcedDir(dir)
+        return self
+
+    def setHdfsConf(self, hdfsConf):
+        self._jconf.setHdfsConf(hdfsConf)
         return self

--- a/py/src/ai/h2o/sparkling/SharedBackendConf.py
+++ b/py/src/ai/h2o/sparkling/SharedBackendConf.py
@@ -356,9 +356,6 @@ class SharedBackendConf(SharedBackendConfUtils):
     def clientCheckRetryTimeout(self):
         return self._jconf.clientCheckRetryTimeout()
 
-    def hdfsConf(self):
-        return self._get_option(self._jconf.hdfsConf())
-
     #
     # Setters
     #
@@ -841,8 +838,4 @@ class SharedBackendConf(SharedBackendConfUtils):
 
     def setClientExtraProperties(self, extraProperties):
         self._jconf.setClientExtraProperties(extraProperties)
-        return self
-
-    def setHdfsConf(self, hdfsConf):
-        self._jconf.setHdfsConf(hdfsConf)
         return self


### PR DESCRIPTION
I propose to move this property since it's used only by the internal backend.