### PR TITLE
[SW-2071] InternalH2OBackend Shouldn't Call setH2OCluster

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.h2o.backends.internal
 
+import ai.h2o.sparkling.backend.external.ExternalBackendConf
 import ai.h2o.sparkling.backend.shared.SparklingBackend
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.h2o.ui.SparklingWaterHeartbeatEvent
@@ -42,7 +43,7 @@ class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend
     // Register H2O and Sparkling Water REST API for H2O client
     RestAPIManager(hc).registerAll()
     H2O.startServingRestApi()
-    conf.setH2OCluster(H2O.CLOUD.leader().getIpPortString)
+    conf.set(ExternalBackendConf.PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, H2O.CLOUD.leader().getIpPortString)
     nodes
   }
 


### PR DESCRIPTION
`setH2OCluster()` method on h2oConf has a side effect and internally calls `setExternalClusterMode()`