### PR TITLE
[SW-1846] Be able to compile Sparkling Water with Scala 2.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,8 @@ ext {
     ]
 
     defaultScalaBaseVersion = '2.11'
-    supportedScalaBaseVersions = ['2.11': '2.11.12']
+    supportedScalaBaseVersions = ['2.11': '2.11.12', '2.12' : '2.12.10']
+    scalaTestVersions = ['2.11': '2.2.1', '2.12': '3.0.8']
 }
 
 def versionSpecificProps = new Properties()
@@ -133,7 +134,7 @@ configure(allprojects) { project ->
     ext {
         scalaBaseVersion = project.findProperty('scalaBaseVersion') ?: defaultScalaBaseVersion
         scalaVersion = supportedScalaBaseVersions[scalaBaseVersion]
-
+        scalaTestVersion = scalaTestVersions[scalaBaseVersion]
         // h2oBuild property is defined in gradle.properties
         h2oVersion = "$h2oMajorVersion.$h2oBuild"
         sparkVersion = loadVersionSpecificProp("sparkVersion", versionSpecificProps)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -88,13 +88,13 @@ dependencies {
     testImplementation("org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}")
     testImplementation("org.apache.spark:spark-repl_${scalaBaseVersion}:${sparkVersion}")
     testImplementation(project(':sparkling-water-macros'))
-    testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:2.2.1")
+    testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
     testImplementation("junit:junit:4.11")
 
-    integTestImplementation("org.scalatest:scalatest_${scalaBaseVersion}:2.2.1")
+    integTestImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
     integTestImplementation("junit:junit:4.11")
 
-    benchImplementation("org.scalatest:scalatest_${scalaBaseVersion}:2.2.1")
+    benchImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
     benchImplementation("junit:junit:4.11")
 
     // Put Spark Assembly on runtime path

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/RestCommunication.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/RestCommunication.scala
@@ -119,6 +119,7 @@ trait RestCommunication extends Logging {
       override def shouldSkipField(f: FieldAttributes): Boolean = {
         skippedFields.exists {
           case (clazz: Class[_], fieldName: String) => clazz == f.getDeclaringClass && fieldName == f.getName
+          case _ => false
         }
       }
 

--- a/core/src/main/scala/water/api/RestAPIManager.scala
+++ b/core/src/main/scala/water/api/RestAPIManager.scala
@@ -30,9 +30,9 @@ private[api] class RestAPIManager(hc: H2OContext) {
     // Register first the core
     register(CoreRestAPI, dummyRestApiContext)
     // Then additional APIs
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
     loader.reload()
-    loader.foreach(api => register(api, dummyRestApiContext))
+    loader.asScala.foreach(api => register(api, dummyRestApiContext))
   }
 
   def register(api: RestApi, context: RestApiContext): Unit = {

--- a/doc/src/site/sphinx/devel/build.rst
+++ b/doc/src/site/sphinx/devel/build.rst
@@ -21,6 +21,15 @@ If you don't want to build executable distribution, but just want to build or te
 
 - To build and test a specific module, use, for example, ``./gradlew :sparkling-water-examples:check``.
 
+Changing Scala Version
+----------------------
+
+Sparkling Water by default uses Scala version which is default for given Spark. All the artifacts published are built
+against the default Scala version for given Spark. If you want build Sparkling Water for non-default Scala version,
+for example from 2.11 to 2.12, create Sparkling Water distribution as ``./gradlew dist -PscalaBaseVersion=2.12``
+
+Building Against Custom H2O
+---------------------------
 
 Note: If you would like to build against custom H2O Python package, specify ``H2O_HOME`` environment variable. The variable
 should point to the root directory of H2O-3 repository. This is mainly used for integration testing with H2O-3.

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -41,14 +41,14 @@ dependencies {
     compileOnly("org.apache.spark:spark-streaming_${scalaBaseVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}")
 
-    integTestImplementation("org.scalatest:scalatest_${scalaBaseVersion}:2.2.1")
+    integTestImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
     integTestImplementation("junit:junit:4.11")
     integTestImplementation(project(path: ':sparkling-water-core', configuration: 'testArchives'))
     integTestImplementation("org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}")
     integTestCompileOnly("org.scala-lang:scala-compiler:${scalaVersion}")
     integTestRuntimeOnly(fileTree(dir: new File((String) sparkHome, "jars/"), include: '*.jar'))
 
-    scriptsTestImplementation("org.scalatest:scalatest_${scalaBaseVersion}:2.2.1")
+    scriptsTestImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
     scriptsTestImplementation("junit:junit:4.11")
     scriptsTestImplementation(project(path: ':sparkling-water-core', configuration: 'testArchives'))
     scriptsTestImplementation("org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}")

--- a/examples/src/scriptsTest/scala/ai/h2o/sparkling/ScriptTestHelper.scala
+++ b/examples/src/scriptsTest/scala/ai/h2o/sparkling/ScriptTestHelper.scala
@@ -77,7 +77,7 @@ trait ScriptsTestHelper extends FunSuite with Logging with BeforeAndAfterAll {
 
     inspections.termsAndValues.foreach {
       termName =>
-        testResult.addTermValue(termName, loop.valueOfTerm(termName).map(_.toString).getOrElse("None"))
+        testResult.addTermValue(termName, loop.extractValue(termName).map(_.toString).getOrElse("None"))
     }
 
     testResult

--- a/extensions/src/main/scala/ai/h2o/sparkling/extensions/stacktrace/StackTraceCollector.scala
+++ b/extensions/src/main/scala/ai/h2o/sparkling/extensions/stacktrace/StackTraceCollector.scala
@@ -27,7 +27,6 @@ class StackTraceCollector extends AbstractH2OExtension {
   private var interval = -1 // -1 means disabled
 
   override def getExtensionName = "StackTraceCollector"
-
   override def printHelp(): Unit = {
     System.out.println(
       "\nStack trace collector extension:\n" +
@@ -61,16 +60,15 @@ class StackTraceCollector extends AbstractH2OExtension {
 
   private class StackTraceCollectorThread extends Thread("StackTraceCollectorThread") {
     setDaemon(true)
-
+    import scala.collection.JavaConverters._
     override def run(): Unit = {
       while (true) {
         try {
           Log.info("Taking stacktrace at time: " + new Date)
-          val allStackTraces = Thread.getAllStackTraces
-          import scala.collection.JavaConversions._
-          for (e <- allStackTraces.entrySet) {
-            Log.info("Taking stacktrace for thread: " + e.getKey)
-            for (st <- e.getValue) {
+          val allStackTraces = Thread.getAllStackTraces.asScala
+          for (e <- allStackTraces) {
+            Log.info("Taking stacktrace for thread: " + e._1)
+            for (st <- e._2) {
               Log.info("\t" + st.toString)
             }
           }

--- a/extensions/src/main/scala/ai/h2o/sparkling/extensions/stacktrace/StackTraceCollector.scala
+++ b/extensions/src/main/scala/ai/h2o/sparkling/extensions/stacktrace/StackTraceCollector.scala
@@ -19,14 +19,15 @@ package ai.h2o.sparkling.extensions.stacktrace
 
 import java.util.Date
 
-import water.{AbstractH2OExtension, H2O}
 import water.util.Log
+import water.{AbstractH2OExtension, H2O}
 
 
 class StackTraceCollector extends AbstractH2OExtension {
   private var interval = -1 // -1 means disabled
 
   override def getExtensionName = "StackTraceCollector"
+
   override def printHelp(): Unit = {
     System.out.println(
       "\nStack trace collector extension:\n" +
@@ -60,16 +61,18 @@ class StackTraceCollector extends AbstractH2OExtension {
 
   private class StackTraceCollectorThread extends Thread("StackTraceCollectorThread") {
     setDaemon(true)
+
     import scala.collection.JavaConverters._
+
     override def run(): Unit = {
       while (true) {
         try {
           Log.info("Taking stacktrace at time: " + new Date)
           val allStackTraces = Thread.getAllStackTraces.asScala
-          for (e <- allStackTraces) {
-            Log.info("Taking stacktrace for thread: " + e._1)
-            for (st <- e._2) {
-              Log.info("\t" + st.toString)
+          for ((thread, traces) <- allStackTraces) {
+            Log.info("Taking stacktrace for thread: " + thread)
+            for (trace <- traces) {
+              Log.info("\t" + trace.toString)
             }
           }
           Thread.sleep(interval * 1000)

--- a/macros/build.gradle
+++ b/macros/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compileOnly("org.scala-lang:scala-compiler:${scalaVersion}")
     compileOnly("org.scala-lang:scala-reflect:${scalaVersion}")
 
-    testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:2.2.1")
+    testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
     testImplementation("junit:junit:4.11")
     testImplementation("org.apache.spark:spark-core_${scalaBaseVersion}:${sparkVersion}")
     testImplementation(project(":sparkling-water-core"))

--- a/ml/build.gradle
+++ b/ml/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation("org.apache.spark:spark-repl_${scalaBaseVersion}:${sparkVersion}")
     testImplementation("ai.h2o:mojo2-runtime-api:${mojoPipelineVersion}")
     testImplementation("ai.h2o:mojo2-runtime-impl:${mojoPipelineVersion}")
-    testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:2.2.1")
+    testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
     testImplementation("junit:junit:4.11")
     testImplementation(project(path: ':sparkling-water-core', configuration: 'testArchives'))
     // For test purposes, force newer client as the tests are modifying classpath and we get errors which

--- a/repl/build.gradle
+++ b/repl/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compileOnly("org.apache.spark:spark-repl_${scalaBaseVersion}:${sparkVersion}")
 
     testImplementation("org.apache.spark:spark-repl_${scalaBaseVersion}:${sparkVersion}")
-    testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:2.2.1")
+    testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
     testImplementation("junit:junit:4.11")
 }
 

--- a/repl/src/main/scala/ai/h2o/sparkling/repl/H2OInterpreter.scala
+++ b/repl/src/main/scala/ai/h2o/sparkling/repl/H2OInterpreter.scala
@@ -71,13 +71,6 @@ class H2OInterpreter(sparkContext: SparkContext, sessionId: Int) extends BaseH2O
 
     settings
   }
-
-
-  override def valueOfTerm(term: String): Option[Any] = {
-    try Some(intp.eval(term)) catch {
-      case _: Exception => None
-    }
-  }
 }
 
 object H2OInterpreter {

--- a/repl/src/main/scala/ai/h2o/sparkling/repl/PatchUtils.scala
+++ b/repl/src/main/scala/ai/h2o/sparkling/repl/PatchUtils.scala
@@ -56,7 +56,11 @@ private[repl] object PatchUtils {
     val patcher: Patcher = (obj: AnyRef, clz: Class[_]) => {
       val f = clz.getDeclaredField("REPLClass")
       f.setAccessible(true)
-      f.set(obj, OUTER_SCOPE_REPL_REGEX)
+      try {
+        f.set(obj, OUTER_SCOPE_REPL_REGEX)
+      } catch {
+        case _: Throwable => // we have already patched once
+      }
       true
     }
 

--- a/repl/src/main/scala/ai/h2o/sparkling/repl/PatchUtils.scala
+++ b/repl/src/main/scala/ai/h2o/sparkling/repl/PatchUtils.scala
@@ -59,7 +59,7 @@ private[repl] object PatchUtils {
       try {
         f.set(obj, OUTER_SCOPE_REPL_REGEX)
       } catch {
-        case _: Throwable => // we have already patched once
+        case _: IllegalAccessError => // we have already patched once
       }
       true
     }

--- a/repl/src/main/scala/ai/h2o/sparkling/repl/PatchUtils.scala
+++ b/repl/src/main/scala/ai/h2o/sparkling/repl/PatchUtils.scala
@@ -59,7 +59,7 @@ private[repl] object PatchUtils {
       try {
         f.set(obj, OUTER_SCOPE_REPL_REGEX)
       } catch {
-        case _: IllegalAccessError => // we have already patched once
+        case _: IllegalArgumentException => // we have already patched once
       }
       true
     }


### PR DESCRIPTION
Enable users to build Sparkling Water with Scala 2.12. 

Manually tested that it compiles and tests unit pass fine with Scala 2.12

Just updated code so it can build on Scala 2.11 and Scala 2.12. 

Note: We do not publish artifacts for non-default Scala for given Spark at this moment. So no tests on purpose at this stage. Just to give developers the ability to start building SW with Scala 2.12 and give us feedback.

Also upgrade to Spark. 3.0 will be easier as we now know that our code is agnostic to Scala version (at least when considering 2.11 and 2.12). We can just specify the scalaBaseVersion on sparkProperties level, not on the global gradle.properties level.
