### PR TITLE
[SW-2000] Fix distribution artifact name

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -186,7 +186,7 @@ copyFilesForZipDistribution.dependsOn(distTaskDependencies)
 
 task zipDistribution(type: Zip, dependsOn: copyFilesForZipDistribution) {
     from "$buildDir/zip"
-    archiveFileName = "sparkling-water-${archiveVersion}.zip"
+    archiveFileName = "sparkling-water-${archiveVersion.get()}.zip"
     destinationDirectory = file("$buildDir/dist")
 }
 


### PR DESCRIPTION
Also verified that the rest of artifacts are named correctly