### PR TITLE
Revert "[SW-2069] Set H2O Cluster Time Zone only via REST (#1943)"

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -183,13 +183,15 @@ abstract class H2OContext private(private val conf: H2OConf) extends Logging wit
         .getOrElse(TimeZone.getDefault.getID)
 
       if (DateTimeZone.getAvailableIDs.contains(sparkTimeZone)) {
-        RestApiUtils.setTimeZone(conf, sparkTimeZone)
+        setTimeZoneImpl(sparkTimeZone)
       } else {
         log.warn(s"The current Spark local time zone '$sparkTimeZone' is not supported by H2O. " +
           "Using default H2O Spark session.")
       }
     }
   }
+
+  protected def setTimeZoneImpl(timeZone: String): Unit
 
   protected def getH2OBuildInfo(nodes: Array[NodeDesc]): H2OBuildInfo
 
@@ -453,6 +455,8 @@ object H2OContext extends Logging {
       }
     }
 
+    override protected def setTimeZoneImpl(timeZone: String): Unit = ParseTime.setTimezone(timeZone)
+
     override protected def getH2OEndpointPort(): Int = H2O.API_PORT
 
     override protected def getSelfNodeDesc(): Option[NodeDesc] = Some(NodeDesc(H2O.SELF))
@@ -498,6 +502,8 @@ object H2OContext extends Logging {
     private var flowIp: String = _
     private var flowPort: Int = _
     private var leaderNode: NodeDesc = _
+
+    override protected def setTimeZoneImpl(timeZone: String): Unit = RestApiUtils.setTimeZone(conf, timeZone)
 
     override protected def getH2OEndpointIp(): String = leaderNode.hostname
 


### PR DESCRIPTION
Getting `main` and `rel-3.28.1` synchronized before setting H2OCluster always to UTC