### PR TITLE
[SW-2064] asDataFrame/asSparkFrame Conversion Function Throws Exception on Wide Datasets

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/frame/H2OChunk.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/frame/H2OChunk.scala
@@ -49,7 +49,7 @@ object H2OChunk extends RestCommunication {
       "compression" -> conf.externalCommunicationCompression)
 
     val endpoint = RestApiUtils.resolveNodeEndpoint(node, conf)
-    val inputStream = readURLContent(endpoint, "GET", Paths.CHUNK, conf, parameters)
+    val inputStream = readURLContent(endpoint, "POST", Paths.CHUNK, conf, parameters)
     Compression.decompress(conf.externalCommunicationCompression, inputStream)
   }
 

--- a/core/src/test/scala/ai/h2o/sparkling/backend/external/RestApiUtilsTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/external/RestApiUtilsTestSuite.scala
@@ -32,7 +32,7 @@ class RestApiUtilsTestSuite extends FunSuite with SharedH2OTestContext {
     val conf = hc.getConf
     val endpoint = RestApiUtils.getClusterEndpoint(conf)
 
-    val caught = intercept[RestApiCommunicationException](RestApiUtils.query(endpoint, Paths.CHUNK, conf))
+    val caught = intercept[RestApiCommunicationException](RestApiUtils.update(endpoint, Paths.CHUNK, conf))
 
     assert(caught.getMessage.contains("Cannot find value for the parameter 'frame_name'"))
   }

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -27,7 +27,7 @@ import hex.splitframe.ShuffleSplitFrame
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.testdata._
 import org.apache.spark.h2o.utils.H2OAsserts._
-import org.apache.spark.h2o.utils.SharedH2OTestContext
+import org.apache.spark.h2o.utils.{SharedH2OTestContext, TestFrameUtils}
 import org.apache.spark.h2o.utils.TestFrameUtils._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.sql.types._
@@ -789,17 +789,20 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
     assert(hf.names() sameElements Array("name.given.name", "name.family", "person.age"))
   }
 
-  test("Test conversion of frame with high number of columns"){
+  test("Test conversion of DataFrame to H2OFrame and back with a high number of columns"){
     import spark.implicits._
-    val numCols = 5000
-    val cols = (1 to numCols).map{ n =>
-      $"_tmp".getItem(n).as("col" + n)
-    }
     import org.apache.spark.sql.functions._
+    val numCols = 5000
+    val cols = (1 to numCols).map(n => $"_tmp".getItem(n).as("col" + n))
+
     val df = sc.parallelize(Seq((1 to numCols).mkString(","))).toDF
-    val widenDF = df.withColumn("_tmp", split($"value", ",")).select(cols: _*).drop("_tmp")
-    val hf = hc.asH2OFrame(widenDF)
+    val wideDF = df.withColumn("_tmp", split($"value", ",")).select(cols: _*).drop("_tmp")
+
+    val hf = hc.asH2OFrame(wideDF)
+    val resultDF = hc.asDataFrame(hf)
+
     assert(hf.numCols() == numCols)
+    resultDF.foreach(_ => {})
   }
 
   def fp(it: Iterator[Row]): Unit = {

--- a/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/converters/DataFrameConverterTest.scala
@@ -792,7 +792,7 @@ class DataFrameConverterTest extends FunSuite with SharedH2OTestContext {
   test("Test conversion of DataFrame to H2OFrame and back with a high number of columns"){
     import spark.implicits._
     import org.apache.spark.sql.functions._
-    val numCols = 5000
+    val numCols = 20000
     val cols = (1 to numCols).map(n => $"_tmp".getItem(n).as("col" + n))
 
     val df = sc.parallelize(Seq((1 to numCols).mkString(","))).toDF


### PR DESCRIPTION
This PR proposes to solve the problem via changing GET mehtod for downloading chunks to POST. Another way how to solve the problem could be to extend size limit of requests/headers. The chosen approach seems to give us no restrictions. 