### PR TITLE
[SW-2022] Start H2OContext on python side if the user didn't explicitly ask for it

### DIFF
--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -18,8 +18,8 @@ From 3.30 to 3.32
   been removed. Also, ``H2OContext`` can be created as ``H2OContext.getOrCreate()`` or ``H2OContext.getOrCreate(conf)``.
   The other variants of this method have been removed.
 
-- It is now required to explicitly create ``H2OContext`` before you run any of our exposed algorithm. Previously,
-  the algorithms would create the H2OContext on demand.
+- It is now required to explicitly create ``H2OContext`` before you run any of our exposed algorithms. Previously,
+  the algorithm would create the H2OContext on demand.
 
 From 3.28.1 to 3.30
 -------------------

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -18,7 +18,7 @@ From 3.30 to 3.32
   been removed. Also, ``H2OContext`` can be created as ``H2OContext.getOrCreate()`` or ``H2OContext.getOrCreate(conf)``.
   The other variants of this method have been removed.
 
-- It is now required to explicitly created ``H2OContext`` before you run any of our exposed algorithm. Previously,
+- It is now required to explicitly create ``H2OContext`` before you run any of our exposed algorithm. Previously,
   the algorithm would create the H2OContext on demand.
 
 From 3.28.1 to 3.30

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -18,6 +18,9 @@ From 3.30 to 3.32
   been removed. Also, ``H2OContext`` can be created as ``H2OContext.getOrCreate()`` or ``H2OContext.getOrCreate(conf)``.
   The other variants of this method have been removed.
 
+- It is now required to explicitly created ``H2OContext`` before you run any of our exposed algorithm. Previously,
+  the algorithm would create the H2OContext on demand.
+
 From 3.28.1 to 3.30
 -------------------
 

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -19,7 +19,7 @@ From 3.30 to 3.32
   The other variants of this method have been removed.
 
 - It is now required to explicitly create ``H2OContext`` before you run any of our exposed algorithm. Previously,
-  the algorithm would create the H2OContext on demand.
+  the algorithms would create the H2OContext on demand.
 
 From 3.28.1 to 3.30
 -------------------

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
@@ -45,7 +45,7 @@ trait H2OAlgoCommonUtils extends H2OCommonParams {
     }
 
     val cols = (getFeaturesCols() ++ excludedCols).map(col)
-    val h2oContext = H2OContext.getOrCreate()
+    val h2oContext = H2OContext.ensure("H2OContext needs to be created in order to train the model. Please create one as H2OContext.getOrCreate().")
     val h2oFrameKey = h2oContext.asH2OFrameKeyString(dataset.select(cols: _*).toDF())
 
     // Our MOJO wrapper needs the full column name before the array/vector expansion in order to do predictions

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OKMeans.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OKMeans.scala
@@ -137,7 +137,7 @@ trait H2OKMeansParams extends H2OAlgoUnsupervisedParams[KMeansParameters] {
         val spark = SparkSessionUtils.active
         import spark.implicits._
         val df = spark.sparkContext.parallelize(userPoints).toDF()
-        H2OContext.getOrCreate().asH2OFrame(df).key
+        H2OContext.ensure("H2OContext needs to be created in order to train the H2OKMeans model. Please create one as H2OContext.getOrCreate().").asH2OFrame(df).key
       }
     }
     parameters._estimate_k = getEstimateK()

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/features/H2OTargetEncoder.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/features/H2OTargetEncoder.scala
@@ -35,7 +35,7 @@ class H2OTargetEncoder(override val uid: String)
   def this() = this(Identifiable.randomUID("H2OTargetEncoder"))
 
   override def fit(dataset: Dataset[_]): H2OTargetEncoderModel = {
-    val h2oContext = H2OContext.getOrCreate()
+    val h2oContext = H2OContext.ensure("H2OContext needs to be created in order to use target encoding. Please create one as H2OContext.getOrCreate().")
     val input = h2oContext.asH2OFrame(dataset.toDF())
     convertRelevantColumnsToCategorical(input)
     val columnsToKeep = getInputCols() ++ Seq(getFoldCol(), getLabelCol()).map(Option(_)).flatten

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala
@@ -51,7 +51,7 @@ class H2OTargetEncoderModel(
   private def inputColumnNameToInternalOutputName(inputColumnName: String): String = inputColumnName + "_te"
 
   def transformTrainingDataset(dataset: Dataset[_]): DataFrame = {
-    val h2oContext = H2OContext.getOrCreate()
+    val h2oContext = H2OContext.ensure("H2OContext needs to be created in order to use target encoding. Please create one as H2OContext.getOrCreate().")
     val temporaryColumn = getClass.getSimpleName + "_temporary_id"
     val withIdDF = dataset.withColumn(temporaryColumn, monotonically_increasing_id)
     val flatDF = SchemaUtils.flattenDataFrame(withIdDF)


### PR DESCRIPTION
The motivation for this started when I was testing the algo api, I was running code:

```
from pyspark.sql.functions import log, col, min, max, mean, lit
dataset = spark.read.csv("file:///Users/kuba/devel/repos/sparkling-water/examples/smalldata/insurance.csv", header=True, inferSchema=True).withColumn("Offset", log(col("Holders")))

from pysparkling.ml import H2OGBM
gbm = H2OGBM(ntrees=2, seed=42, distribution="bernoulli", labelCol="capsule")
model = gbm.fit(dataset)
```

You can see that I do not call `H2OContext.getOrCreate()`. H2OContext is in this case created automatically inside the `fit` method on Scala. 

In Python & R implementation of H2OContext, we are now setting option `spark.ext.h2o.rest.api.based.client=true` (https://github.com/h2oai/sparkling-water/blob/14cfdcdb7712d9386444e79e81906e20961cac0d/py/src/ai/h2o/sparkling/H2OContext.py#L93), but not on the Scala backend. Due to this laziness ``H2OContext.getOrCreate`` hasn't been called in python & we do not set this option. 
I have ensured that we call, lazily when required, ``H2OContext.getOrCreate`` automatically on python side. Can be done by overriding the fit method on our algo wrappers.