### PR TITLE
[SW-2086] Move classes from org.apache.spark.h2o.utils to ai.h2o.sparkling

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OAwareBaseRDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OAwareBaseRDD.scala
@@ -17,7 +17,6 @@
 package ai.h2o.sparkling.backend
 
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{OneToOneDependency, Partition, SparkContext}
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OAwareEmptyRDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OAwareEmptyRDD.scala
@@ -17,7 +17,6 @@
 package ai.h2o.sparkling.backend
 
 import org.apache.spark.SparkContext
-import org.apache.spark.h2o.utils.NodeDesc
 
 import scala.reflect.ClassTag
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OAwareRDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OAwareRDD.scala
@@ -16,7 +16,6 @@
 */
 package ai.h2o.sparkling.backend
 
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, TaskContext}
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2ODataFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2ODataFrame.scala
@@ -18,11 +18,10 @@
 package ai.h2o.sparkling.backend
 
 import ai.h2o.sparkling.SparkTimeZone
-import ai.h2o.sparkling.backend.utils.ConversionUtils
+import ai.h2o.sparkling.backend.utils.SupportedTypes._
+import ai.h2o.sparkling.backend.utils.{ConversionUtils, ReflectionUtils}
 import ai.h2o.sparkling.frame.H2OFrame
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.utils.ReflectionUtils
-import org.apache.spark.h2o.utils.SupportedTypes._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.{Partition, TaskContext}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OFrameRelation.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OFrameRelation.scala
@@ -17,9 +17,9 @@
 
 package ai.h2o.sparkling.backend
 
+import ai.h2o.sparkling.backend.utils.ReflectionUtils
 import ai.h2o.sparkling.frame.{H2OColumn, H2OColumnType, H2OFrame}
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.utils.ReflectionUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.{BaseRelation, PrunedScan, TableScan}
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField, StructType}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2ORDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2ORDD.scala
@@ -20,10 +20,9 @@ package ai.h2o.sparkling.backend
 import java.lang.reflect.Constructor
 
 import ai.h2o.sparkling.SparkTimeZone
-import ai.h2o.sparkling.backend.utils.ConversionUtils
+import ai.h2o.sparkling.backend.utils.{ConversionUtils, ProductType}
 import ai.h2o.sparkling.frame.H2OFrame
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.utils.ProductType
 import org.apache.spark.{Partition, TaskContext}
 
 import scala.annotation.meta.{field, getter, param}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/NodeDesc.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/NodeDesc.scala
@@ -15,18 +15,18 @@
 * limitations under the License.
 */
 
