### PR TITLE
[SW-2043] Deprecate get_grid_models, get_grid_models_params and get_grid_models_metrics params on H2OGridSearch

### DIFF
--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -228,7 +228,7 @@ Removal of Deprecated Methods and Classes
   ``setClusterInfoFile`` on ``H2OConf``.
 
 - In ``H2OGridSearch`` Python API, the methods: ``get_grid_models``, ``get_grid_models_params`` and `` get_grid_models_metrics``
-  are removed and replaced by ``getGridModels``, ``getGridModelsParams`` and `` getGridModelsMetrics``
+  are removed and replaced by ``getGridModels``, ``getGridModelsParams`` and `` getGridModelsMetrics``.
 
 
 From 3.28.0 to 3.28.1

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -227,6 +227,10 @@ Removal of Deprecated Methods and Classes
 - The method ``setClusterConfigFile`` was removed from ``H2OConf`` in Python and Scala API. The replacement method is
   ``setClusterInfoFile`` on ``H2OConf``.
 
+- In ``H2OGridSearch`` Python API, the methods: ``get_grid_models``, ``get_grid_models_params`` and `` get_grid_models_metrics``
+  are removed and replaced by ``getGridModels``, ``getGridModelsParams`` and `` getGridModelsMetrics``
+
+
 From 3.28.0 to 3.28.1
 ---------------------
 

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OGridSearch.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OGridSearch.py
@@ -23,6 +23,7 @@ from ai.h2o.sparkling.ml.params import H2OGridSearchParams
 from pyspark import keyword_only
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql import SparkSession
+import warnings
 
 class H2OGridSearch(H2OGridSearchParams, H2OSupervisedAlgoBase):
 
@@ -63,14 +64,29 @@ class H2OGridSearch(H2OGridSearchParams, H2OSupervisedAlgoBase):
         self._set(**kwargs)
 
     def get_grid_models(self):
+        warnings.warn("The method 'get_grid_models' has been deprecated and will be removed in 3.30."
+                      " Use the 'getGridModels' method instead.")
+        return self.getGridModels()
+
+    def getGridModels(self):
         return [H2OMOJOModel(m) for m in self._java_obj.getGridModels()]
 
     def get_grid_models_params(self):
+        warnings.warn("The method 'get_grid_models_params' has been deprecated and will be removed in 3.30."
+                      " Use the 'getGridModelsParams' method instead.")
+        return self.getGridModelsParams()
+
+    def getGridModelsParams(self):
         jdf = self._java_obj.getGridModelsParams()
         sqlContext = SparkSession.builder.getOrCreate()._wrapped
         return DataFrame(jdf, sqlContext)
 
     def get_grid_models_metrics(self):
+        warnings.warn("The method 'get_grid_models_metrics' has been deprecated and will be removed in 3.30."
+                      " Use the 'getGridModelsMetrics' method instead.")
+        return self.getGridModelsMetrics()
+
+    def getGridModelsMetrics(self):
         jdf = self._java_obj.getGridModelsMetrics()
         sqlContext = SparkSession.builder.getOrCreate()._wrapped
         return DataFrame(jdf, sqlContext)


### PR DESCRIPTION
This should also be last place where we had inconsistencies between Scala & Python client.

All methods should be in sync now ( except in Python & R we have method ``hc.asSparkFrame`` but in Scala we have ``hc.asDataFrame``) -> we need to rename the method on Scala side, but that is scope of another PR https://0xdata.atlassian.net/browse/SW-2044)