### PR TITLE
[SW-2040] Fix doc warning: Could not find any member to link for org.apache.spark.internal.Logging

### DIFF
--- a/utils/src/main/scala/org/apache/spark/expose/Logging.scala
+++ b/utils/src/main/scala/org/apache/spark/expose/Logging.scala
@@ -17,6 +17,6 @@
 package org.apache.spark.expose
 
 /**
-  * The trait is used just to make visible the logic of [[org.apache.spark.internal.Logging]].
+  * The trait is used to make visible the logic of org.apache.spark.internal.Logging.
   */
 trait Logging extends org.apache.spark.internal.Logging with Serializable


### PR DESCRIPTION
Just tiny cleanup to avoid warning in the build.

On newer Spark versions the `org.apache.spark.internal.Logging` does not exist, so treat it just as string