### PR TITLE
[SW-2047] Deprecate options for disabling or enabling REST api on H2O worker nodes. It needs to be on because of REST client

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
@@ -20,6 +20,7 @@ package ai.h2o.sparkling.backend.internal
 import java.io.{File, FileWriter}
 
 import ai.h2o.sparkling.backend.shared.SharedBackendConf
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.utils.ScalaUtils.withResource
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkEnv
@@ -45,6 +46,7 @@ trait InternalBackendConf extends SharedBackendConf {
 
   def subseqTries: Int = sparkConf.getInt(PROP_SUBSEQ_TRIES._1, PROP_SUBSEQ_TRIES._2)
 
+  @DeprecatedMethod(version = "3.30")
   def h2oNodeWebEnabled: Boolean = sparkConf.getBoolean(PROP_NODE_ENABLE_WEB._1, PROP_NODE_ENABLE_WEB._2)
 
   def nodeIcedDir: Option[String] = sparkConf.getOption(PROP_NODE_ICED_DIR._1)
@@ -62,8 +64,10 @@ trait InternalBackendConf extends SharedBackendConf {
 
   def setSubseqTries(subseqTriesNum: Int): H2OConf = set(PROP_SUBSEQ_TRIES._1, subseqTriesNum.toString)
 
+  @DeprecatedMethod(version = "3.30")
   def setH2ONodeWebEnabled(): H2OConf = set(PROP_NODE_ENABLE_WEB._1, value = true)
 
+  @DeprecatedMethod(version = "3.30")
   def setH2ONodeWebDisabled(): H2OConf = set(PROP_NODE_ENABLE_WEB._1, value = false)
 
   def setNodeIcedDir(dir: String): H2OConf = set(PROP_NODE_ICED_DIR._1, dir)

--- a/core/src/test/scala/org/apache/spark/h2o/ConfigurationPropertiesTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/ConfigurationPropertiesTestSuite.scala
@@ -94,7 +94,6 @@ abstract class ConfigurationPropertiesTestSuite_HttpHeadersBase extends Configur
       "X-MyCustomHeaderB" -> "B")
     h2oConf
       .setFlowExtraHttpHeaders(extraHttpHeaders)
-      .setH2ONodeWebEnabled()
       .setClusterSize(1)
     hc = H2OContext.getOrCreate(h2oConf)
 

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -266,10 +266,6 @@ Internal backend configuration properties
 |                                                    |                |                                                 | out size of Spark cluster, which are   |
 |                                                    |                |                                                 | producing the same number of nodes.    |
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
-| ``spark.ext.h2o.node.enable.web``                  | ``false``      | ``setH2ONodeWebEnabled()``                      | Enable or disable web on H2O worker    |
-|                                                    |                |                                                 | nodes. It is disabled by default for   |
-|                                                    |                | ``setH2ONodeWebDisabled()``                     | security reasons.                      |
-+----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
 | ``spark.ext.h2o.hdfs_conf``                        | |hadoopConfig| | ``setHdfsConf(String)``                         | Either a string with the Path to a file|
 |                                                    |                |                                                 | with Hadoop HDFS configuration or the  |
 |                                                    |                |                                                 | org.apache.hadoop.conf.Configuration   |

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -24,7 +24,7 @@ From 3.28.1 to 3.30
 - It is now required to explicitly create ``H2OContext`` before you run any of our exposed algorithms. Previously,
   the algorithm would create the H2OContext on demand.
 
-- It is no longer possible to disable web (REST API endpoints) on the worker ndoes in the internal client as we require
+- It is no longer possible to disable web (REST API endpoints) on the worker nodes in the internal client as we require
   the endpoints to be available. In particular, the methods ``setH2ONodeWebEnabled``, ``setH2ONodeWebDisabled`` and
   ``h2oNodeWebEnabled`` are removed without replacement. Also the option ``spark.ext.h2o.node.enable.web`` does not have
   any effect anymore.

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -24,6 +24,11 @@ From 3.28.1 to 3.30
 - It is now required to explicitly create ``H2OContext`` before you run any of our exposed algorithms. Previously,
   the algorithm would create the H2OContext on demand.
 
+- It is no longer possible to disable web (REST API endpoints) on the worker ndoes in the internal client as we require
+  the endpoints to be available. In particular, the methods ``setH2ONodeWebEnabled``, ``setH2ONodeWebDisabled`` and
+  ``h2oNodeWebEnabled`` are removed without replacement. Also the option ``spark.ext.h2o.node.enable.web`` does not have
+  any effect anymore.
+
 Removal of Deprecated Methods and Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/py/src/ai/h2o/sparkling/InternalBackendConf.py
+++ b/py/src/ai/h2o/sparkling/InternalBackendConf.py
@@ -79,7 +79,7 @@ class InternalBackendConf(SharedBackendConfUtils):
         return self
 
     def setH2ONodeWebDisabled(self):
-        warnings.warn("Method 'setH2ONodeWebEnabled' is deprecated and will be removed in the next major release 3.30'.")
+        warnings.warn("Method 'setH2ONodeWebDisabled' is deprecated and will be removed in the next major release 3.30'.")
         self._jconf.setH2ONodeWebDisabled()
         return self
 

--- a/py/src/ai/h2o/sparkling/InternalBackendConf.py
+++ b/py/src/ai/h2o/sparkling/InternalBackendConf.py
@@ -16,7 +16,7 @@
 #
 
 from ai.h2o.sparkling.SharedBackendConfUtils import SharedBackendConfUtils
-
+import warnings
 
 class InternalBackendConf(SharedBackendConfUtils):
 
@@ -40,6 +40,7 @@ class InternalBackendConf(SharedBackendConfUtils):
         return self._jconf.subseqTries()
 
     def h2oNodeWebEnabled(self):
+        warnings.warn("Method 'h2oNodeWebEnabled' is deprecated and will be removed in the next major release 3.30'.")
         return self._jconf.h2oNodeWebEnabled()
 
     def nodeIcedDir(self):
@@ -73,10 +74,12 @@ class InternalBackendConf(SharedBackendConfUtils):
         return self
 
     def setH2ONodeWebEnabled(self):
+        warnings.warn("Method 'setH2ONodeWebEnabled' is deprecated and will be removed in the next major release 3.30'.")
         self._jconf.setH2ONodeWebEnabled()
         return self
 
     def setH2ONodeWebDisabled(self):
+        warnings.warn("Method 'setH2ONodeWebEnabled' is deprecated and will be removed in the next major release 3.30'.")
         self._jconf.setH2ONodeWebDisabled()
         return self
 

--- a/py/tests/unit/with_runtime_clientless_sparkling/clientless_test_utils.py
+++ b/py/tests/unit/with_runtime_clientless_sparkling/clientless_test_utils.py
@@ -25,7 +25,6 @@ def createH2OConf():
     conf.set("spark.ext.h2o.rest.api.based.client", "true")
     conf.useAutoClusterStart()
     conf.setExternalClusterMode()
-    conf.setH2ONodeWebEnabled()
     return conf
 
 def yarnLogs(appId):

--- a/r/src/R/ai/h2o/sparkling/InternalBackendConf.R
+++ b/r/src/R/ai/h2o/sparkling/InternalBackendConf.R
@@ -33,8 +33,6 @@ InternalBackendConf <- setRefClass("InternalBackendConf", methods = list(
 
     subseqTries = function() { invoke(jconf, "subseqTries") },
 
-    h2oNodeWebEnabled = function() { invoke(jconf, "h2oNodeWebEnabled") },
-
     nodeIcedDir = function() { ConfUtils.getOption(invoke(jconf, "nodeIcedDir")) },
 
     hdfsConf = function() { ConfUtils.getOption(invoke(jconf, "hdfsConf")) },
@@ -51,10 +49,6 @@ InternalBackendConf <- setRefClass("InternalBackendConf", methods = list(
     setDefaultCloudSize = function(defaultClusterSize) { invoke(jconf, "setDefaultCloudSize", as.integer(defaultClusterSize)); .self },
 
     setSubseqTries = function(subseqTriesNum) { invoke(jconf, "setSubseqTries", as.integer(subseqTriesNum)); .self },
-
-    setH2ONodeWebEnabled = function() { invoke(jconf, "setH2ONodeWebEnabled"); .self },
-
-    setH2ONodeWebDisabled = function() { invoke(jconf, "setH2ONodeWebDisabled"); .self },
 
     setNodeIcedDir = function(dir) { invoke(jconf, "setNodeIcedDir", dir); .self },
 


### PR DESCRIPTION
I have checked and actually these options are not used anywhere in the Sparkling Water, so wen user was specifying them, they did not have any effect & REST API was always open. Nevertheless, we should deprecate properly and remove in 3.30