### PR TITLE
[SW-2009] No need to search for client ip in rest api mode

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendUtils.scala
@@ -119,16 +119,9 @@ private[backend] trait ExternalBackendUtils extends SharedBackendUtils {
   }
 
   private def setClientIp(conf: H2OConf): Unit = {
-    if (conf.isAutoClusterStartUsed) {
-      val clientIp = ExternalH2OBackend.identifyClientIp(conf.h2oCluster.get.split(":")(0))
-      if (clientIp.isDefined && conf.clientIp.isEmpty && conf.clientNetworkMask.isEmpty) {
-        conf.setClientIp(clientIp.get)
-      }
-    } else {
-      val clientIp = ExternalH2OBackend.identifyClientIp(conf.h2oClusterHost.get)
-      if (clientIp.isDefined && conf.clientIp.isEmpty && conf.clientNetworkMask.isEmpty) {
-        conf.setClientIp(clientIp.get)
-      }
+    val clientIp = ExternalH2OBackend.identifyClientIp(conf.h2oClusterHost.get)
+    if (clientIp.isDefined && conf.clientIp.isEmpty && conf.clientNetworkMask.isEmpty) {
+      conf.setClientIp(clientIp.get)
     }
 
     if (conf.clientIp.isEmpty) {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendUtils.scala
@@ -102,7 +102,7 @@ private[backend] trait ExternalBackendUtils extends SharedBackendUtils {
     proc
   }
 
-  protected[backend] def identifyClientIp(remoteAddress: String): Option[String] = {
+  private def identifyClientIp(remoteAddress: String): Option[String] = {
     val interfaces = NetworkInterface.getNetworkInterfaces
     while (interfaces.hasMoreElements) {
       val interface = interfaces.nextElement()
@@ -119,7 +119,7 @@ private[backend] trait ExternalBackendUtils extends SharedBackendUtils {
   }
 
   private def setClientIp(conf: H2OConf): Unit = {
-    val clientIp = ExternalH2OBackend.identifyClientIp(conf.h2oClusterHost.get)
+    val clientIp = identifyClientIp(conf.h2oClusterHost.get)
     if (clientIp.isDefined && conf.clientIp.isEmpty && conf.clientNetworkMask.isEmpty) {
       conf.setClientIp(clientIp.get)
     }

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
@@ -45,25 +45,12 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Loggi
       logInfo("Starting the external H2O cluster on YARN.")
       val ipPort = launchExternalH2OOnYarn(conf)
       conf.setH2OCluster(ipPort)
-      val clientIp = ExternalH2OBackend.identifyClientIp(ipPort.split(":")(0))
-      if (clientIp.isDefined && conf.clientIp.isEmpty && conf.clientNetworkMask.isEmpty) {
-        conf.setClientIp(clientIp.get)
-      }
-    } else {
-      val clientIp = ExternalH2OBackend.identifyClientIp(conf.h2oClusterHost.get)
-      if (clientIp.isDefined && conf.clientIp.isEmpty && conf.clientNetworkMask.isEmpty) {
-        conf.setClientIp(clientIp.get)
-      }
-    }
-
-    if (conf.clientIp.isEmpty) {
-      conf.setClientIp(ExternalH2OBackend.getHostname(SparkEnv.get))
     }
 
     logInfo("Connecting to external H2O cluster.")
     val nodes = getAndVerifyWorkerNodes(conf)
     if (!RestApiUtils.isRestAPIBased(hc)) {
-      ExternalH2OBackend.startH2OClient(hc, nodes)
+      ExternalH2OBackend.startH2OClient(hc, conf, nodes)
     }
     nodes
   }


### PR DESCRIPTION
The client ip configuration has now only effect when we run in the original client approach. 

This change is reflecting that. We do not need to do the search for client ip in rest API mode as we don't use client anyway.

Also this way we keep the code related to client connection close and separated from rest of the code