### PR TITLE
[SW-2023] Avoid repeated log messages

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -598,6 +598,9 @@ object H2OContext extends Logging {
       val existingContext = instantiatedContext.get()
       if (existingContext != null) {
         val startedManually = existingContext.conf.isManualClusterStartUsed
+        if (conf.h2oCluster.isEmpty) {
+          throw new IllegalArgumentException("H2O Cluster endpoint has to be specified!")
+        }
         if (startedManually && connectingToNewCluster(existingContext, conf)) {
           val checkedConf = checkAndUpdateConf(conf)
           instantiatedContext.set(new H2OContextRestAPIBased(checkedConf).init())

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -591,7 +591,6 @@ object H2OContext extends Logging {
    * @return H2O Context
    */
   def getOrCreate(conf: H2OConf): H2OContext = synchronized {
-    val checkedConf = checkAndUpdateConf(conf)
     val isRestApiBasedClient = conf.getBoolean(SharedBackendConf.PROP_REST_API_BASED_CLIENT._1,
       SharedBackendConf.PROP_REST_API_BASED_CLIENT._2)
     val isExternalBackend = conf.runsInExternalClusterMode
@@ -599,16 +598,19 @@ object H2OContext extends Logging {
       val existingContext = instantiatedContext.get()
       if (existingContext != null) {
         val startedManually = existingContext.conf.isManualClusterStartUsed
+        val checkedConf = checkAndUpdateConf(conf)
         if (startedManually && connectingToNewCluster(existingContext, checkedConf)) {
           instantiatedContext.set(new H2OContextRestAPIBased(checkedConf).init())
           logWarning(s"Connecting to a new external H2O cluster : ${checkedConf.h2oCluster.get}")
         }
       } else {
+        val checkedConf = checkAndUpdateConf(conf)
         instantiatedContext.set(new H2OContextRestAPIBased(checkedConf).init())
       }
     } else {
       if (instantiatedContext.get() == null)
         if (H2O.API_PORT == 0) { // api port different than 0 means that client is already running
+          val checkedConf = checkAndUpdateConf(conf)
           instantiatedContext.set(new H2OContextClientBased(checkedConf).init())
         } else {
           throw new IllegalArgumentException(

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -598,8 +598,8 @@ object H2OContext extends Logging {
       val existingContext = instantiatedContext.get()
       if (existingContext != null) {
         val startedManually = existingContext.conf.isManualClusterStartUsed
-        val checkedConf = checkAndUpdateConf(conf)
-        if (startedManually && connectingToNewCluster(existingContext, checkedConf)) {
+        if (startedManually && connectingToNewCluster(existingContext, conf)) {
+          val checkedConf = checkAndUpdateConf(conf)
           instantiatedContext.set(new H2OContextRestAPIBased(checkedConf).init())
           logWarning(s"Connecting to a new external H2O cluster : ${checkedConf.h2oCluster.get}")
         }


### PR DESCRIPTION
Calling H2OContext.getOrCreate should provide all the warnings, such as:

```
20/02/28 16:11:55 WARN ExternalH2OBackend: To avoid non-deterministic behavior of Spark broadcast-based joins,
we recommend to set `spark.sql.autoBroadcastJoinThreshold` property of SparkSession to -1.
E.g. spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
We also recommend to avoid using broadcast hints in your Spark SQL code.
20/02/28 16:11:55 WARN ExternalH2OBackend: Increasing 'spark.locality.wait' to value 30000
20/02/28 16:11:55 WARN ExternalH2OBackend: To avoid non-deterministic behavior of Spark broadcast-based joins,
we recommend to set `spark.sql.autoBroadcastJoinThreshold` property of SparkSession to -1.
E.g. spark.conf.set("spark.sql.autoBroadcastJoinThreshold", -1)
We also recommend to avoid using broadcast hints in your Spark SQL code.
```

But additional calls of H2OContext.getOrCreate() should be already silent