### PR TITLE
[SW-2045] Deprecate initial_score_interval on H2OXGBoost as it's only H2O's internal argument

### DIFF
--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -230,6 +230,8 @@ Removal of Deprecated Methods and Classes
 - In ``H2OGridSearch`` Python API, the methods: ``get_grid_models``, ``get_grid_models_params`` and `` get_grid_models_metrics``
   are removed and replaced by ``getGridModels``, ``getGridModelsParams`` and `` getGridModelsMetrics``.
 
+- On ``H2OXGboost`` Scala and Python API, the methods ``getInitialScoreIntervals`` and ``setInitialScoreIntervals`` are removed
+  without replacement. They correspond to an internal H2O argument which should not be exposed.
 
 From 3.28.0 to 3.28.1
 ---------------------

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OXGBoost.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OXGBoost.scala
@@ -16,6 +16,7 @@
 */
 package ai.h2o.sparkling.ml.algos
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.ml.params.H2OAlgoParamsHelper._
 import ai.h2o.sparkling.ml.params.{DeprecatableParams, H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams, HasMonotoneConstraints, HasStoppingCriteria}
 import ai.h2o.sparkling.ml.utils.H2OParamsReadable
@@ -70,7 +71,6 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
   private val maxAbsLeafnodePred = floatParam("maxAbsLeafnodePred")
   private val maxDeltaStep = floatParam("maxDeltaStep")
   private val scoreTreeInterval = intParam("scoreTreeInterval")
-  private val initialScoreInterval = intParam("initialScoreInterval", "Initial Score Interval")
   private val scoreInterval = intParam("scoreInterval", "Score Interval")
   private val minSplitImprovement = floatParam("minSplitImprovement")
   private val gamma = floatParam("gamma")
@@ -113,7 +113,6 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
     maxAbsLeafnodePred -> 0,
     maxDeltaStep -> 0,
     scoreTreeInterval -> 0,
-    initialScoreInterval -> 4000,
     scoreInterval -> 4000,
     minSplitImprovement -> 0,
     gamma -> 0.0f,
@@ -172,7 +171,8 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
 
   def getScoreTreeInterval(): Int = $(scoreTreeInterval)
 
-  def getInitialScoreInterval(): Int = $(initialScoreInterval)
+  @DeprecatedMethod(version = "3.30")
+  def getInitialScoreInterval(): Int = 4000
 
   def getScoreInterval(): Int = $(scoreInterval)
 
@@ -253,7 +253,8 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
 
   def setScoreTreeInterval(value: Int): this.type = set(scoreTreeInterval, value)
 
-  def setInitialScoreInterval(value: Int): this.type = set(initialScoreInterval, value)
+  @DeprecatedMethod(version = "3.30")
+  def setInitialScoreInterval(value: Int): this.type = this
 
   def setScoreInterval(value: Int): this.type = set(scoreInterval, value)
 
@@ -338,7 +339,6 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
     parameters._max_abs_leafnode_pred = $(maxAbsLeafnodePred)
     parameters._max_delta_step = $(maxDeltaStep)
     parameters._score_tree_interval = $(scoreTreeInterval)
-    parameters._initial_score_interval = $(initialScoreInterval)
     parameters._score_interval = $(scoreInterval)
     parameters._min_split_improvement = $(minSplitImprovement)
     parameters._gamma = $(gamma)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
@@ -44,7 +44,6 @@ class H2OXGBoost(H2OXGBoostParams, H2OTreeBasedSupervisedAlgoBase):
                  maxAbsLeafnodePred=0.0,
                  maxDeltaStep=0.0,
                  scoreTreeInterval=0,
-                 initialScoreInterval=4000,
                  scoreInterval=4000,
                  minSplitImprovement=0.0,
                  gamma=0.0,

--- a/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
@@ -23,6 +23,7 @@ from ai.h2o.sparkling.ml.params.H2OTypeConverters import H2OTypeConverters
 from ai.h2o.sparkling.ml.params.HasMonotoneConstraints import HasMonotoneConstraints
 from ai.h2o.sparkling.ml.params.HasStoppingCriteria import HasStoppingCriteria
 from ai.h2o.sparkling.ml.Utils import Utils
+import warnings
 
 class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams, HasMonotoneConstraints,
                        HasStoppingCriteria):
@@ -123,12 +124,6 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         Params._dummy(),
         "scoreTreeInterval",
         "score tree interval",
-        H2OTypeConverters.toInt())
-
-    initialScoreInterval = Param(
-        Params._dummy(),
-        "initialScoreInterval",
-        "Initial Score Interval",
         H2OTypeConverters.toInt())
 
     scoreInterval = Param(
@@ -309,7 +304,8 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         return self.getOrDefault(self.scoreTreeInterval)
 
     def getInitialScoreInterval(self):
-        return self.getOrDefault(self.initialScoreInterval)
+        warnings.warn("Method 'getInitialScoreInterval' is deprecated and will be removed in the next major release 3.30.")
+        return 4000
 
     def getScoreInterval(self):
         return self.getOrDefault(self.scoreInterval)
@@ -429,7 +425,8 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         return self._set(scoreTreeInterval=value)
 
     def setInitialScoreInterval(self, value):
-        return self._set(initialScoreInterval=value)
+        warnings.warn("Method 'setInitialScoreInterval' is deprecated and will be removed in the next major release 3.30.")
+        return self
 
     def setScoreInterval(self, value):
         return self._set(scoreInterval=value)


### PR DESCRIPTION
Replacing setters and getters right away as this is internal H2O argument anyways