### PR TITLE
[SW-2004] Two notebooks in Databricks can't both connect to same H2O cluster

### DIFF
--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -56,6 +56,7 @@ def _get_first(rdd):
 
 class H2OContext(object):
 
+    isConnected = False
     def __init__(self):
         """
          This constructor is used just to initialize the environment. It does not start H2OContext.
@@ -123,8 +124,9 @@ class H2OContext(object):
         h2o_context._client_port = jhc.h2oLocalClientPort()
 
         # Create H2O REST API client
-        if not h2o_context.__isClientConnected():
+        if not h2o_context.__isClientConnected() and not H2OContext.isConnected:
             h2o_context.__h2o_connect()
+            H2OContext.isConnected = True
 
         h2o_context.__setClientConnected()
 

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -124,13 +124,11 @@ class H2OContext(object):
         h2o_context._client_port = jhc.h2oLocalClientPort()
 
         # Create H2O REST API client
-        if not h2o_context.__isClientConnected() and not H2OContext.isConnected:
+        if not h2o_context.__isClientConnected() or not H2OContext.isConnected:
             h2o_context.__h2o_connect()
             H2OContext.isConnected = True
-
-        h2o_context.__setClientConnected()
-
-        print(h2o_context)
+            print(h2o_context)
+            h2o_context.__setClientConnected()
 
         return h2o_context
 

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+.rsparklingenv <- new.env(parent = emptyenv())
+.rsparklingenv$isConnected <- FALSE
 
 getClientConnectedField <- function(jhc) {
   child <- sparklyr::invoke(jhc, "getClass")
@@ -62,12 +64,13 @@ H2OContext.getOrCreate <- function(sc = NULL, conf = NULL) {
   schema <- invoke(returnedConf, "getScheme")
   insecure <- conf$verifySslCertificates() == FALSE
   https <- schema == "https"
-  if (!isClientConnected(jhc)) {
+  if (!isClientConnected(jhc) && !.rsparklingenv$isConnected) {
     if (contextPath == "") {
         contextPath <- NA_character_
     }
     h2o.init(strict_version_check = FALSE, https=https, insecure=insecure, ip = ip, port = port, context_path = contextPath, startH2O = F, username = conf$userName(), password = conf$password())
     setClientConnected(jhc)
+    .rsparklingenv$isConnected <- TRUE
   }
   hc
 }

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -64,7 +64,7 @@ H2OContext.getOrCreate <- function(sc = NULL, conf = NULL) {
   schema <- invoke(returnedConf, "getScheme")
   insecure <- conf$verifySslCertificates() == FALSE
   https <- schema == "https"
-  if (!isClientConnected(jhc) && !.rsparklingenv$isConnected) {
+  if (!isClientConnected(jhc) || !.rsparklingenv$isConnected) {
     if (contextPath == "") {
         contextPath <- NA_character_
     }


### PR DESCRIPTION
We have introduced the ``_isClientConnected()`` in order to ensure that when the backend restarts, the same H2OContext in python will recognize the change and call internally h2o.connect again. Previously, it would not call h2o.connect again as `_is_initialized` was already to True.

However we also removed the _is_initialized flag which was a bug. We need to keep that flag enabled as well because, for example, user can call the H2OContext.getOrCreate in different python notebook, but the java backend already tells us that the client is connected so we won't call h2o.connect, but we do need to run connect in this case