### PR TITLE
[SW-1970] Deprecate sparkSession and sparkContext argument of H2OContext.getOrCreate()

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -34,7 +34,7 @@ class H2OConf private(val sparkConf: SparkConf, deprecatedClassName: String) ext
   with InternalBackendConf with ExternalBackendConf with Serializable {
 
   private def deprecationWarning(oldParams: String): Unit = {
-    logWarning(s"The constructor 'new H2OConf($oldParams)' is deprecated." +
+    logWarning(s"The constructor 'new H2OConf($oldParams)' is deprecated. " +
       s"Use 'new H2OConf()' instead! This method will be removed in release 3.32.")
   }
 

--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -30,18 +30,34 @@ import org.apache.spark.{SparkConf, SparkContext}
  * Configuration holder which is representing
  * properties passed from user to Sparkling Water.
  */
-class H2OConf(val sparkConf: SparkConf) extends Logging with InternalBackendConf with ExternalBackendConf with Serializable {
+class H2OConf private(val sparkConf: SparkConf, deprecatedClassName: String) extends Logging
+  with InternalBackendConf with ExternalBackendConf with Serializable {
 
+  private def deprecationWarning(oldParams: String): Unit = {
+    logWarning(s"The constructor 'new H2OConf($oldParams)' is deprecated." +
+      s"Use 'new H2OConf()' instead! This method will be removed in release 3.32.")
+  }
+
+  deprecatedClassName match {
+    case "SparkSession" => deprecationWarning("sparkSession: SparkSession")
+    case "JavaSparkContext" => deprecationWarning("jsc: JavaSparkContext")
+    case "SparkContext" => deprecationWarning("sc: SparkContext")
+    case _ =>
+  }
   H2OConf.checkDeprecatedOptions(sparkConf)
 
-  def this() = this(SparkSessionUtils.active.sparkContext.getConf)
+  def this(sparkConf: SparkConf) = this(sparkConf, "")
+
+  def this() = this(SparkSessionUtils.active.sparkContext.getConf, "")
+
+  private def this(deprecatedClassName: String) = this(SparkSessionUtils.active.sparkContext.getConf, deprecatedClassName)
 
   /** Support for creating H2OConf in Java environments */
-  def this(jsc: JavaSparkContext) = this()
+  def this(jsc: JavaSparkContext) = this("JavaSparkContext")
 
-  def this(sc: SparkContext) = this()
+  def this(sc: SparkContext) = this("SparkContext")
 
-  def this(sparkSession: SparkSession) = this()
+  def this(sparkSession: SparkSession) = this("SparkSession")
 
   // Precondition
   require(sparkConf != null, "Spark conf was null")

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -24,6 +24,7 @@ import ai.h2o.sparkling.backend.converters.{DatasetConverter, SparkDataFrameConv
 import ai.h2o.sparkling.backend.external
 import ai.h2o.sparkling.backend.external.{ExternalH2OBackend, H2OClusterNotReachableException, ProxyStarter, RestApiException, RestApiUtils}
 import ai.h2o.sparkling.backend.shared.{AzureDatabricksUtils, Converter, SharedBackendConf, SparklingBackend}
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark._
 import org.apache.spark.h2o.backends.internal.InternalH2OBackend
@@ -630,13 +631,25 @@ object H2OContext extends Logging {
     getOrCreate(Option(instantiatedContext.get()).map(_.getConf).getOrElse(new H2OConf()))
   }
 
-  def getOrCreate(sparkSession: SparkSession, conf: H2OConf): H2OContext = getOrCreate(conf)
+  @DeprecatedMethod("getOrCreate(conf: H2OConf)", "3.32")
+  def getOrCreate(sparkSession: SparkSession, conf: H2OConf): H2OContext = {
+    getOrCreate(conf)
+  }
 
-  def getOrCreate(sc: SparkContext, conf: H2OConf): H2OContext = getOrCreate(conf)
+  @DeprecatedMethod("getOrCreate(conf: H2OConf)", "3.32")
+  def getOrCreate(sc: SparkContext, conf: H2OConf): H2OContext = {
+    getOrCreate(conf)
+  }
 
-  def getOrCreate(sparkSession: SparkSession): H2OContext = getOrCreate()
+  @DeprecatedMethod("getOrCreate()", "3.32")
+  def getOrCreate(sparkSession: SparkSession): H2OContext = {
+    getOrCreate()
+  }
 
-  def getOrCreate(sc: SparkContext): H2OContext = getOrCreate()
+  @DeprecatedMethod("getOrCreate()", "3.32")
+  def getOrCreate(sc: SparkContext): H2OContext = {
+    getOrCreate()
+  }
 }
 
 class WrongSparkVersion(msg: String) extends Exception(msg) with NoStackTrace

--- a/core/src/main/scala/org/apache/spark/h2o/JavaH2OContext.java
+++ b/core/src/main/scala/org/apache/spark/h2o/JavaH2OContext.java
@@ -247,20 +247,27 @@ public class JavaH2OContext {
         return new JavaH2OContext(H2OContext.getOrCreate(conf));
     }
 
+    private static JavaH2OContext deprecationWarn(JavaH2OContext jhc, String oldParams, String newParams) {
+        jhc.hc.log().warn("Method 'getOrCreate(" + oldParams + ")' is deprecated and will be removed in release 3.32. Use" +
+        "'getOrCreate(" + newParams + ")' instead!");
+        return jhc;
+    }
+
     public static JavaH2OContext getOrCreate(JavaSparkContext jsc) {
-        return getOrCreate();
+        return deprecationWarn(getOrCreate(), "JavaSparkContext jsc", "");
     }
 
     public static JavaH2OContext getOrCreate(JavaSparkContext jsc, H2OConf conf) {
-        return getOrCreate(conf);
+        return deprecationWarn(getOrCreate(), "JavaSparkContext jsc, H2OConf conf", "H2OConf conf");
     }
 
     public static JavaH2OContext getOrCreate(SparkSession sparkSession) {
-        return getOrCreate();
+        return deprecationWarn(getOrCreate(), "SparkSession sparkSession", "");
     }
 
     public static JavaH2OContext getOrCreate(SparkSession sparkSession, H2OConf conf) {
-        return getOrCreate(conf);
+        return deprecationWarn(getOrCreate(), "SparkSession sparkSession, H2OConf conf", "H2OConf conf");
+
     }
 
     public String toString() {

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -3,6 +3,21 @@ Migration Guide
 
 Migration guide between Sparkling Water versions.
 
+From 3.30 to 3.32
+-----------------
+
+- In PySparkling, the ``H2OConf`` no longer accepts any arguments. To create new ``H2OConf``, please just call ``conf = H2OConf()``.
+  Also the ``H2OContext.getOrCreate`` method no longer accepts the spark argument. You can start H2OContext as
+  ``H2OContext.getOrCreate()`` or ``H2OContext.getOrCreate(conf)``
+
+- In RSparkling, the ``H2OConf`` no longer accepts any arguments. To create new ``H2OConf``, please just call ``conf <- H2OConf()``.
+  Also the ``H2OContext.getOrCreate`` method no longer accepts the spark argument. You can start H2OContext as
+  ``H2OContext.getOrCreate()`` or ``H2OContext.getOrCreate(conf)``
+
+- In Scala, ``H2OConf`` can be created as ``new H2OConf()`` or ``new H2OConf(sparkConf)``. Other constructor variants have
+  been removed. Also, ``H2OContext`` can be created as ``H2OContext.getOrCreate()`` or ``H2OContext.getOrCreate(conf)``.
+  The other variants of this method have been removed.
+
 From 3.28.1 to 3.30
 -------------------
 

--- a/macros/src/main/scala/ai/h2o/sparkling/macros/DeprecatedMethodMacro.scala
+++ b/macros/src/main/scala/ai/h2o/sparkling/macros/DeprecatedMethodMacro.scala
@@ -62,7 +62,7 @@ object DeprecatedMethodMacro {
         case q"${Modifiers(f, p, a)} def $methodName[..$tpes](...$args): $returnType = { ..$body }" :: Nil => {
 
           val daMessage = if (replacement.isEmpty) "" else s"Use '$replacement' instead!"
-          val removalMessage = if (version.isEmpty) "" else s"This method will be removed in release $version."
+          val removalMessage = if (version.isEmpty) "" else s"This method will be removed in the release $version."
           val da = q"""new deprecated($daMessage, "")"""
           val warnMessage = s"The method '$methodName' is deprecated. $daMessage $removalMessage"
 

--- a/py/src/ai/h2o/sparkling/H2OConf.py
+++ b/py/src/ai/h2o/sparkling/H2OConf.py
@@ -15,20 +15,21 @@
 # limitations under the License.
 #
 
+import warnings
 from ai.h2o.sparkling.ExternalBackendConf import ExternalBackendConf
 from ai.h2o.sparkling.Initializer import Initializer
 from ai.h2o.sparkling.InternalBackendConf import InternalBackendConf
 from ai.h2o.sparkling.SharedBackendConf import SharedBackendConf
 from pyspark.ml.util import _jvm
-import warnings
 
 
 class H2OConf(SharedBackendConf, InternalBackendConf, ExternalBackendConf):
     def __init__(self, spark=None):
         try:
             if spark is not None:
-                warnings.warn("Constructor H2OConf(spark) with spark argument is deprecated. Please use just H2OConf(). The argument "
-                              "will be removed in release 3.32.")
+                warnings.warn(
+                    "Constructor H2OConf(spark) with spark argument is deprecated. Please use just H2OConf(). "
+                    "The argument will be removed in release 3.32.")
             Initializer.load_sparkling_jar()
             self._jconf = _jvm().org.apache.spark.h2o.H2OConf()
         except:

--- a/py/src/ai/h2o/sparkling/H2OConf.py
+++ b/py/src/ai/h2o/sparkling/H2OConf.py
@@ -20,11 +20,15 @@ from ai.h2o.sparkling.Initializer import Initializer
 from ai.h2o.sparkling.InternalBackendConf import InternalBackendConf
 from ai.h2o.sparkling.SharedBackendConf import SharedBackendConf
 from pyspark.ml.util import _jvm
+import warnings
 
 
 class H2OConf(SharedBackendConf, InternalBackendConf, ExternalBackendConf):
     def __init__(self, spark=None):
         try:
+            if spark is not None:
+                warnings.warn("Constructor H2OConf(spark) with spark argument is deprecated. Please use just H2OConf(). The argument "
+                              "will be removed in release 3.32.")
             Initializer.load_sparkling_jar()
             self._jconf = _jvm().org.apache.spark.h2o.H2OConf()
         except:

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -98,6 +98,9 @@ class H2OContext(object):
         :return:  instance of H2OContext
         """
 
+        if spark is not None and not isinstance(spark, H2OConf):
+            warnings.warn("Method getOrCreate with spark argument is deprecated. Please use either just getOrCreate() or if you need"
+                          "to pass extra H2OConf, use getOrCreate(conf). The spark argument will be removed in release 3.32.")
 
         # Workaround for bug in Spark 2.1 as SparkSession created in PySpark is not seen in Java
         # and call SparkSession.builder.getOrCreate on Java side creates a new session, which is not

--- a/r/src/R/ai/h2o/sparkling/H2OConf.R
+++ b/r/src/R/ai/h2o/sparkling/H2OConf.R
@@ -27,7 +27,7 @@ getOption <- function(option) {
 H2OConf <- setRefClass("H2OConf", fields = list(jconf = "ANY"), methods = list(
   initialize = function(spark = NULL) {
     if (!is.null(spark)) {
-      print("Constructor H2OConf(spark) with spark argument is deprecated. Please use just H2OConf(). The argument will be removed in release 3.32.")
+      print("Constructor H2OConf(spark) with the spark argument is deprecated. Please use just H2OConf(). The argument will be removed in release 3.32.")
     }
     sc <- spark_connection_find()[[1]]
     .self$jconf <- invoke_new(sc, "org.apache.spark.h2o.H2OConf")

--- a/r/src/R/ai/h2o/sparkling/H2OConf.R
+++ b/r/src/R/ai/h2o/sparkling/H2OConf.R
@@ -26,6 +26,9 @@ getOption <- function(option) {
 #' @export H2OConf
 H2OConf <- setRefClass("H2OConf", fields = list(jconf = "ANY"), methods = list(
   initialize = function(spark = NULL) {
+    if (!is.null(spark)) {
+      print("Constructor H2OConf(spark) with spark argument is deprecated. Please use just H2OConf(). The argument will be removed in release 3.32.")
+    }
     sc <- spark_connection_find()[[1]]
     .self$jconf <- invoke_new(sc, "org.apache.spark.h2o.H2OConf")
   },

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -37,7 +37,7 @@ setClientConnected <- function(jhc) {
 H2OContext.getOrCreate <- function(sc = NULL, conf = NULL) {
 
   if (!is.null(sc) && typeof(sc) == "list") {
-    print("Method getOrCreate with sc argument is deprecated. Please use either just getOrCreate() or if you need
+    print("Method getOrCreate with the sc argument is deprecated. Please use either just getOrCreate() or if you need
       to pass extra H2OConf, use getOrCreate(conf). The sc argument will be removed in release 3.32.")
   }
 

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -35,6 +35,12 @@ setClientConnected <- function(jhc) {
 
 #' @export H2OContext.getOrCreate
 H2OContext.getOrCreate <- function(sc = NULL, conf = NULL) {
+
+  if (!is.null(sc) && typeof(sc) == "list") {
+    print("Method getOrCreate with sc argument is deprecated. Please use either just getOrCreate() or if you need
+      to pass extra H2OConf, use getOrCreate(conf). The sc argument will be removed in release 3.32.")
+  }
+
   if (!is.null(sc) && typeof(sc) == "S4") {
     # it means user is passing conf as first argument
     conf <- sc


### PR DESCRIPTION
Final stage of simplification of the getOrCreate method. On purpose I would like to remove the original methods in 2 major releases time to get users more time to migrate as this is the most exposed method