### PR TITLE
[SW-1995] Enabling Compression for REST API Conversions

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendConf.scala
@@ -18,7 +18,9 @@
 package ai.h2o.sparkling.backend.external
 
 import ai.h2o.sparkling.backend.shared.SharedBackendConf
+import ai.h2o.sparkling.utils.Compression
 import org.apache.spark.h2o.H2OConf
+
 import collection.JavaConverters._
 
 /**
@@ -78,6 +80,8 @@ trait ExternalBackendConf extends SharedBackendConf {
   def externalHadoopExecutable: String = sparkConf.get(PROP_EXTERNAL_HADOOP_EXECUTABLE._1, PROP_EXTERNAL_HADOOP_EXECUTABLE._2)
 
   def externalExtraJars: Option[String] = sparkConf.getOption(PROP_EXTERNAL_EXTRA_JARS._1)
+
+  def externalCommunicationCompression: String = sparkConf.get(PROP_EXTERNAL_COMMUNICATION_COMPRESSION._1, PROP_EXTERNAL_COMMUNICATION_COMPRESSION._2)
 
   private[backend] def isBackendVersionCheckDisabled = sparkConf.getBoolean(PROP_EXTERNAL_DISABLE_VERSION_CHECK._1, PROP_EXTERNAL_DISABLE_VERSION_CHECK._2)
 
@@ -155,6 +159,10 @@ trait ExternalBackendConf extends SharedBackendConf {
   def setExternalExtraJars(paths: java.util.ArrayList[String]): H2OConf = setExternalExtraJars(paths.asScala)
 
   def setExternalExtraJars(paths: Seq[String]): H2OConf = setExternalExtraJars(paths.mkString(","))
+
+  def setExternalCommunicationCompression(compressionType: String): H2OConf = {
+    set(PROP_EXTERNAL_COMMUNICATION_COMPRESSION._1, compressionType)
+  }
 
   def externalConfString: String =
     s"""Sparkling Water configuration:
@@ -246,4 +254,9 @@ object ExternalBackendConf {
 
   /** Comma-separated paths to jar files that will be placed onto classpath of each H2O node. */
   val PROP_EXTERNAL_EXTRA_JARS: (String, None.type) = ("spark.ext.h2o.external.extra.jars", None)
+
+  /** The type of compression used for data transfer between Spark and H2O nodes */
+  val PROP_EXTERNAL_COMMUNICATION_COMPRESSION: (String, String) = {
+    ("spark.ext.h2o.external.communication.compression", Compression.defaultCompression)
+  }
 }

--- a/core/src/main/scala/ai/h2o/sparkling/frame/H2OChunk.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/frame/H2OChunk.scala
@@ -21,7 +21,7 @@ import java.io.{InputStream, OutputStream}
 
 import ai.h2o.sparkling.backend.external.{RestApiUtils, RestCommunication}
 import ai.h2o.sparkling.extensions.rest.api.Paths
-import ai.h2o.sparkling.utils.Base64Encoding
+import ai.h2o.sparkling.utils.{Base64Encoding, Compression, FinalizingOutputStream}
 import org.apache.spark.h2o.H2OConf
 import org.apache.spark.h2o.utils.NodeDesc
 
@@ -45,10 +45,12 @@ object H2OChunk extends RestCommunication {
       "num_rows" -> numRows,
       "chunk_id" -> chunkId,
       "expected_types" -> expectedTypesString,
-      "selected_columns" -> selectedColumnsIndicesString)
+      "selected_columns" -> selectedColumnsIndicesString,
+      "compression" -> conf.externalCommunicationCompression)
 
     val endpoint = RestApiUtils.resolveNodeEndpoint(node, conf)
