### PR TITLE
[SW-1872][FOLLOWUP] Remove deprecated nEstimators getter and setter H2OXGBoost Python API

### DIFF
--- a/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
@@ -263,10 +263,6 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
     def getQuietMode(self):
         return self.getOrDefault(self.quietMode)
 
-    def getNEstimators(self):
-        Utils.methodDeprecationWarning("getNEstimators")
-        return 0
-
     def getMaxDepth(self):
         return self.getOrDefault(self.maxDepth)
 
@@ -386,10 +382,6 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
 
     def setNtrees(self, value):
         return self._set(ntrees=value)
-
-    def setNEstimators(self, value):
-        Utils.methodDeprecationWarning("setNEstimators")
-        return self
 
     def setMaxDepth(self, value):
         return self._set(maxDepth=value)


### PR DESCRIPTION
I would like to follow on the comment https://github.com/h2oai/sparkling-water/pull/1878#pullrequestreview-364090922 and complete the removal.