### PR TITLE
[SW-1988] Deprecate passing arguments via kwargs method in getOrCreate in PySparkling

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/shared/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/shared/SharedBackendConf.scala
@@ -135,6 +135,8 @@ trait SharedBackendConf {
 
   def clientCheckRetryTimeout: Int = sparkConf.getInt(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._2)
 
+  def verifySslCertificates: Boolean = sparkConf.getBoolean(PROP_VERIFY_SSL_CERTIFICATES._1, PROP_VERIFY_SSL_CERTIFICATES._2)
+
   /** Setters */
 
   /** Generic parameters */
@@ -287,6 +289,7 @@ trait SharedBackendConf {
 
   def setClientExtraProperties(extraProperties: String): H2OConf = set(PROP_CLIENT_EXTRA_PROPERTIES._1, extraProperties)
 
+  def setVerifySslCertificates(verify: Boolean): H2OConf = set(PROP_VERIFY_SSL_CERTIFICATES._1, verify)
 
   private[backend] def getFileProperties: Seq[(String, _)] = Seq(PROP_JKS, PROP_LOGIN_CONF, PROP_SSL_CONF)
 }
@@ -458,4 +461,7 @@ object SharedBackendConf {
 
   /** Extra properties passed to H2O client during startup. */
   val PROP_CLIENT_EXTRA_PROPERTIES: (String, None.type) = ("spark.ext.h2o.client.extra", None)
+
+  /** Whether certificates should be verified before using in H2O or not. */
+  val PROP_VERIFY_SSL_CERTIFICATES: (String, Boolean) = ("spark.ext.h2o.verify_ssl_certificates", true)
 }

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -224,6 +224,9 @@ Configuration properties independent of selected backend
 |                                                    |                | corresponding parameters in Sparkling  |
 |                                                    |                | Water.                                 |
 +----------------------------------------------------+----------------+----------------------------------------+
+| ``spark.ext.h2o.verify_ssl_certificates``          | ``True``       | Whether certificates should be         |
+|                                                    |                | verified before using in H2O or not.   |
++----------------------------------------------------+----------------+----------------------------------------+
 
 --------------
 

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -28,6 +28,9 @@ Removal of Deprecated Methods and Classes
   ``setUserName`` and ``setPassword`` ond the ``H2OConf`` or via
   the Spark options ``spark.ext.h2o.user.name`` and ``spark.ext.h2o.password`` directly.
 
+- On Pysparkling, passing ``verify_ssl_certificates`` parameter as H2OContext argument is removed in favor of
+  method ``setVerifySslCertificates`` on ``H2OConf`` or via the spark option ``spark.ext.h2o.verify_ssl_certificates``.
+
 - On RSparkling, the method ``h2o_context`` is removed. To create H2OContext, please call
   ``hc <- H2OContext.getOrCreate()``. Also the methods ``h2o_flow``, ``as_h2o_frame`` and ``as_spark_dataframe`` are
   removed. Please use the methods available on the ``H2OContext`` instance created via ``hc <- H2OContext.getOrCreate()``.

--- a/doc/src/site/sphinx/tutorials/secured_flow.rst
+++ b/doc/src/site/sphinx/tutorials/secured_flow.rst
@@ -83,7 +83,7 @@ In order to use https correctly, the following two options need to be specified:
 
 In case your certificates are self-signed, the connection to the H2O cluster will fail due to the security
 limitations. In this case, you can skip the certificates verification
-by calling ``setVerifySslCertificates`` ``H2OConf`` as:
+by calling ``setVerifySslCertificates`` on ``H2OConf`` as:
 
 .. content-tabs::
 
@@ -176,17 +176,6 @@ certificates are created.
         :title: R
 
         To enable https in RSparkling using this mode, run in your RStudio:
-
-
-        and when you have the shell running, start ``H2OContext`` as:
-
-        .. code:: r
-
-            from pysparkling import *
-            hc = H2OContext.getOrCreate()
-
-        You can also start PySparkling shell without the configuration
-        and specify it using the setters on ``H2OConf`` as:
 
         .. code:: r
 

--- a/doc/src/site/sphinx/tutorials/secured_flow.rst
+++ b/doc/src/site/sphinx/tutorials/secured_flow.rst
@@ -46,7 +46,7 @@ In order to use https correctly, the following two options need to be specified:
     .. tab-container:: Python
         :title: Python
 
-        To enable https in Pysparkling, you can start PySparkling as:
+        To enable https in PySparkling, you can start PySparkling as:
 
         .. code:: shell
 
@@ -68,18 +68,48 @@ In order to use https correctly, the following two options need to be specified:
             conf = H2OConf().setJks("/path/to/keystore").setJksPass("password)
             hc = H2OContext.getOrCreate(conf)
 
-        In case your certificates are self-signed, the connection of the
-        Python client to the backend cluster will fail due to the security
-        limitations. In this case, you can skip the certificates verification
-        using ``verify_ssl_certificates=False`` and connect as:
+    .. tab-container:: R
+        :title: R
+
+        To enable https in RSparkling, run in RStudio:
+
+        .. code:: r
+
+            library(rsparkling)
+            sc <- spark_connect(master = "local")
+            conf <- H2OConf()$setJks("/path/to/keystore")$setJksPass("password")
+            hc <- H2OContext.getOrCreate(conf)
+
+
+In case your certificates are self-signed, the connection to the H2O cluster will fail due to the security
+limitations. In this case, you can skip the certificates verification
+by calling ``setVerifySslCertificates`` ``H2OConf`` as:
+
+.. content-tabs::
+
+    .. tab-container:: Scala
+        :title: Scala
+
+        .. code:: scala
+
+            val conf = new H2OConf().setVerifySslCertificates(false)
+            val hc = H2OContext.getOrCreate(conf)
+
+    .. tab-container:: Python
+        :title: Python
 
         .. code:: python
 
-            from pysparkling import *
-            conf = H2OConf().setJks("/path/to/keystore").setJksPass("password)
-            hc = H2OContext.getOrCreate(conf, verify_ssl_certificates=False)
+            conf = H2OConf().setVerifySslCertificates(False)
+            hc = H2OContext.getOrCreate(conf)
 
+    .. tab-container:: R
+        :title: R
 
+        .. code:: r
+
+            conf <- H2OConf()$setVerifySslCertificates(FALSE)
+            hc <- H2OContext.getOrCreate(conf)
 
 Generate the files automatically
 --------------------------------
@@ -98,7 +128,7 @@ certificates are created.
 
         .. code:: shell
 
-            bin/sparkling-shell --conf "spark.ext.h2o.auto.flow.ssl=true"
+            bin/sparkling-shell --conf "spark.ext.h2o.auto.flow.ssl=true" --conf "spark.ext.h2o.verify_ssl_certificates=false"
 
         and when you have the shell running, start ``H2OContext`` as:
 
@@ -113,25 +143,25 @@ certificates are created.
         .. code:: scala
 
             import org.apache.spark.h2o._
-            val conf = new H2OConf().setAutoFlowSslEnabled()
+            val conf = new H2OConf().setAutoFlowSslEnabled().setVerifySslCertificates(false)
             val hc = H2OContext.getOrCreate(conf)
 
 
     .. tab-container:: Python
         :title: Python
 
-        To enable https in Pysparkling using this mode, you can start PySparkling as:
+        To enable https in PySparkling using this mode, you can start PySparkling as:
 
         .. code:: shell
 
-            bin/pysparkling --conf "spark.ext.h2o.auto.flow.ssl=true"
+            bin/pysparkling --conf "spark.ext.h2o.auto.flow.ssl=true"  --conf "spark.ext.h2o.verify_ssl_certificates=false"
 
         and when you have the shell running, start ``H2OContext`` as:
 
         .. code:: python
 
             from pysparkling import *
-            hc = H2OContext.getOrCreate(verify_ssl_certificates=False)
+            hc = H2OContext.getOrCreate()
 
         You can also start PySparkling shell without the configuration
         and specify it using the setters on ``H2OConf`` as:
@@ -139,5 +169,28 @@ certificates are created.
         .. code:: python
 
             from pysparkling import *
-            conf = H2OConf().setAutoFlowSslEnabled()
-            hc = H2OContext.getOrCreate(conf, verify_ssl_certificates=False)
+            conf = H2OConf().setAutoFlowSslEnabled().setVerifySslCertificates(False)
+            hc = H2OContext.getOrCreate(conf)
+
+    .. tab-container:: R
+        :title: R
+
+        To enable https in RSparkling using this mode, run in your RStudio:
+
+
+        and when you have the shell running, start ``H2OContext`` as:
+
+        .. code:: r
+
+            from pysparkling import *
+            hc = H2OContext.getOrCreate()
+
+        You can also start PySparkling shell without the configuration
+        and specify it using the setters on ``H2OConf`` as:
+
+        .. code:: r
+
+            library(rsparkling)
+            sc <- spark_connect(master = "local")
+            conf <- H2OConf()$setAutoFlowSslEnabled()$setVerifySslCertificates(False)
+            hc <- H2OContext.getOrCreate(conf)

--- a/doc/src/site/sphinx/tutorials/secured_flow.rst
+++ b/doc/src/site/sphinx/tutorials/secured_flow.rst
@@ -192,5 +192,5 @@ certificates are created.
 
             library(rsparkling)
             sc <- spark_connect(master = "local")
-            conf <- H2OConf()$setAutoFlowSslEnabled()$setVerifySslCertificates(False)
+            conf <- H2OConf()$setAutoFlowSslEnabled()$setVerifySslCertificates(FALSE)
             hc <- H2OContext.getOrCreate(conf)

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -72,9 +72,9 @@ class H2OContext(object):
 
         kwargs = {}
         kwargs["https"] = True if schema == "https" else False
+        kwargs["verify_ssl_certificates"] = conf.verifySslCertificates()
         if conf.userName() and conf.password():
             kwargs["auth"] = (conf.userName(), conf.password())
-
         url = "{}://{}:{}".format(schema, h2o_context._client_ip, h2o_context._client_port)
         if conf.contextPath() is not None:
             url = "{}/{}".format(url, conf.contextPath())

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -71,7 +71,7 @@ class H2OContext(object):
         conf = h2o_context._conf
 
         kwargs = {}
-        kwargs["https"] = True if schema == "https" else False
+        kwargs["https"] = schema == "https"
         kwargs["verify_ssl_certificates"] = conf.verifySslCertificates()
         if conf.userName() and conf.password():
             kwargs["auth"] = (conf.userName(), conf.password())

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -66,22 +66,19 @@ class H2OContext(object):
         except:
             raise
 
-    def __h2o_connect(h2o_context, **kwargs):
-        if "https" in kwargs:
-            warnings.warn("https argument is automatically set up and the specified value will be ignored.")
+    def __h2o_connect(h2o_context):
         schema = h2o_context._jhc.h2oContext().getConf().getScheme()
-        kwargs["https"] = False
-
         conf = h2o_context._conf
+
+        kwargs = {}
+        kwargs["https"] = True if schema == "https" else False
         if conf.userName() and conf.password():
             kwargs["auth"] = (conf.userName(), conf.password())
-        if schema == "https":
-            kwargs["https"] = True
-        if h2o_context._conf.contextPath() is not None:
-            url = "{}://{}:{}/{}".format(schema, h2o_context._client_ip, h2o_context._client_port, h2o_context._conf.contextPath())
-            return h2o.connect(url=url, **kwargs)
-        else:
-            return h2o.connect(ip=h2o_context._client_ip, port=h2o_context._client_port, **kwargs)
+
+        url = "{}://{}:{}".format(schema, h2o_context._client_ip, h2o_context._client_port)
+        if conf.contextPath() is not None:
+            url = "{}/{}".format(url, conf.contextPath())
+        return h2o.connect(url=url, **kwargs)
 
 
     @staticmethod
@@ -134,7 +131,7 @@ class H2OContext(object):
 
         # Create H2O REST API client
         if not h2o_context.__isClientConnected():
-            h2o_context.__h2o_connect(**kwargs)
+            h2o_context.__h2o_connect()
 
         h2o_context.__setClientConnected()
 

--- a/py/src/ai/h2o/sparkling/SharedBackendConf.py
+++ b/py/src/ai/h2o/sparkling/SharedBackendConf.py
@@ -356,6 +356,9 @@ class SharedBackendConf(SharedBackendConfUtils):
     def clientCheckRetryTimeout(self):
         return self._jconf.clientCheckRetryTimeout()
 
+    def verifySslCertificates(self):
+        return self._jconf.verifySslCertificates()
+
     #
     # Setters
     #
@@ -838,4 +841,8 @@ class SharedBackendConf(SharedBackendConfUtils):
 
     def setClientExtraProperties(self, extraProperties):
         self._jconf.setClientExtraProperties(extraProperties)
+        return self
+
+    def setVerifySslCertificates(self, verify):
+        self._jconf.setVerifySslCertificates(verify)
         return self

--- a/r/src/R/ai/h2o/sparkling/H2OConf.R
+++ b/r/src/R/ai/h2o/sparkling/H2OConf.R
@@ -56,5 +56,9 @@ H2OConf <- setRefClass("H2OConf", fields = list(jconf = "ANY"), methods = list(
   setJks = function(value) {invoke(jconf, "setJks", value); .self },
 
   jksPass = function() { getOption(invoke(jconf, "jksPass")) },
-  setJksPass = function(value) {invoke(jconf, "setJksPass", value); .self }
+  setJksPass = function(value) {invoke(jconf, "setJksPass", value); .self },
+
+  autoFlowSsl = function() { getOption(invoke(jconf, "autoFlowSsl")) },
+  setAutoFlowSslEnabled = function() {invoke(jconf, "setAutoFlowSslEnabled"); .self },
+  setAutoFlowSslDisabled = function() {invoke(jconf, "setAutoFlowSslDisabled"); .self }
 ))

--- a/r/src/R/ai/h2o/sparkling/H2OConf.R
+++ b/r/src/R/ai/h2o/sparkling/H2OConf.R
@@ -47,5 +47,14 @@ H2OConf <- setRefClass("H2OConf", fields = list(jconf = "ANY"), methods = list(
   setInternalSecureConnectionsDisabled = function() { invoke(jconf, "setInternalSecureConnectionsDisabled"); .self },
 
   sslConf = function() { getOption(invoke(jconf, "sslConf")) },
-  setSslConf = function(value) {invoke(jconf, "setSslConf", value); .self }
+  setSslConf = function(value) { invoke(jconf, "setSslConf", value); .self },
+
+  verifySslCertificates = function() { invoke(jconf, "verifySslCertificates") },
+  setVerifySslCertificates = function(value) {invoke(jconf, "setVerifySslCertificates", value); .self },
+
+  jks = function() { getOption(invoke(jconf, "jks")) },
+  setJks = function(value) {invoke(jconf, "setJks", value); .self },
+
+  jksPass = function() { getOption(invoke(jconf, "jksPass")) },
+  setJksPass = function(value) {invoke(jconf, "setJksPass", value); .self }
 ))

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -61,10 +61,9 @@ H2OContext.getOrCreate <- function(sc = NULL, conf = NULL) {
   port <- invoke(jhc, "h2oLocalClientPort")
   if (!isClientConnected(jhc)) {
     if (contextPath == "") {
-      invisible(capture.output(h2o.init(strict_version_check = FALSE, ip = ip, port = port, startH2O = F, username = conf$userName(), password = conf$password())))
-    } else {
-      invisible(capture.output(h2o.init(strict_version_check = FALSE, ip = ip, port = port, context_path = contextPath, startH2O = F, username = conf$userName(), password = conf$password())))
+        contextPath <- NA_character_
     }
+    invisible(capture.output(h2o.init(strict_version_check = FALSE, ip = ip, port = port, context_path = contextPath, startH2O = F, username = conf$userName(), password = conf$password())))
     setClientConnected(jhc)
   }
   hc

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -59,11 +59,14 @@ H2OContext.getOrCreate <- function(sc = NULL, conf = NULL) {
   contextPath <- substring(contextPathWithSlash, 2, nchar(contextPathWithSlash))
   ip <- invoke(jhc, "h2oLocalClientIp")
   port <- invoke(jhc, "h2oLocalClientPort")
+  schema <- invoke(returnedConf, "getScheme")
+  insecure <- conf$verifySslCertificates() == FALSE
+  https <- schema == "https"
   if (!isClientConnected(jhc)) {
     if (contextPath == "") {
         contextPath <- NA_character_
     }
-    invisible(capture.output(h2o.init(strict_version_check = FALSE, ip = ip, port = port, context_path = contextPath, startH2O = F, username = conf$userName(), password = conf$password())))
+    h2o.init(strict_version_check = FALSE, https=https, insecure=insecure, ip = ip, port = port, context_path = contextPath, startH2O = F, username = conf$userName(), password = conf$password())
     setClientConnected(jhc)
   }
   hc


### PR DESCRIPTION
See https://0xdata.atlassian.net/browse/SW-1988 for more details