### PR TITLE
[SW-1969] Respect SparkSession of a current environment

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedRDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedRDD.scala
@@ -18,6 +18,7 @@
 package ai.h2o.sparkling.backend.converters
 
 import ai.h2o.sparkling.backend.shared.Converter
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark._
 import org.apache.spark.h2o._
 import org.apache.spark.mllib.regression.LabeledPoint
@@ -47,145 +48,166 @@ private[this] object SupportedRDD {
 
   implicit def toH2OFrameFromRDDJavaBool(rdd: RDD[java.lang.Boolean]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDJavaByte(rdd: RDD[java.lang.Byte]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDJavaShort(rdd: RDD[java.lang.Short]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDJavaInt(rdd: RDD[java.lang.Integer]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDJavaFloat(rdd: RDD[java.lang.Float]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDJavaDouble(rdd: RDD[java.lang.Double]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDJavaLong(rdd: RDD[java.lang.Long]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDBool(rdd: RDD[Boolean]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDByte(rdd: RDD[Byte]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDShort(rdd: RDD[Short]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDInt(rdd: RDD[Int]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDFloat(rdd: RDD[Float]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromDouble(rdd: RDD[Double]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDLong(rdd: RDD[Long]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDString(rdd: RDD[String]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDLabeledPoint(rdd: RDD[LabeledPoint]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDTimeStamp(rdd: RDD[java.sql.Timestamp]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.map(v => Tuple1(v)).toDF(), frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDProductNoTypeTag(rdd: RDD[Product]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      SparkDataFrameConverter.toH2OFrameKeyString(hc, hc.sparkSession.createDataFrame(rdd), frameKeyName, converter)
+      val df = SparkSessionUtils.active.createDataFrame(rdd)
+      SparkDataFrameConverter.toH2OFrameKeyString(hc, df, frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDProduct[A <: Product : ClassTag : TypeTag](rdd: RDD[A]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      SparkDataFrameConverter.toH2OFrameKeyString(hc, hc.sparkSession.createDataFrame(rdd), frameKeyName, converter)
+      val df = SparkSessionUtils.active.createDataFrame(rdd)
+      SparkDataFrameConverter.toH2OFrameKeyString(hc, df, frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDmlVector(rdd: RDD[ml.linalg.Vector]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.map(v => Tuple1(v)).toDF, frameKeyName, converter)
     }
   }
 
   implicit def toH2OFrameFromRDDMLlibVector(rdd: RDD[mllib.linalg.Vector]): SupportedRDD = new SupportedRDD {
     override def toH2OFrameKeyString(hc: H2OContext, frameKeyName: Option[String], converter: Converter): String = {
-      import hc.sparkSession.implicits._
+      val spark = SparkSessionUtils.active
+      import spark.implicits._
       SparkDataFrameConverter.toH2OFrameKeyString(hc, rdd.map(v => Tuple1(v)).toDF, frameKeyName, converter)
     }
   }

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
@@ -22,12 +22,12 @@ import java.util.Properties
 
 import ai.h2o.sparkling.backend.shared.{ArgumentBuilder, SharedBackendConf, SparklingBackend}
 import ai.h2o.sparkling.utils.ScalaUtils._
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.commons.io.IOUtils
 import org.apache.spark.expose.Logging
 import org.apache.spark.h2o.ui.SparklingWaterHeartbeatEvent
 import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{BuildInfo, H2OConf, H2OContext}
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkEnv, SparkFiles}
 import water.api.schemas3.{CloudLockV3, PingV3}
 import water.init.NetworkUtils
@@ -325,7 +325,7 @@ object ExternalH2OBackend extends ExternalBackendUtils {
       }
 
       if (conf.cloudName.isEmpty) {
-        conf.setCloudName(H2O_JOB_NAME.format(SparkSession.builder().getOrCreate().sparkContext.applicationId))
+        conf.setCloudName(H2O_JOB_NAME.format(SparkSessionUtils.active.sparkContext.applicationId))
       }
 
       if (conf.clusterInfoFile.isEmpty) {
@@ -373,7 +373,7 @@ object ExternalH2OBackend extends ExternalBackendUtils {
         throw new IllegalArgumentException("H2O Cluster endpoint has to be specified!")
       }
     }
-    distributeFiles(conf, SparkSession.builder().getOrCreate().sparkContext)
+    distributeFiles(conf, SparkSessionUtils.active.sparkContext)
     conf
   }
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendWriter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendWriter.scala
@@ -29,7 +29,7 @@ private[sparkling] class InternalBackendWriter(frameName: String,
                                                chunkId: Int,
                                                sparse: Array[Boolean],
                                                vecStartSize: Map[Int, Int]) extends Writer {
-  private val chunks = ChunkUtils.createNewChunks(frameName, expectedTypes, chunkId)
+  private val chunks = ChunkUtils.createNewChunks(frameName, expectedTypes, chunkId, sparse)
   private val sparseVectorPts = collection.mutable.Map(vecStartSize.mapValues(size => new Array[Int](size)).toSeq: _*)
   private val sparseVectorInUse = collection.mutable.Map(vecStartSize.mapValues(_ => false).toSeq: _*)
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendWriter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendWriter.scala
@@ -29,7 +29,7 @@ private[sparkling] class InternalBackendWriter(frameName: String,
                                                chunkId: Int,
                                                sparse: Array[Boolean],
                                                vecStartSize: Map[Int, Int]) extends Writer {
-  private val chunks = ChunkUtils.createNewChunks(frameName, expectedTypes, chunkId, sparse)
+  private val chunks = ChunkUtils.createNewChunks(frameName, expectedTypes, chunkId)
   private val sparseVectorPts = collection.mutable.Map(vecStartSize.mapValues(size => new Array[Int](size)).toSeq: _*)
   private val sparseVectorInUse = collection.mutable.Map(vecStartSize.mapValues(_ => false).toSeq: _*)
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/shared/SecurityUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/shared/SecurityUtils.scala
@@ -25,7 +25,8 @@ import water.network.{SecurityUtils => H2OSecurityUtils}
 
 private[backend] object SecurityUtils {
 
-  def enableSSL(spark: SparkSession, conf: H2OConf): Unit = {
+  def enableSSL(conf: H2OConf): Unit = {
+    val spark = SparkSession.active
     val sslPair = generateSSLPair()
     val config = generateSSLConfig(sslPair)
     conf.set(SharedBackendConf.PROP_SSL_CONF._1, config)
@@ -35,7 +36,7 @@ private[backend] object SecurityUtils {
     }
   }
 
-  def enableFlowSSL(spark: SparkSession, conf: H2OConf): H2OConf = {
+  def enableFlowSSL(conf: H2OConf): H2OConf = {
     val sslPair = generateSSLPair("h2o-internal-auto-flow-ssl")
     conf.setJks(sslPair.jks.getLocation)
     conf.setJksPass(sslPair.jks.pass)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/shared/SecurityUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/shared/SecurityUtils.scala
@@ -17,16 +17,16 @@
 
 package ai.h2o.sparkling.backend.shared
 
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.expose.Utils
 import org.apache.spark.h2o.H2OConf
-import org.apache.spark.sql.SparkSession
 import water.network.SecurityUtils.SSLCredentials
 import water.network.{SecurityUtils => H2OSecurityUtils}
 
 private[backend] object SecurityUtils {
 
   def enableSSL(conf: H2OConf): Unit = {
-    val spark = SparkSession.active
+    val spark = SparkSessionUtils.active
     val sslPair = generateSSLPair()
     val config = generateSSLConfig(sslPair)
     conf.set(SharedBackendConf.PROP_SSL_CONF._1, config)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/shared/SharedBackendUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/shared/SharedBackendUtils.scala
@@ -22,7 +22,6 @@ import java.io.File
 import org.apache.spark.expose.{Logging, Utils}
 import org.apache.spark.h2o.H2OConf
 import org.apache.spark.h2o.utils.NodeDesc
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkContext, SparkEnv, SparkFiles}
 import water.support.SparkContextSupport
 
@@ -62,11 +61,11 @@ trait SharedBackendUtils extends Logging with Serializable {
     }
 
     if (conf.isInternalSecureConnectionsEnabled && conf.sslConf.isEmpty) {
-      SecurityUtils.enableSSL(SparkSession.builder().getOrCreate(), conf)
+      SecurityUtils.enableSSL(conf)
     }
 
     if (conf.autoFlowSsl) {
-      SecurityUtils.enableFlowSSL(SparkSession.builder().getOrCreate(), conf)
+      SecurityUtils.enableFlowSSL(conf)
     }
 
     if (conf.backendClusterMode != "internal" && conf.backendClusterMode != "external") {

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -24,6 +24,7 @@ import ai.h2o.sparkling.backend.converters.{DatasetConverter, SparkDataFrameConv
 import ai.h2o.sparkling.backend.external
 import ai.h2o.sparkling.backend.external.{ExternalH2OBackend, H2OClusterNotReachableException, ProxyStarter, RestApiException, RestApiUtils}
 import ai.h2o.sparkling.backend.shared.{AzureDatabricksUtils, Converter, SharedBackendConf, SparklingBackend}
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark._
 import org.apache.spark.h2o.backends.internal.InternalH2OBackend
 import org.apache.spark.h2o.ui._
@@ -183,8 +184,9 @@ abstract class H2OContext private(val sparkSession: SparkSession, private val co
 
     // Initial update
     val swHeartBeatEvent = getSparklingWaterHeartBeatEvent()
-    sparkSession.sparkContext.listenerBus.post(swHeartBeatEvent)
-    sparkSession.sparkContext.listenerBus.post(H2OContextStartedEvent(h2oClusterInfo, h2oBuildInfo, swPropertiesInfo))
+    SparkSessionUtils.active.sparkContext.listenerBus.post(swHeartBeatEvent)
+    val listenerBus = SparkSessionUtils.active.sparkContext.listenerBus
+    listenerBus.post(H2OContextStartedEvent(h2oClusterInfo, h2oBuildInfo, swPropertiesInfo))
   }
 
 

--- a/core/src/main/scala/water/api/DataFrames/DataFramesHandler.scala
+++ b/core/src/main/scala/water/api/DataFrames/DataFramesHandler.scala
@@ -16,9 +16,10 @@
 */
 package water.api.DataFrames
 
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
 import water.Iced
 import water.api.{Handler, HandlerFactory, RestApiContext}
 import water.exceptions.H2ONotFoundArgumentException
@@ -27,7 +28,7 @@ import water.exceptions.H2ONotFoundArgumentException
   * Handler for all Spark's DataFrame related queries
   */
 class DataFramesHandler(val sc: SparkContext, val h2oContext: H2OContext) extends Handler {
-  val sqlContext = SparkSession.builder().getOrCreate().sqlContext
+  val sqlContext = SparkSessionUtils.active.sqlContext
 
   def list(version: Int, s: DataFramesV3): DataFramesV3 = {
     val r = s.createAndFillImpl()

--- a/core/src/main/scala/water/api/H2OFrames/H2OFramesHandler.scala
+++ b/core/src/main/scala/water/api/H2OFrames/H2OFramesHandler.scala
@@ -16,6 +16,7 @@
 */
 package water.api.H2OFrames
 
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.{H2OContext, H2OFrame}
 import water.api.{Handler, HandlerFactory, RestApiContext}
@@ -47,7 +48,7 @@ class H2OFramesHandler(val sc: SparkContext, val h2oContext: H2OContext) extends
       s.dataframe_id = "df_" + dataFrame.rdd.id.toString
     }
     dataFrame.createOrReplaceTempView(s.dataframe_id.toLowerCase)
-    h2oContext.sparkSession.sqlContext.cacheTable(s.dataframe_id)
+    SparkSessionUtils.active.sqlContext.cacheTable(s.dataframe_id)
     s
   }
 }

--- a/core/src/main/scala/water/api/RDDs/RDDsHandler.scala
+++ b/core/src/main/scala/water/api/RDDs/RDDsHandler.scala
@@ -16,6 +16,7 @@
 */
 package water.api.RDDs
 
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.{H2OContext, H2OFrame}
 import org.apache.spark.mllib.regression.LabeledPoint
@@ -72,7 +73,7 @@ class RDDsHandler(val sc: SparkContext, val h2oContext: H2OContext) extends Hand
             val schema = ScalaReflection.schemaFor(v._2)
             StructField(v._1, schema.dataType, schema.nullable)
             }
-          val df = h2oContext.sparkSession.createDataFrame(rdd.asInstanceOf[RDD[Product]].map(Row.fromTuple), StructType(fields))
+          val df = SparkSessionUtils.active.createDataFrame(rdd.asInstanceOf[RDD[Product]].map(Row.fromTuple), StructType(fields))
           h2oContext.asH2OFrame(df, name)
         case t => throw new IllegalArgumentException(s"Do not understand type $t")
       }

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
@@ -20,9 +20,10 @@ import ai.h2o.sparkling.backend.external.RestApiUtils
 import ai.h2o.sparkling.frame.H2OFrame
 import ai.h2o.sparkling.ml.params.H2OCommonParams
 import ai.h2o.sparkling.ml.utils.SchemaUtils
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.Dataset
 import water.support.H2OFrameSupport
 import water.{DKV, Key}
 
@@ -45,7 +46,7 @@ trait H2OAlgoCommonUtils extends H2OCommonParams {
     }
 
     val cols = (getFeaturesCols() ++ excludedCols).map(col)
-    val h2oContext = H2OContext.getOrCreate(SparkSession.builder().getOrCreate())
+    val h2oContext = H2OContext.getOrCreate(SparkSessionUtils.active)
     val h2oFrameKey = h2oContext.asH2OFrameKeyString(dataset.select(cols: _*).toDF())
 
     // Our MOJO wrapper needs the full column name before the array/vector expansion in order to do predictions

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
@@ -21,6 +21,7 @@ import ai.h2o.automl.{Algo, AutoML, AutoMLBuildSpec}
 import ai.h2o.sparkling.ml.models.{H2OMOJOModel, H2OMOJOSettings}
 import ai.h2o.sparkling.ml.params._
 import ai.h2o.sparkling.ml.utils.H2OParamsReadable
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import hex.ScoreKeeper
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.h2o.Frame
@@ -43,7 +44,7 @@ class H2OAutoML(override val uid: String) extends Estimator[H2OMOJOModel]
   // Override default values
   setDefault(nfolds, 5)
 
-  private lazy val spark = SparkSession.builder().getOrCreate()
+  private lazy val spark = SparkSessionUtils.active
 
   def this() = this(Identifiable.randomUID(classOf[H2OAutoML].getSimpleName))
 

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OKMeans.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OKMeans.scala
@@ -19,12 +19,12 @@ package ai.h2o.sparkling.ml.algos
 import ai.h2o.sparkling.backend.external.RestApiUtils
 import ai.h2o.sparkling.frame.{H2OColumnType, H2OFrame}
 import ai.h2o.sparkling.ml.params.{H2OAlgoParamsHelper, H2OAlgoUnsupervisedParams}
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import hex.kmeans.KMeansModel.KMeansParameters
 import hex.kmeans.{KMeans, KMeansModel}
 import hex.schemas.GLMV3.GLMParametersV3
 import org.apache.spark.h2o.{Frame, H2OContext}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
-import org.apache.spark.sql.SparkSession
 import water.DKV
 
 /**
@@ -134,7 +134,7 @@ trait H2OKMeansParams extends H2OAlgoUnsupervisedParams[KMeansParameters] {
       if (userPoints == null) {
         null
       } else {
-        val spark = SparkSession.builder().getOrCreate()
+        val spark = SparkSessionUtils.active
         import spark.implicits._
         val df = spark.sparkContext.parallelize(userPoints).toDF()
         H2OContext.getOrCreate(spark).asH2OFrame(df).key

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/features/H2OTargetEncoder.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/features/H2OTargetEncoder.scala
@@ -20,11 +20,12 @@ package ai.h2o.sparkling.ml.features
 import ai.h2o.sparkling.ml.models.{H2OTargetEncoderBase, H2OTargetEncoderModel}
 import ai.h2o.sparkling.ml.params.H2OAlgoParamsHelper
 import ai.h2o.targetencoding._
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.h2o.{Frame, H2OContext}
 import org.apache.spark.ml.Estimator
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
-import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.Dataset
 
 class H2OTargetEncoder(override val uid: String)
   extends Estimator[H2OTargetEncoderModel]
@@ -35,7 +36,7 @@ class H2OTargetEncoder(override val uid: String)
   def this() = this(Identifiable.randomUID("H2OTargetEncoder"))
 
   override def fit(dataset: Dataset[_]): H2OTargetEncoderModel = {
-    val h2oContext = H2OContext.getOrCreate(SparkSession.builder().getOrCreate())
+    val h2oContext = H2OContext.getOrCreate(SparkSessionUtils.active)
     val input = h2oContext.asH2OFrame(dataset.toDF())
     convertRelevantColumnsToCategorical(input)
     val columnsToKeep = getInputCols() ++ Seq(getFoldCol(), getLabelCol()).map(Option(_)).flatten

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala
@@ -17,16 +17,16 @@
 
 package ai.h2o.sparkling.ml.models
 
-import ai.h2o.targetencoding.{BlendingParams, TargetEncoder, TargetEncoderModel}
 import ai.h2o.sparkling.ml.features.H2OTargetEncoderModelUtils
 import ai.h2o.sparkling.ml.utils.SchemaUtils
+import ai.h2o.sparkling.utils.SparkSessionUtils
+import ai.h2o.targetencoding.{BlendingParams, TargetEncoder, TargetEncoderModel}
 import org.apache.spark.h2o.H2OContext
 import org.apache.spark.ml.Model
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.{MLWritable, MLWriter}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
-import water.DKV
+import org.apache.spark.sql.{DataFrame, Dataset}
 import water.support.ModelSerializationSupport
 
 class H2OTargetEncoderModel(
@@ -52,7 +52,7 @@ class H2OTargetEncoderModel(
   private def inputColumnNameToInternalOutputName(inputColumnName: String): String = inputColumnName + "_te"
 
   def transformTrainingDataset(dataset: Dataset[_]): DataFrame = {
-    val h2oContext = H2OContext.getOrCreate(SparkSession.builder().getOrCreate())
+    val h2oContext = H2OContext.getOrCreate(SparkSessionUtils.active)
     val temporaryColumn = getClass.getSimpleName + "_temporary_id"
     val withIdDF = dataset.withColumn(temporaryColumn, monotonically_increasing_id)
     val flatDF = SchemaUtils.flattenDataFrame(withIdDF)

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -108,6 +108,14 @@ class H2OContext(object):
         :return:  instance of H2OContext
         """
 
+        # Workaround for bug in Spark 2.1 as SparkSession created in PySpark is not seen in Java
+        # and call SparkSession.builder.getOrCreate on Java side creates a new session, which is not
+        # desirable
+        activeSession = SparkSession._instantiatedSession
+        if activeSession is not None:
+            jvm = activeSession.sparkContext._jvm
+            jvm.org.apache.spark.sql.SparkSession.setDefaultSession(activeSession._jsparkSession)
+
         # Get spark session
         spark_session = spark
         if isinstance(spark, SparkContext):

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -218,7 +218,8 @@ class H2OContext(object):
         if isinstance(h2oFrame, H2OFrame):
             frame_id = h2oFrame.frame_id
             jdf = self._jhc.asDataFrame(frame_id, copyMetadata)
-            df = DataFrame(jdf, self._sql_context)
+            sqlContext = SparkSession.builder.getOrCreate()._wrapped
+            df = DataFrame(jdf, sqlContext)
             # Attach h2o_frame to dataframe which forces python not to delete the frame when we leave the scope of this
             # method.
             # Without this, after leaving this method python would garbage collect the frame since it's not used

--- a/repl/src/main/scala/ai/h2o/sparkling/repl/BaseH2OInterpreter.scala
+++ b/repl/src/main/scala/ai/h2o/sparkling/repl/BaseH2OInterpreter.scala
@@ -22,9 +22,9 @@
 
 package ai.h2o.sparkling.repl
 
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.expose.Logging
-import org.apache.spark.sql.SparkSession
 
 import scala.Predef.{println => _}
 import scala.annotation.tailrec
@@ -101,7 +101,7 @@ private[repl] abstract class BaseH2OInterpreter(val sparkContext: SparkContext, 
   private def initializeInterpreter(): Unit = {
     settings = createSettings()
     intp = createInterpreter()
-    val spark = SparkSession.builder().getOrCreate()
+    val spark = SparkSessionUtils.active
     addThunk(
       intp.beQuietDuring {
         intp.bind("sc", "org.apache.spark.SparkContext", sparkContext, List("@transient"))

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOBaseCache.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOBaseCache.scala
@@ -17,8 +17,8 @@
 
 package ai.h2o.sparkling.ml.models
 
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.expose.Logging
-import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable
 
@@ -29,7 +29,7 @@ trait H2OMOJOBaseCache[B, M] extends Logging {
   private val lastAccessMap = mutable.Map.empty[String, Long]
 
   private lazy val cleanupRetryTimeout = {
-    val sparkConf = SparkSession.builder().getOrCreate().sparkContext.getConf
+    val sparkConf = SparkSessionUtils.active.sparkContext.getConf
     sparkConf.getInt("spark.ext.h2o.mojo.destroy.timeout", 10 * 60 * 1000)
   }
 

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOLoader.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOLoader.scala
@@ -19,10 +19,10 @@ package ai.h2o.sparkling.ml.models
 
 import java.io.InputStream
 
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.SparkSession
 
 trait H2OMOJOLoader[T] {
 
@@ -30,7 +30,7 @@ trait H2OMOJOLoader[T] {
 
   def createFromMojo(path: String, settings: H2OMOJOSettings): T = {
     val inputPath = new Path(path)
-    val fs = inputPath.getFileSystem(SparkSession.builder().getOrCreate().sparkContext.hadoopConfiguration)
+    val fs = inputPath.getFileSystem(SparkSessionUtils.active.sparkContext.hadoopConfiguration)
     val qualifiedInputPath = inputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
     val is = fs.open(qualifiedInputPath)
 

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOReader.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOReader.scala
@@ -18,8 +18,8 @@
 package ai.h2o.sparkling.ml.models
 
 import ai.h2o.sparkling.ml.utils.H2OReaderBase
+import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql._
 
 
 private[models] class H2OMOJOReader[T <: HasMojoData] extends H2OReaderBase[T] {
@@ -28,7 +28,7 @@ private[models] class H2OMOJOReader[T <: HasMojoData] extends H2OReaderBase[T] {
     val model = super.load(path)
 
     val inputPath = new Path(path, H2OMOJOProps.serializedFileName)
-    val fs = inputPath.getFileSystem(SparkSession.builder().getOrCreate().sparkContext.hadoopConfiguration)
+    val fs = inputPath.getFileSystem(SparkSessionUtils.active.sparkContext.hadoopConfiguration)
     val qualifiedInputPath = inputPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
     val is = fs.open(qualifiedInputPath)
     val mojoData = Stream.continually(is.read()).takeWhile(_ != -1).map(_.toByte).toArray

--- a/utils/src/main/scala/ai/h2o/sparkling/utils/SparkSessionUtils.scala
+++ b/utils/src/main/scala/ai/h2o/sparkling/utils/SparkSessionUtils.scala
@@ -15,22 +15,15 @@
 * limitations under the License.
 */
 
-package ai.h2o.sparkling.ml.models
+package ai.h2o.sparkling.utils
 
-import ai.h2o.sparkling.utils.SparkSessionUtils
-import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.SparkSession
 
-private[models] trait HasMojoData {
-
-  // Called during init of the model
-   def setMojoData(mojoData : Array[Byte]): this.type = {
-    this.mojoData = mojoData
-    broadcastMojo = SparkSessionUtils.active.sparkContext.broadcast(this.mojoData)
-    this
+/**
+ * Internal utilities methods for Spark Session
+ */
+object SparkSessionUtils {
+  def active: SparkSession = {
+    SparkSession.builder().getOrCreate()
   }
-
-  protected def getMojoData(): Array[Byte] = broadcastMojo.value
-
-  @transient private var mojoData: Array[Byte] = _
-  private var broadcastMojo: Broadcast[Array[Byte]] = _
 }


### PR DESCRIPTION
This change ensures we always use active SparkSession.

The SparkSession passed to H2OContext is basically ignored now, which is correct. I plan to create the parameter-less methods for H2OContext getOrCreate in different JIRA to keep this one smaller https://0xdata.atlassian.net/browse/SW-1977.

The final deprecation of the getOrCreate with spark/sc parameter will be done again in follow-up to  https://0xdata.atlassian.net/browse/SW-1977 in https://0xdata.atlassian.net/browse/SW-1970