-    readURLContent(endpoint, "GET", Paths.CHUNK, conf, parameters)
+    val inputStream = readURLContent(endpoint, "GET", Paths.CHUNK, conf, parameters)
+    Compression.decompress(conf.externalCommunicationCompression, inputStream)
   }
 
   def putChunk(
@@ -67,9 +69,13 @@ object H2OChunk extends RestCommunication {
       "num_rows" -> numRows,
       "chunk_id" -> chunkId,
       "expected_types" -> expectedTypesString,
-      "maximum_vector_sizes" -> maxVecSizesString)
+      "maximum_vector_sizes" -> maxVecSizesString,
+      "compression" -> conf.externalCommunicationCompression)
 
     val endpoint = RestApiUtils.resolveNodeEndpoint(node, conf)
-    insert(endpoint, Paths.CHUNK, conf, parameters)
+    val connection = insertWithoutCheckingResult(endpoint, Paths.CHUNK, conf, parameters)
+    val outputStream = connection.getOutputStream()
+    val compressedStream = Compression.compress(conf.externalCommunicationCompression, outputStream)
+    new FinalizingOutputStream(compressedStream, () => checkResponseCode(connection))
   }
 }

--- a/core/src/test/scala/org/apache/spark/h2o/ConfigurationPropertiesTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/ConfigurationPropertiesTestSuite.scala
@@ -22,11 +22,12 @@ import java.nio.file.{Files, Path}
 import java.security.Permission
 
 import org.apache.spark.SparkContext
-import org.apache.spark.h2o.utils.SparkTestContext
+import org.apache.spark.h2o.utils.{SparkTestContext, TestFrameUtils}
 import org.apache.spark.sql.SparkSession
 import org.junit.runner.RunWith
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.junit.JUnitRunner
+import water.api.TestUtils
 
 import collection.JavaConverters._
 
@@ -180,3 +181,39 @@ class ConfigurationPropertiesTestSuite_SetNotifyLocalViaNodeExtraProperties exte
     testNotifyLocalPropertyCreatesFile("local-cluster[1,1,1024]", setExtraNodeProperties)
   }
 }
+
+abstract class ConfigurationPropertiesTestSuite_ExternalCommunicationCompression(compressionType: String)
+  extends ConfigurationPropertiesTestSuite {
+
+  test(s"Convert dataset from Spark to H2O and back with $compressionType") {
+    val spark = createSparkSession("local[*]")
+    val h2oConf = new H2OConf()
+    h2oConf.setExternalCommunicationCompression(compressionType)
+    hc = H2OContext.getOrCreate(h2oConf)
+    val dataset = spark.read
+      .option("header", "true")
+      .option("inferSchema", "true")
+      .csv(TestUtils.locate("smalldata/prostate/prostate.csv"))
+
+    val frame = hc.asH2OFrame(dataset)
+    val result = hc.asDataFrame(frame)
+
+    TestFrameUtils.assertDataFramesAreIdentical(dataset, result)
+  }
+}
+
+@RunWith(classOf[JUnitRunner])
+class ConfigurationPropertiesTestSuite_ExternalCommunicationCompression_NONE
+  extends ConfigurationPropertiesTestSuite_ExternalCommunicationCompression("NONE")
+
+@RunWith(classOf[JUnitRunner])
+class ConfigurationPropertiesTestSuite_ExternalCommunicationCompression_SNAPPY
+  extends ConfigurationPropertiesTestSuite_ExternalCommunicationCompression("SNAPPY")
+
+@RunWith(classOf[JUnitRunner])
+class ConfigurationPropertiesTestSuite_ExternalCommunicationCompression_DEFLATE
+  extends ConfigurationPropertiesTestSuite_ExternalCommunicationCompression("DEFLATE")
+
+@RunWith(classOf[JUnitRunner])
+class ConfigurationPropertiesTestSuite_ExternalCommunicationCompression_GZIP
+  extends ConfigurationPropertiesTestSuite_ExternalCommunicationCompression("GZIP")

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -372,6 +372,11 @@ External backend configuration properties
 |                                                       |                |                                                 | will be placed onto classpath of    |
 |                                                       |                | ``setExternalExtraJars(String[])``              | each H2O node.                      |
 +-------------------------------------------------------+----------------+-------------------------------------------------+-------------------------------------+
