### PR TITLE
[SW-2033] Deprecate exactLambdas param on H2OGLM

### DIFF
--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -67,6 +67,8 @@ Removal of Deprecated Methods and Classes
 
 - Method ``get_conf`` on PySparkling ``H2OContext`` is removed in favor of the ``getConf`` method.
 
+- On Python and Scala ``H2OGLM`` API, the methods ``setExactLambdas`` and ``getExactLambdas`` are removed without replacement.
+
 - On H2OConf Python API, the following methods have been renamed to be consistent with the Scala counterparts:
 
        - ``h2o_cluster`` -> ``h2oCluster``

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGLM.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGLM.scala
@@ -16,6 +16,7 @@
 */
 package ai.h2o.sparkling.ml.algos
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.ml.params.H2OAlgoParamsHelper._
 import ai.h2o.sparkling.ml.params.{DeprecatableParams, H2OAlgoSupervisedParams}
 import ai.h2o.sparkling.ml.utils.H2OParamsReadable
@@ -69,7 +70,6 @@ trait H2OGLMParams extends H2OAlgoSupervisedParams[GLMParameters] with Deprecata
   private val lambdaSearch = booleanParam("lambdaSearch")
   private val nlambdas = intParam("nlambdas")
   private val nonNegative = booleanParam("nonNegative")
-  private val exactLambdas = booleanParam("exactLambdas", "exact lambdas")
   private val lambdaMinRatio = doubleParam("lambdaMinRatio")
   private val maxIterations = intParam("maxIterations")
   private val intercept = booleanParam("intercept")
@@ -100,7 +100,6 @@ trait H2OGLMParams extends H2OAlgoSupervisedParams[GLMParameters] with Deprecata
     lambdaSearch -> false,
     nlambdas -> -1,
     nonNegative -> false,
-    exactLambdas -> false,
     lambdaMinRatio -> -1,
     maxIterations -> -1,
     intercept -> true,
@@ -144,7 +143,8 @@ trait H2OGLMParams extends H2OAlgoSupervisedParams[GLMParameters] with Deprecata
 
   def getNonNegative(): Boolean = $(nonNegative)
 
-  def getExactLambdas(): Boolean = $(exactLambdas)
+  @DeprecatedMethod
+  def getExactLambdas(): Boolean = false
 
   def getLambdaMinRatio(): Double = $(lambdaMinRatio)
 
@@ -212,7 +212,8 @@ trait H2OGLMParams extends H2OAlgoSupervisedParams[GLMParameters] with Deprecata
 
   def setNonNegative(value: Boolean): this.type = set(nonNegative, value)
 
-  def setExactLambdas(value: Boolean): this.type = set(exactLambdas, value)
+  @DeprecatedMethod
+  def setExactLambdas(value: Boolean): this.type = this
 
   def setLambdaMinRatio(value: Double): this.type = set(lambdaMinRatio, value)
 
@@ -254,7 +255,6 @@ trait H2OGLMParams extends H2OAlgoSupervisedParams[GLMParameters] with Deprecata
     parameters._lambda_search = $(lambdaSearch)
     parameters._nlambdas = $(nlambdas)
     parameters._non_negative = $(nonNegative)
-    parameters._exactLambdas = $(exactLambdas)
     parameters._lambda_min_ratio = $(lambdaMinRatio)
     parameters._max_iterations = $(maxIterations)
     parameters._intercept = $(intercept)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OGLM.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OGLM.py
@@ -40,7 +40,6 @@ class H2OGLM(H2OGLMParams, H2OSupervisedAlgoBase):
                  lambdaSearch=False,
                  nlambdas=-1,
                  nonNegative=False,
-                 exactLambdas=False,
                  lambdaMinRatio=-1.0,
                  maxIterations=-1,
                  intercept=True,
@@ -73,7 +72,8 @@ class H2OGLM(H2OGLMParams, H2OSupervisedAlgoBase):
                  featuresCols=[],
                  convertUnknownCategoricalLevelsToNa=False,
                  convertInvalidNumbersToNa=False,
-                 namedMojoOutputColumns=True):
+                 namedMojoOutputColumns=True,
+                 **DeprecatedParams):
         Initializer.load_sparkling_jar()
         super(H2OGLM, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2OGLM", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/params/H2OGLMParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OGLMParams.py
@@ -19,7 +19,7 @@ from ai.h2o.sparkling.ml.params.H2OAlgoSupervisedParams import H2OAlgoSupervised
 from ai.h2o.sparkling.ml.params.H2OTypeConverters import H2OTypeConverters
 from h2o.utils.typechecks import assert_is_type
 from pyspark.ml.param import *
-
+import warnings
 
 class H2OGLMParams(H2OAlgoSupervisedParams):
     ##
@@ -102,12 +102,6 @@ class H2OGLMParams(H2OAlgoSupervisedParams):
         Params._dummy(),
         "nonNegative",
         "nonNegative",
-        H2OTypeConverters.toBoolean())
-
-    exactLambdas = Param(
-        Params._dummy(),
-        "exactLambdas",
-        "exact lambdas",
         H2OTypeConverters.toBoolean())
 
     lambdaMinRatio = Param(
@@ -224,7 +218,8 @@ class H2OGLMParams(H2OAlgoSupervisedParams):
         return self.getOrDefault(self.nonNegative)
 
     def getExactLambdas(self):
-        return self.getOrDefault(self.exactLambdas)
+        warnings.warn("Method 'getExactLambdas' is deprecated and will be removed in the next major release.")
+        return False
 
     def getLambdaMinRatio(self):
         return self.getOrDefault(self.lambdaMinRatio)
@@ -305,7 +300,8 @@ class H2OGLMParams(H2OAlgoSupervisedParams):
         return self._set(nonNegative=value)
 
     def setExactLambdas(self, value):
-        return self._set(exactLambdas=value)
+        warnings.warn("Method 'setExactLambdas' is deprecated and will be removed in the next major release.")
+        return self
 
     def setLambdaMinRatio(self, value):
         return self._set(lambdaMinRatio=value)


### PR DESCRIPTION
This parameter does not have any effect in H2O + will be removed from H2O codebase in 3.30