-package org.apache.spark.h2o.utils
+package ai.h2o.sparkling.backend
 
 import water.H2ONode
 import water.nbhm.NonBlockingHashMap
 
 /** Helper class containing node ID, hostname and port.
-  *
-  * @param nodeId  In case of external cluster mode the node ID is ID of H2O Node, in the internal cluster mode the ID
-  * is ID of Spark Executor where corresponding instance is located
-  * @param hostname hostname of the node
-  * @param port port of the node
-  */
+ *
+ * @param nodeId   In case of external cluster mode the node ID is ID of H2O Node, in the internal cluster mode the ID
+ *                 is ID of Spark Executor where corresponding instance is located
+ * @param hostname hostname of the node
+ * @param port     port of the node
+ */
 case class NodeDesc(nodeId: String, hostname: String, port: Int) {
   override def productPrefix = ""
 
@@ -38,24 +38,25 @@ object NodeDesc {
     intern(node)
   }
 
-  private[utils] def fromH2ONode(node: H2ONode): NodeDesc = {
+  private def fromH2ONode(node: H2ONode): NodeDesc = {
     val ipPort = node.getIpPortString.split(":")
     NodeDesc(node.index().toString, ipPort(0), Integer.parseInt(ipPort(1)))
   }
 
-  private[utils] def intern(node: H2ONode): NodeDesc = {
+  private def intern(node: H2ONode): NodeDesc = {
     var nodeDesc = INTERN_CACHE.get(node)
     if (nodeDesc != null) {
-      return nodeDesc
+      nodeDesc
     } else {
       nodeDesc = fromH2ONode(node)
       val oldNodeDesc = INTERN_CACHE.putIfAbsent(node, nodeDesc)
       if (oldNodeDesc != null) {
-        return oldNodeDesc
+        oldNodeDesc
       } else {
-        return nodeDesc
+        nodeDesc
       }
     }
   }
-  val INTERN_CACHE = new NonBlockingHashMap[H2ONode, NodeDesc]
+
+  private val INTERN_CACHE = new NonBlockingHashMap[H2ONode, NodeDesc]
 }

--- a/core/src/main/scala/ai/h2o/sparkling/backend/Reader.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/Reader.scala
@@ -20,13 +20,12 @@ package ai.h2o.sparkling.backend
 import java.util.TimeZone
 
 import ai.h2o.sparkling.backend.converters.TimeZoneConversions
+import ai.h2o.sparkling.backend.utils.SupportedTypes
+import ai.h2o.sparkling.backend.utils.SupportedTypes._
 import ai.h2o.sparkling.extensions.serde.ChunkAutoBufferReader
 import ai.h2o.sparkling.frame.H2OChunk
 import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.SupportedTypes._
-import org.apache.spark.h2o.utils.{NodeDesc, SupportedTypes}
 import org.apache.spark.unsafe.types.UTF8String
-
 
 private[backend] class Reader(keyName: String,
                               chunkIdx: Int,

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SparklingBackend.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SparklingBackend.scala
@@ -18,7 +18,6 @@
 package ai.h2o.sparkling.backend
 
 import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.NodeDesc
 
 trait SparklingBackend {
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/Writer.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/Writer.scala
@@ -25,7 +25,6 @@ import ai.h2o.sparkling.extensions.serde.{ChunkAutoBufferWriter, SerdeUtils}
 import ai.h2o.sparkling.frame.{H2OChunk, H2OFrame}
 import ai.h2o.sparkling.utils.ScalaUtils.withResource
 import ai.h2o.sparkling.utils.SparkSessionUtils
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OContext, RDD}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._

--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/SparkDataFrameConverter.scala
@@ -19,14 +19,14 @@ package ai.h2o.sparkling.backend.converters
 
 import ai.h2o.sparkling.SparkTimeZone
 import ai.h2o.sparkling.backend.utils.ConversionUtils.expectedTypesFromClasses
+import ai.h2o.sparkling.backend.utils.ReflectionUtils
+import ai.h2o.sparkling.backend.utils.SupportedTypes.Double
 import ai.h2o.sparkling.backend.{H2OAwareRDD, H2OFrameRelation, Writer, WriterMetadata}
 import ai.h2o.sparkling.ml.utils.SchemaUtils._
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.ExposeUtils
 import org.apache.spark.expose.Logging
 import org.apache.spark.h2o.H2OContext
-import org.apache.spark.h2o.utils.ReflectionUtils
-import org.apache.spark.h2o.utils.SupportedTypes.Double
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{DataType, DecimalType}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendUtils.scala
@@ -19,10 +19,10 @@ package ai.h2o.sparkling.backend.external
 
 import java.net.{InetAddress, NetworkInterface}
 
+import ai.h2o.sparkling.backend.NodeDesc
 import ai.h2o.sparkling.backend.api.RestAPIManager
 import ai.h2o.sparkling.backend.utils.SharedBackendUtils
 import org.apache.spark.SparkEnv
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.init.{HostnameGuesser, NetworkBridge}
 import water.{H2O, H2OStarter, Paxos}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
@@ -22,12 +22,11 @@ import java.util.Properties
 
 import ai.h2o.sparkling.backend.exceptions.{H2OClusterNotReachableException, RestApiException}
 import ai.h2o.sparkling.backend.utils.{ArgumentBuilder, RestApiUtils}
-import ai.h2o.sparkling.backend.{SharedBackendConf, SparklingBackend}
+import ai.h2o.sparkling.backend.{NodeDesc, SharedBackendConf, SparklingBackend}
 import ai.h2o.sparkling.utils.ScalaUtils._
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.commons.io.IOUtils
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{BuildInfo, H2OConf, H2OContext}
 import org.apache.spark.{SparkEnv, SparkFiles}
 import water.api.schemas3.CloudLockV3

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/LogUtil.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/LogUtil.scala
@@ -15,16 +15,17 @@
 * limitations under the License.
 */
 
-package org.apache.spark.h2o.utils
+package ai.h2o.sparkling.backend.utils
 
 import org.apache.log4j.{Level, LogManager}
+import org.apache.spark.expose.Logging
 import water.MRTask
 import water.util.{Log, LogBridge}
 
 /**
-  * A simple helper to control H2O log subsystem
-  */
-object LogUtil extends org.apache.spark.internal.Logging {
+ * A simple helper to control H2O log subsystem
+ */
+object LogUtil extends Logging {
 
   def setH2OClientLogLevel(level: String): Unit = {
     setLogLevel(
@@ -57,4 +58,3 @@ object LogUtil extends org.apache.spark.internal.Logging {
     }
   }
 }
-

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/ReflectionUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/ReflectionUtils.scala
@@ -15,10 +15,10 @@
 * limitations under the License.
 */
 
-package org.apache.spark.h2o.utils
+package ai.h2o.sparkling.backend.utils
 
+import ai.h2o.sparkling.backend.utils.SupportedTypes._
 import ai.h2o.sparkling.frame.{H2OColumn, H2OColumnType}
-import org.apache.spark.h2o.utils.SupportedTypes._
 import org.apache.spark.sql.types._
 import water.api.API
 import water.fvec.Vec
@@ -28,8 +28,8 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 /**
-  * Work with reflection only inside this helper.
-  */
+ * Work with reflection only inside this helper.
+ */
 object ReflectionUtils {
   type NameOfType = String
 
@@ -51,7 +51,6 @@ object ReflectionUtils {
     tt map (supportedTypeFor(_).javaClass) toArray
   }
 
-  // TODO(vlad): get rid of this duplication (see productMembers)
   def listMemberTypes(st: Type): Seq[Type] = {
     val names = fieldNamesOf(st)
     val formalTypeArgs = st.typeSymbol.asClass.typeParams
@@ -86,12 +85,12 @@ object ReflectionUtils {
   }
 
   /** Return API annotation assigned with the given field
-    * or null.
-    *
-    * @param klazz     class to query
-    * @param fieldName field name to query
-    * @return instance of API annotation assigned with the field or null
-    */
+   * or null.
+   *
+   * @param klazz     class to query
+   * @param fieldName field name to query
+   * @return instance of API annotation assigned with the field or null
+   */
   def api(klazz: Class[_], fieldName: String): API = {
     klazz.getField(fieldName).getAnnotation(classOf[API])
   }
@@ -145,13 +144,13 @@ object ReflectionUtils {
   import SupportedTypes._
 
   /**
-    * Return catalyst structural type for given H2O vector.
-    *
-    * The mapping of type is flat.
-    *
-    * @param v H2O vector
-    * @return catalyst data type
-    */
+   * Return catalyst structural type for given H2O vector.
+   *
+   * The mapping of type is flat.
+   *
+   * @param v H2O vector
+   * @return catalyst data type
+   */
   def dataTypeFor(v: Vec): DataType = supportedType(v).sparkType
 
   def dataTypeFor(columnType: H2OColumn): DataType = supportedType(columnType).sparkType
@@ -171,10 +170,11 @@ object ReflectionUtils {
   }
 
   /**
-    * This method converts a REST column entity to a data type supported by Spark.
-    * @param column A column entity obtained via H2O REST API
-    * @return A data type supported by Spark
-    */
+   * This method converts a REST column entity to a data type supported by Spark.
+   *
+   * @param column A column entity obtained via H2O REST API
+   * @return A data type supported by Spark
+   */
   def supportedType(column: H2OColumn): SupportedType = column.dataType match {
     case H2OColumnType.`enum` | H2OColumnType.string | H2OColumnType.uuid => String
     case H2OColumnType.int =>
@@ -211,7 +211,7 @@ object ReflectionUtils {
   }
 }
 
-import ReflectionUtils._
+import ai.h2o.sparkling.backend.utils.ReflectionUtils._
 
 case class ProductMember(name: String, typeName: NameOfType, typeClass: Class[_]) {
   override def toString = s"$name: $typeName"

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.backend.utils
 
 import java.net.URI
 
+import ai.h2o.sparkling.backend.NodeDesc
 import org.apache.http.client.utils.URIBuilder
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.api.schemas3._
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/SharedBackendUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/SharedBackendUtils.scala
@@ -19,10 +19,9 @@ package ai.h2o.sparkling.backend.utils
 
 import java.io.File
 
-import ai.h2o.sparkling.backend.SharedBackendConf
+import ai.h2o.sparkling.backend.{NodeDesc, SharedBackendConf}
 import org.apache.spark.expose.{Logging, Utils}
 import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.{SparkContext, SparkEnv, SparkFiles}
 import water.support.SparkContextSupport
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/SupportedTypes.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/SupportedTypes.scala
@@ -14,9 +14,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.apache.spark.h2o.utils
+package ai.h2o.sparkling.backend.utils
 
-import org.apache.spark.h2o.utils.ReflectionUtils.NameOfType
+import ai.h2o.sparkling.backend.utils.ReflectionUtils.NameOfType
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import water.fvec.Vec
@@ -25,9 +25,9 @@ import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.runtime.universe._
 
 /**
-  * All type associations are gathered in this file.
-  */
-object SupportedTypes extends Enumeration {
+ * All type associations are gathered in this file.
+ */
+private[backend] object SupportedTypes extends Enumeration {
 
   type VecType = Byte
 
@@ -82,21 +82,18 @@ object SupportedTypes extends Enumeration {
 
   private def onNAreturn[T](value: T)(what: String) = value
 
-  // scalastyle:off
-  val Boolean   = SimpleType[scala.Boolean] (Vec.T_NUM,  BooleanType,   classOf[jl.Boolean  ], onNAreturn(false), typeOf[Boolean])
-  val Byte      = SimpleType[scala.Byte   ] (Vec.T_NUM,  ByteType,      classOf[jl.Byte     ], onNAthrow, typeOf[Byte])
-  val Short     = SimpleType[scala.Short  ] (Vec.T_NUM,  ShortType,     classOf[jl.Short    ], onNAthrow, typeOf[Short])
-  val Integer   = SimpleType[scala.Int    ] (Vec.T_NUM,  IntegerType,   classOf[jl.Integer  ], onNAthrow, typeOf[Int])
-  val Long      = SimpleType[scala.Long   ] (Vec.T_NUM,  LongType,      classOf[jl.Long     ], onNAthrow, typeOf[Long])
-  val Float     = SimpleType[scala.Float  ] (Vec.T_NUM,  FloatType,     classOf[jl.Float    ], onNAreturn(scala.Float.NaN), typeOf[Float])
-  val Double    = SimpleType[scala.Double ] (Vec.T_NUM,  DoubleType,    classOf[jl.Double   ], onNAreturn(scala.Double.NaN), typeOf[Double])
-  val Timestamp = SimpleType[js.Timestamp ] (Vec.T_TIME, TimestampType, classOf[js.Timestamp], onNAthrow)
-  val Date      = SimpleType[js.Date      ] (Vec.T_TIME, DateType,      classOf[js.Date     ], onNAthrow)
-  val String    = SimpleType[String       ] (Vec.T_STR,  StringType,    classOf[String],       onNAreturn(null), typeOf[String])
-  // TODO(vlad): figure it out, why
-  val UTF8      = SimpleType[UTF8String   ] (Vec.T_STR,  StringType,    classOf[String],       onNAreturn(null), typeOf[UTF8String])
-  // scalastyle:on
-  
+  val Boolean = SimpleType[scala.Boolean](Vec.T_NUM, BooleanType, classOf[jl.Boolean], onNAreturn(false), typeOf[Boolean])
+  val Byte = SimpleType[scala.Byte](Vec.T_NUM, ByteType, classOf[jl.Byte], onNAthrow, typeOf[Byte])
+  val Short = SimpleType[scala.Short](Vec.T_NUM, ShortType, classOf[jl.Short], onNAthrow, typeOf[Short])
+  val Integer = SimpleType[scala.Int](Vec.T_NUM, IntegerType, classOf[jl.Integer], onNAthrow, typeOf[Int])
+  val Long = SimpleType[scala.Long](Vec.T_NUM, LongType, classOf[jl.Long], onNAthrow, typeOf[Long])
+  val Float = SimpleType[scala.Float](Vec.T_NUM, FloatType, classOf[jl.Float], onNAreturn(scala.Float.NaN), typeOf[Float])
+  val Double = SimpleType[scala.Double](Vec.T_NUM, DoubleType, classOf[jl.Double], onNAreturn(scala.Double.NaN), typeOf[Double])
+  val Timestamp = SimpleType[js.Timestamp](Vec.T_TIME, TimestampType, classOf[js.Timestamp], onNAthrow)
+  val Date = SimpleType[js.Date](Vec.T_TIME, DateType, classOf[js.Date], onNAthrow)
+  val String = SimpleType[String](Vec.T_STR, StringType, classOf[String], onNAreturn(null), typeOf[String])
+  val UTF8 = SimpleType[UTF8String](Vec.T_STR, StringType, classOf[String], onNAreturn(null), typeOf[UTF8String])
+
   private implicit def val2type(v: Value): SimpleType[_] = v.asInstanceOf[SimpleType[_]]
 
   val allSimple: List[SimpleType[_]] = values.toList map val2type

--- a/core/src/main/scala/ai/h2o/sparkling/frame/H2OChunk.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/frame/H2OChunk.scala
@@ -19,11 +19,11 @@ package ai.h2o.sparkling.frame
 
 import java.io.{InputStream, OutputStream}
 
+import ai.h2o.sparkling.backend.NodeDesc
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestCommunication}
 import ai.h2o.sparkling.extensions.rest.api.Paths
 import ai.h2o.sparkling.utils.{Base64Encoding, Compression}
 import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.NodeDesc
 
 
 case class H2OChunk(index: Int, numberOfRows: Int, location: NodeDesc)

--- a/core/src/main/scala/ai/h2o/sparkling/frame/H2OFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/frame/H2OFrame.scala
@@ -19,13 +19,13 @@ package ai.h2o.sparkling.frame
 
 import java.text.MessageFormat
 
+import ai.h2o.sparkling.backend.NodeDesc
 import ai.h2o.sparkling.backend.utils.RestApiUtils._
 import ai.h2o.sparkling.backend.utils.{RestCommunication, RestEncodingUtils}
 import ai.h2o.sparkling.extensions.rest.api.Paths
 import ai.h2o.sparkling.extensions.rest.api.schema.{FinalizeFrameV3, InitializeFrameV3}
 import ai.h2o.sparkling.job.H2OJob
 import ai.h2o.sparkling.utils.Base64Encoding
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.api.schemas3.FrameChunksV3.FrameChunkV3
 import water.api.schemas3.FrameV3.ColV3

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -23,13 +23,12 @@ import ai.h2o.sparkling.backend.converters.{DatasetConverter, SparkDataFrameConv
 import ai.h2o.sparkling.backend.exceptions.{H2OClusterNotReachableException, RestApiException}
 import ai.h2o.sparkling.backend.external._
 import ai.h2o.sparkling.backend.utils._
-import ai.h2o.sparkling.backend.{SharedBackendConf, SparklingBackend}
+import ai.h2o.sparkling.backend.{NodeDesc, SharedBackendConf, SparklingBackend}
 import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark._
 import org.apache.spark.h2o.backends.internal.InternalH2OBackend
 import org.apache.spark.h2o.ui._
-import org.apache.spark.h2o.utils._
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.util.ShutdownHookManager

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/H2ORpcEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/H2ORpcEndpoint.scala
@@ -20,8 +20,8 @@ package org.apache.spark.h2o.backends.internal
 
 import java.net.InetAddress
 
+import ai.h2o.sparkling.backend.NodeDesc
 import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 import water.util.Log
 import water.{H2O, H2ONode}

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendUtils.scala
@@ -18,9 +18,8 @@
 package org.apache.spark.h2o.backends.internal
 
 import ai.h2o.sparkling.backend.SharedBackendConf
-import ai.h2o.sparkling.backend.utils.{ArgumentBuilder, SharedBackendUtils}
+import ai.h2o.sparkling.backend.utils.{ArgumentBuilder, ReflectionUtils, SharedBackendUtils}
 import org.apache.spark.h2o.H2OConf
-import org.apache.spark.h2o.utils.ReflectionUtils
 import org.apache.spark.scheduler.local.LocalSchedulerBackend
 import org.apache.spark.{SparkContext, SparkEnv}
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -17,11 +17,10 @@
 
 package org.apache.spark.h2o.backends.internal
 
-import ai.h2o.sparkling.backend.SparklingBackend
+import ai.h2o.sparkling.backend.{NodeDesc, SparklingBackend}
 import ai.h2o.sparkling.backend.api.RestAPIManager
 import ai.h2o.sparkling.backend.external.ExternalBackendConf
 import ai.h2o.sparkling.utils.SparkSessionUtils
-import org.apache.spark.h2o.utils.NodeDesc
 import org.apache.spark.h2o.{H2OConf, H2OContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.RpcEndpointRef

--- a/core/src/test/scala/ai/h2o/sparkling/backend/utils/SupportedTypesTest.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/utils/SupportedTypesTest.scala
@@ -14,11 +14,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.apache.spark.h2o
+package ai.h2o.sparkling.backend.utils
 
-import org.apache.spark.h2o.utils.ReflectionUtils._
-import org.apache.spark.h2o.utils.SupportedTypes._
-import org.apache.spark.h2o.utils.SupportedTypes
+import ai.h2o.sparkling.backend.utils.ReflectionUtils._
+import ai.h2o.sparkling.backend.utils.SupportedTypes._
 import org.apache.spark.unsafe.types.UTF8String
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -27,8 +26,8 @@ import org.scalatest.junit.JUnitRunner
 import scala.reflect.runtime.universe._
 
 /**
-  * Tests for type info handling
-  */
+ * Tests for type info handling
+ */
 @RunWith(classOf[JUnitRunner])
 class SupportedTypesTest extends FunSuite {
 
@@ -58,7 +57,8 @@ class SupportedTypesTest extends FunSuite {
 
   test("Fail to infer type from a weird value") {
     def mustFail[T](msg: String, value: T) = try {
-      val t = supportedTypeOf(value); fail(s"Not acceptable: $msg: got $t")
+      val t = supportedTypeOf(value);
+      fail(s"Not acceptable: $msg: got $t")
     } catch {
       case iae: IllegalArgumentException => ; //success
     }

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OAlgoParamsHelper.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OAlgoParamsHelper.scala
@@ -20,7 +20,7 @@ import java.util
 
 import com.google.common.base.CaseFormat
 import hex.Model.Parameters
-import org.apache.spark.h2o.utils.ReflectionUtils.api
+import ai.h2o.sparkling.backend.utils.ReflectionUtils.api
 import org.apache.spark.ml.param._
 
 import scala.reflect.ClassTag


### PR DESCRIPTION
The reason why I'm moving the classes to ai.h2o.sparkling package is to have all internal classes in the `backend` package and so we can restrict access to all of them for the users. Since we will start creating Scala API I would like to have clear distinction.