### PR TITLE
[SW-2051] Deprecate _score_interval argument as it's only H2O's internal argument

### DIFF
--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -230,8 +230,10 @@ Removal of Deprecated Methods and Classes
 - In ``H2OGridSearch`` Python API, the methods: ``get_grid_models``, ``get_grid_models_params`` and `` get_grid_models_metrics``
   are removed and replaced by ``getGridModels``, ``getGridModelsParams`` and `` getGridModelsMetrics``.
 
-- On ``H2OXGboost`` Scala and Python API, the methods ``getInitialScoreIntervals`` and ``setInitialScoreIntervals`` are removed
-  without replacement. They correspond to an internal H2O argument which should not be exposed.
+- On ``H2OXGboost`` Scala and Python API, the methods ``getInitialScoreIntervals``, ``setInitialScoreIntervals``,
+  ``getScoreInterval`` and ``setScoreInterval`` are removed without replacement. They correspond to an
+  internal H2O argument which should not be exposed.
+
 
 From 3.28.0 to 3.28.1
 ---------------------

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OXGBoost.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OXGBoost.scala
@@ -16,6 +16,7 @@
 */
 package ai.h2o.sparkling.ml.algos
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.ml.params.H2OAlgoParamsHelper._
 import ai.h2o.sparkling.ml.params.{DeprecatableParams, H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams, HasMonotoneConstraints, HasStoppingCriteria}
 import ai.h2o.sparkling.ml.utils.H2OParamsReadable
@@ -70,7 +71,6 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
   private val maxAbsLeafnodePred = floatParam("maxAbsLeafnodePred")
   private val maxDeltaStep = floatParam("maxDeltaStep")
   private val scoreTreeInterval = intParam("scoreTreeInterval")
-  private val scoreInterval = intParam("scoreInterval", "Score Interval")
   private val minSplitImprovement = floatParam("minSplitImprovement")
   private val gamma = floatParam("gamma")
   private val nthread = intParam("nthread")
@@ -112,7 +112,6 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
     maxAbsLeafnodePred -> 0,
     maxDeltaStep -> 0,
     scoreTreeInterval -> 0,
-    scoreInterval -> 4000,
     minSplitImprovement -> 0,
     gamma -> 0.0f,
     nthread -> -1,
@@ -169,8 +168,9 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
   def getMaxDeltaStep(): Float = $(maxDeltaStep)
 
   def getScoreTreeInterval(): Int = $(scoreTreeInterval)
-  
-  def getScoreInterval(): Int = $(scoreInterval)
+
+  @DeprecatedMethod(version = "3.30")
+  def getScoreInterval(): Int = 4000
 
   def getMinSplitImprovement(): Float = $(minSplitImprovement)
 
@@ -249,7 +249,8 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
 
   def setScoreTreeInterval(value: Int): this.type = set(scoreTreeInterval, value)
 
-  def setScoreInterval(value: Int): this.type = set(scoreInterval, value)
+  @DeprecatedMethod(version = "3.30")
+  def setScoreInterval(value: Int): this.type = this
 
   def setMinSplitImprovement(value: Float): this.type = set(minSplitImprovement, value)
 
@@ -332,7 +333,6 @@ trait H2OXGBoostParams extends H2OAlgoSupervisedParams[XGBoostParameters]
     parameters._max_abs_leafnode_pred = $(maxAbsLeafnodePred)
     parameters._max_delta_step = $(maxDeltaStep)
     parameters._score_tree_interval = $(scoreTreeInterval)
-    parameters._score_interval = $(scoreInterval)
     parameters._min_split_improvement = $(minSplitImprovement)
     parameters._gamma = $(gamma)
     parameters._nthread = $(nthread)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
@@ -44,7 +44,6 @@ class H2OXGBoost(H2OXGBoostParams, H2OTreeBasedSupervisedAlgoBase):
                  maxAbsLeafnodePred=0.0,
                  maxDeltaStep=0.0,
                  scoreTreeInterval=0,
-                 scoreInterval=4000,
                  minSplitImprovement=0.0,
                  gamma=0.0,
                  nthread=-1,

--- a/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
@@ -23,6 +23,7 @@ from ai.h2o.sparkling.ml.params.H2OTypeConverters import H2OTypeConverters
 from ai.h2o.sparkling.ml.params.HasMonotoneConstraints import HasMonotoneConstraints
 from ai.h2o.sparkling.ml.params.HasStoppingCriteria import HasStoppingCriteria
 from ai.h2o.sparkling.ml.Utils import Utils
+import warnings
 
 class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams, HasMonotoneConstraints,
                        HasStoppingCriteria):
@@ -123,12 +124,6 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         Params._dummy(),
         "scoreTreeInterval",
         "score tree interval",
-        H2OTypeConverters.toInt())
-
-    scoreInterval = Param(
-        Params._dummy(),
-        "scoreInterval",
-        "Score Interval",
         H2OTypeConverters.toInt())
 
     minSplitImprovement = Param(
@@ -303,7 +298,8 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         return self.getOrDefault(self.scoreTreeInterval)
 
     def getScoreInterval(self):
-        return self.getOrDefault(self.scoreInterval)
+        warnings.warn("Method 'getScoreInterval' is deprecated and will be removed in the next major release 3.30.")
+        return 4000
 
     def getMinSplitImprovement(self):
         return self.getOrDefault(self.minSplitImprovement)
@@ -420,7 +416,8 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         return self._set(scoreTreeInterval=value)
 
     def setScoreInterval(self, value):
-        return self._set(scoreInterval=value)
+        warnings.warn("Method 'setScoreInterval' is deprecated and will be removed in the next major release 3.30.")
+        return self
 
     def setMinSplitImprovement(self, value):
         return self._set(minSplitImprovement=value)


### PR DESCRIPTION
Same as _initial_score_interval. Internal argument only, should have never been exposed.

(discovered via training algos via rest)