### PR TITLE
[SW-2036] Rename 'setClusterConfigFile' on H2OConf to 'setClusterInfoFile'

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendConf.scala
@@ -18,6 +18,7 @@
 package ai.h2o.sparkling.backend.external
 
 import ai.h2o.sparkling.backend.shared.SharedBackendConf
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.utils.Compression
 import org.apache.spark.h2o.H2OConf
 
@@ -109,7 +110,10 @@ trait ExternalBackendConf extends SharedBackendConf {
 
   def setClusterStartTimeout(clusterStartTimeout: Int): H2OConf = set(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, clusterStartTimeout.toString)
 
-  def setClusterConfigFile(path: String): H2OConf = set(PROP_EXTERNAL_CLUSTER_INFO_FILE._1, path)
+  @DeprecatedMethod("setClusterInfoFile", "3.30")
+  def setClusterConfigFile(path: String): H2OConf = setClusterInfoFile(path)
+
+  def setClusterInfoFile(path: String): H2OConf = set(PROP_EXTERNAL_CLUSTER_INFO_FILE._1, path)
 
   def setMapperXmx(mem: String): H2OConf = set(PROP_EXTERNAL_H2O_MEMORY._1, mem)
 

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -303,7 +303,7 @@ External backend configuration properties
 | ``spark.ext.h2o.cluster.start.timeout``               | ``120s``       | ``setClusterStartTimeout(Integer)``             | Timeout in seconds for starting     |
 |                                                       |                |                                                 | H2O external cluster.               |
 +-------------------------------------------------------+----------------+-------------------------------------------------+-------------------------------------+
-| ``spark.ext.h2o.cluster.info.name``                   | ``None``       | ``setClusterConfigFile(Integer)``               | Full path to a file which is used   |
+| ``spark.ext.h2o.cluster.info.name``                   | ``None``       | ``setClusterInfoFile(Integer)``                 | Full path to a file which is used   |
 |                                                       |                |                                                 | sd the notification file for the    |
 |                                                       |                |                                                 | startup of external H2O cluster.    |
 +-------------------------------------------------------+----------------+-------------------------------------------------+-------------------------------------+

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -24,9 +24,6 @@ From 3.28.1 to 3.30
 - It is now required to explicitly create ``H2OContext`` before you run any of our exposed algorithms. Previously,
   the algorithm would create the H2OContext on demand.
 
-- The method ``setClusterConfigFile`` was removed from ``H2OConf`` in Python and Scala API. The replacement method is
-  ``setClusterInfoFile`` on ``H2OConf``.
-
 Removal of Deprecated Methods and Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -226,6 +223,9 @@ Removal of Deprecated Methods and Classes
        - ``set_client_extra_properties`` -> ``setClientExtraProperties``
 
 - In ``H2OAutoML`` Python and Scala API, the member ``leaderboard()``/``leaderboard`` is replaced by the method ``getLeaderboard()``.
+
+- The method ``setClusterConfigFile`` was removed from ``H2OConf`` in Python and Scala API. The replacement method is
+  ``setClusterInfoFile`` on ``H2OConf``.
 
 From 3.28.0 to 3.28.1
 ---------------------

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -24,6 +24,9 @@ From 3.28.1 to 3.30
 - It is now required to explicitly create ``H2OContext`` before you run any of our exposed algorithms. Previously,
   the algorithm would create the H2OContext on demand.
 
+- The method ``setClusterConfigFile`` was removed from ``H2OConf`` in Python and Scala API. The replacement method is
+  ``setClusterInfoFile`` on ``H2OConf``.
+
 Removal of Deprecated Methods and Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/py/src/ai/h2o/sparkling/ExternalBackendConf.py
+++ b/py/src/ai/h2o/sparkling/ExternalBackendConf.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import warnings
 from ai.h2o.sparkling.SharedBackendConfUtils import SharedBackendConfUtils
 
 
@@ -116,7 +117,13 @@ class ExternalBackendConf(SharedBackendConfUtils):
         return self
 
     def setClusterConfigFile(self, path):
-        self._jconf.setClusterConfigFile(path)
+        warnings.warn("The method 'setClusterConfigFile' has been deprecated and will be removed in 3.30."
+                      " Use the 'setClusterInfoFile' method instead.")
+        self.setClusterInfoFile(path)
+        return self
+
+    def setClusterInfoFile(self, path):
+        self._jconf.setClusterInfoFile(path)
         return self
 
     def setMapperXmx(self, mem):


### PR DESCRIPTION
This PR tries to get naming conventions of the setter aligned with its getter `clusterInfoFile` and property `spark.ext.h2o.cluster.info.name`.