+| ``spark.ext.h2o.external.communication.compression``  | ``SNAPPY``     | ``setExternalCommunicationCompression(String)`` | The type of compression used for    |
+|                                                       |                |                                                 | data transfer between Spark and H2O |
+|                                                       |                |                                                 | node. Possible values are ``NONE``, |
+|                                                       |                |                                                 | ``DEFLATE``, ``GZIP``, ``SNAPPY``.  |
++-------------------------------------------------------+----------------+-------------------------------------------------+-------------------------------------+
 
 .. _getter:
 

--- a/extensions/src/main/scala/ai/h2o/sparkling/extensions/rest/api/ChunkServlet.scala
+++ b/extensions/src/main/scala/ai/h2o/sparkling/extensions/rest/api/ChunkServlet.scala
@@ -35,7 +35,8 @@ final class ChunkServlet extends HttpServlet {
       numRows: Int,
       chunkId: Int,
       expectedTypes: Array[Byte],
-      selectedColumnIndices: Array[Int]) {
+      selectedColumnIndices: Array[Int],
+      compression: String) {
 
     def validate(): Unit = {
       val frame = DKV.getGet[Frame](this.frameName)

--- a/py/src/ai/h2o/sparkling/ExternalBackendConf.py
+++ b/py/src/ai/h2o/sparkling/ExternalBackendConf.py
@@ -96,6 +96,9 @@ class ExternalBackendConf(SharedBackendConfUtils):
     def externalExtraJars(self):
         return self._get_option(self._jconf.externalExtraJars())
 
+    def externalCommunicationCompression(self):
+        return self._jconf.externalCommunicationCompression()
+
     #
     # Setters
     #
@@ -186,4 +189,8 @@ class ExternalBackendConf(SharedBackendConfUtils):
 
     def setExternalExtraJars(self, paths):
         self._jconf.setExternalExtraJars(paths)
+        return self
+
+    def setExternalCommunicationCompression(self, compression):
+        self._jconf.setExternalCommunicationCompression(self, compression)
         return self

--- a/r/src/R/ai/h2o/sparkling/H2OConf.R
+++ b/r/src/R/ai/h2o/sparkling/H2OConf.R
@@ -68,5 +68,8 @@ H2OConf <- setRefClass("H2OConf", fields = list(jconf = "ANY"), methods = list(
   runsInExternalClusterMode = function() {invoke(jconf, "runsInExternalClusterMode") },
   runsInInternalClusterMode = function() {invoke(jconf, "runsInInternalClusterMode") },
   setInternalClusterMode = function() {invoke(jconf, "setInternalClusterMode"); .self },
-  setExternalClusterMode = function() {invoke(jconf, "setExternalClusterMode"); .self }
+  setExternalClusterMode = function() {invoke(jconf, "setExternalClusterMode"); .self },
+
+  externalCommunicationCompression = function() { invoke(jconf, "externalCommunicationCompression") },
+  setExternalCommunicationCompression = function() {invoke(jconf, "setExternalCommunicationCompression"); .self }
 ))

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly("org.apache.spark:spark-core_${scalaBaseVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}")
     compileOnly("org.scala-lang:scala-compiler:${scalaVersion}")
-    resource("org.xerial.snappy:snappy-java:1.1.7")
+    implementation("org.xerial.snappy:snappy-java:1.1.7")
 }
 
 defineStandardPublication().call()

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compileOnly("org.apache.spark:spark-core_${scalaBaseVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-mllib_${scalaBaseVersion}:${sparkVersion}")
     compileOnly("org.scala-lang:scala-compiler:${scalaVersion}")
+    resource("org.xerial.snappy:snappy-java:1.1.7")
 }
 
 defineStandardPublication().call()

