### PR TITLE
[SW-2007] Call print(hc) during first creation of H2OContext.r as in H2OContex.py

### DIFF
--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -72,6 +72,7 @@ H2OContext.getOrCreate <- function(sc = NULL, conf = NULL) {
     h2o.init(strict_version_check = FALSE, https=https, insecure=insecure, ip = ip, port = port, context_path = contextPath, startH2O = F, username = conf$userName(), password = conf$password())
     setClientConnected(jhc)
     .rsparklingenv$isConnected <- TRUE
+    print(hc)
   }
   hc
 }


### PR DESCRIPTION
Users should see:

```
Sparkling Water Context:
 * Sparkling Water Version: 3.30.0.1-1-2.4
 * H2O name: kuba
 * cluster size: 1
 * list of used nodes:
  (executorId, host, port)
  ------------------------
  (0,192.168.43.22,54321)
  ------------------------

  Open H2O Flow in browser: http://localhost:54322 (CMD + click in Mac OSX)
```
when they call hc <- H2OContext.getOrCreate. This is done in all other clients