### PR TITLE
[SW-1962] Remove materialization of iterator in asSparkFrame conversion

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendH2ODataFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendH2ODataFrame.scala
@@ -61,13 +61,11 @@ private[backend] class ExternalBackendH2ODataFrame(val frame: H2OFrame, val requ
   }
 
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
-    // When user ask to read whatever number of rows, buffer them all, because we can't keep the connection
-    // to h2o opened indefinitely(spark works in a lazy way)
     new H2ODataFrameIterator {
       private val chnk = frame.chunks.find(_.index == split.index).head
       override val reader: Reader = new ExternalBackendReader(frameKeyName, split.index, chnk.numberOfRows,
         chnk.location, expectedTypes.get, selectedColumnIndices, h2oConf)
-    }.toList.toIterator
+    }
   }
 
   protected override def indexToSupportedType(index: Int): SupportedType = {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendH2ORDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendH2ORDD.scala
@@ -51,13 +51,11 @@ private[backend] class ExternalBackendH2ORDD[A <: Product : TypeTag : ClassTag] 
           (@transient hc: H2OContext) = this(frame, ProductType.create[A])(hc)
 
   override def compute(split: Partition, context: TaskContext): Iterator[A] = {
-    // When user ask to read whatever number of rows, buffer them all, because we can't keep the connection
-    // to h2o opened indefinitely(spark works in a lazy way)
     new H2ORDDIterator {
       private val chnk = frame.chunks.find(_.index == split.index).head
       override val reader: Reader = new ExternalBackendReader(frameKeyName, split.index, chnk.numberOfRows,
         chnk.location, expectedTypes.get, selectedColumnIndices, h2oConf)
-    }.toList.toIterator
+    }
   }
 
   protected override val colNames: Array[String] = {


### PR DESCRIPTION
There is speedup after removing

OLD:

H2OFrameToDataFrameConversionBenchmark results for the dataset 'random01Int4':
time: 30014 milliseconds

H2OFrameToDataFrameConversionBenchmark results for the dataset 'random01Int40':
time: 53403 milliseconds

H2OFrameToDataFrameConversionBenchmark results for the dataset 'random01Int400':
time: 308676 milliseconds

NEW:

H2OFrameToDataFrameConversionBenchmark results for the dataset 'random01Int4':
time: 15342 milliseconds

H2OFrameToDataFrameConversionBenchmark results for the dataset 'random01Int40':
time: 32885 milliseconds

H2OFrameToDataFrameConversionBenchmark results for the dataset 'random01Int400':
time: 273107 milliseconds