--- a/utils/src/main/scala/ai/h2o/sparkling/utils/Compression.scala
+++ b/utils/src/main/scala/ai/h2o/sparkling/utils/Compression.scala
@@ -18,7 +18,7 @@
 package ai.h2o.sparkling.utils
 
 import java.io.{InputStream, OutputStream}
-import java.util.zip.{DeflaterInputStream, DeflaterOutputStream, GZIPInputStream, GZIPOutputStream}
+import java.util.zip.{DeflaterOutputStream, GZIPInputStream, GZIPOutputStream, InflaterInputStream}
 
 import org.xerial.snappy.{SnappyInputStream, SnappyOutputStream}
 
@@ -39,7 +39,7 @@ object Compression {
   def decompress(compressionType: String, inputStream: InputStream): InputStream = {
     validateCompressionType(compressionType) match {
       case "NONE" => inputStream
-      case "DEFLATE" => new DeflaterInputStream(inputStream)
+      case "DEFLATE" => new InflaterInputStream(inputStream)
       case "GZIP" => new GZIPInputStream(inputStream)
       case "SNAPPY" => new SnappyInputStream(inputStream)
     }

--- a/utils/src/main/scala/ai/h2o/sparkling/utils/Compression.scala
+++ b/utils/src/main/scala/ai/h2o/sparkling/utils/Compression.scala
@@ -1,0 +1,55 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package ai.h2o.sparkling.utils
+
+import java.io.{InputStream, OutputStream}
+import java.util.zip.{DeflaterInputStream, DeflaterOutputStream, GZIPInputStream, GZIPOutputStream}
+
+import org.xerial.snappy.{SnappyInputStream, SnappyOutputStream}
+
+object Compression {
+  val supportedCompressionTypes: Seq[String] = Seq("NONE", "DEFLATE", "GZIP", "SNAPPY")
+
+  val defaultCompression: String = "SNAPPY"
+
+  def compress(compressionType: String, outputStream: OutputStream): OutputStream = {
+    validateCompressionType(compressionType) match {
+      case "NONE" => outputStream
+      case "DEFLATE" => new DeflaterOutputStream(outputStream)
+      case "GZIP" => new GZIPOutputStream(outputStream)
+      case "SNAPPY" => new SnappyOutputStream(outputStream)
+    }
+  }
+
+  def decompress(compressionType: String, inputStream: InputStream): InputStream = {
+    validateCompressionType(compressionType) match {
+      case "NONE" => inputStream
+      case "DEFLATE" => new DeflaterInputStream(inputStream)
+      case "GZIP" => new GZIPInputStream(inputStream)
+      case "SNAPPY" => new SnappyInputStream(inputStream)
+    }
+  }
+
+  def validateCompressionType(compressionType: String): String = {
+    val upperCompressionType = compressionType.toUpperCase
+    if (!supportedCompressionTypes.contains(upperCompressionType)) {
+      throw new IllegalArgumentException("s'$compressionType' is not supported compression type.")
+    }
+    upperCompressionType
+  }
+}


### PR DESCRIPTION
**Benchmark results on EMR** 

Compression `NONE`:
```
DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int4':
time: 8964 milliseconds

DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int40':
time: 49782 milliseconds

DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int400':
time: 428360 milliseconds
```

Compression `SNAPPY`:
```
DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int4':
time: 8915 milliseconds

DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int40':
time: 48033 milliseconds

DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int400':
time: 413359 milliseconds
```

Compression `DEFLATE`:
```
DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int4':
time: 9702 milliseconds

DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int40':
time: 49522 milliseconds

DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int400':
time: 448095 milliseconds
```

Compression `GZIP`:
```
DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int4':
time: 9386 milliseconds

DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int40':
time: 50886 milliseconds

DataFrameToH2OFrameConversionBenchmark results for the dataset 'random01Int400':
time: 442188 milliseconds
```