### PR TITLE
[SW-2035] Rename the 'setClientPortBase' on H2OConf to 'setClientBasePort'

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/shared/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/shared/SharedBackendConf.scala
@@ -17,6 +17,7 @@
 
 package ai.h2o.sparkling.backend.shared
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import org.apache.spark.h2o.H2OConf
 
 import scala.collection.JavaConverters._
@@ -257,7 +258,10 @@ trait SharedBackendConf {
 
   def setH2OClientLogDir(dir: String): H2OConf = set(PROP_CLIENT_LOG_DIR._1, dir)
 
-  def setClientPortBase(basePort: Int): H2OConf = set(PROP_CLIENT_PORT_BASE._1, basePort.toString)
+  @DeprecatedMethod("setClientBasePort", "3.30")
+  def setClientPortBase(basePort: Int): H2OConf = setClientBasePort(basePort)
+
+  def setClientBasePort(basePort: Int): H2OConf = set(PROP_CLIENT_PORT_BASE._1, basePort.toString)
 
   def setClientWebPort(port: Int): H2OConf = set(PROP_CLIENT_WEB_PORT._1, port.toString)
 

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -183,7 +183,7 @@ Configuration properties independent of selected backend
 |                                                    |                |                                                 | machine.                               |
 |                                                    |                |                                                 |                                        |
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
-| ``spark.ext.h2o.client.port.base``                 | ``54321``      | ``setClientPortBase(Integer)``                  | Port on which H2O client publishes     |
+| ``spark.ext.h2o.client.port.base``                 | ``54321``      | ``setClientBasePort(Integer)``                  | Port on which H2O client publishes     |
 |                                                    |                |                                                 | its API. If already occupied, the next |
 |                                                    |                |                                                 | odd port is tried on so on.            |
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+

--- a/py/src/ai/h2o/sparkling/SharedBackendConf.py
+++ b/py/src/ai/h2o/sparkling/SharedBackendConf.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import warnings
 from ai.h2o.sparkling.SharedBackendConfUtils import SharedBackendConfUtils
 
 
@@ -382,7 +383,13 @@ class SharedBackendConf(SharedBackendConfUtils):
         return self
 
     def setClientPortBase(self, basePort):
-        self._jconf.setClientPortBase(basePort)
+        warnings.warn("The method 'setClientPortBase' has been deprecated and will be removed in 3.30."
+                      " Use the 'setClientBasePort' method instead.")
+        self.setClientBasePort(basePort)
+        return self
+
+    def setClientBasePort(self, basePort):
+        self._jconf.setClientBasePort(basePort)
         return self
 
     def setClientWebPort(self, port):


### PR DESCRIPTION
This PR tries to get the naming conventions of of the setter with `setNodeBasePort()` and `clientBasePort`