### PR TITLE
[SW-2098] Update the option which will be used to determine whether to start H2O client in scala

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -436,8 +436,6 @@ object SharedBackendConf {
    */
   val PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT: (String, Int) = ("spark.ext.h2o.cluster.client.retry.timeout", PROP_BACKEND_HEARTBEAT_INTERVAL._2 * 6)
 
-  val PROP_REST_API_BASED_CLIENT: (String, Boolean) = ("spark.ext.h2o.rest.api.based.client", false)
-
   /** Extra properties passed to H2O client during startup. */
   val PROP_CLIENT_EXTRA_PROPERTIES: (String, None.type) = ("spark.ext.h2o.client.extra", None)
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
@@ -20,7 +20,7 @@ package ai.h2o.sparkling.backend.external
 import java.io.{File, FileInputStream, FileOutputStream}
 import java.util.Properties
 
-import ai.h2o.sparkling.backend.utils.{ArgumentBuilder, RestApiUtils, SharedBackendUtils, ShellUtils}
+import ai.h2o.sparkling.backend.utils.{ArgumentBuilder, H2OClientUtils, RestApiUtils, SharedBackendUtils, ShellUtils}
 import ai.h2o.sparkling.backend.{SharedBackendConf, SparklingBackend}
 import ai.h2o.sparkling.utils.ScalaUtils._
 import ai.h2o.sparkling.utils.SparkSessionUtils
@@ -113,9 +113,9 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Shell
       .add("-baseport", conf.nodeBasePort)
       .add("-timeout", conf.clusterStartTimeout)
       .add("-disown")
-      .add("-sw_ext_backend", !RestApiUtils.isRestAPIBased(hc))
+      .add("-sw_ext_backend", H2OClientUtils.isH2OClientBased(hc))
       .add(Seq("-J", "-rest_api_ping_timeout", "-J", conf.clientCheckRetryTimeout.toString))
-      .add(Seq("-J", "-client_disconnect_timeout", "-J", conf.clientCheckRetryTimeout.toString), !RestApiUtils.isRestAPIBased(hc))
+      .add(Seq("-J", "-client_disconnect_timeout", "-J", conf.clientCheckRetryTimeout.toString), H2OClientUtils.isH2OClientBased(hc))
       .add("-run_as_user", conf.runAsUser)
       .add(Seq("-J", "-stacktrace_collector_interval", "-J", conf.stacktraceCollectorInterval.toString), conf.stacktraceCollectorInterval != -1)
       .add("-output", conf.HDFSOutputDir)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OClientUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OClientUtils.scala
@@ -32,6 +32,16 @@ import water.{H2O, H2OStarter, Paxos}
  */
 object H2OClientUtils extends SharedBackendUtils {
 
+  val PROP_SCALA_H2O_CLIENT_BASED: (String, Boolean) = ("spark.ext.h2o.scala.api.client.based", true)
+
+  def isH2OClientBased(conf: H2OConf): Boolean = {
+    conf.getBoolean(PROP_SCALA_H2O_CLIENT_BASED._1, PROP_SCALA_H2O_CLIENT_BASED._2)
+  }
+
+  def isH2OClientBased(hc: H2OContext): Boolean = {
+    isH2OClientBased(hc.getConf)
+  }
+
   /**
    * Get common arguments for H2O client.
    *

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
@@ -26,16 +26,6 @@ import water.api.schemas3._
 
 trait RestApiUtils extends RestCommunication {
 
-  def isRestAPIBased(hc: Option[H2OContext] = None): Boolean = {
-    isRestAPIBased(hc.getOrElse(H2OContext.ensure()).getConf)
-  }
-
-  def isRestAPIBased(conf: H2OConf): Boolean = {
-    conf.get("spark.ext.h2o.rest.api.based.client", "false") == "true"
-  }
-
-  def isRestAPIBased(hc: H2OContext): Boolean = isRestAPIBased(Some(hc))
-
   def getPingInfo(conf: H2OConf): PingV3 = {
     val endpoint = getClusterEndpoint(conf)
     query[PingV3](endpoint, "/3/Ping", conf)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/SharedBackendUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/SharedBackendUtils.scala
@@ -142,7 +142,7 @@ trait SharedBackendUtils extends Logging with Serializable {
    */
   def getH2OCommonArgs(conf: H2OConf): Seq[String] = {
     new ArgumentBuilder()
-      .add("-allow_clients", !RestApiUtils.isRestAPIBased(conf))
+      .add("-allow_clients", H2OClientUtils.isH2OClientBased(conf))
       .add("-internal_security_conf_rel_paths")
       .add("-name", conf.cloudName.get)
       .add("-port_offset", conf.internalPortOffset)
@@ -167,8 +167,8 @@ trait SharedBackendUtils extends Logging with Serializable {
       .add("-flow_dir", conf.flowDir)
       .add("-ice_root", conf.clientIcedDir)
       .add("-port", Some(conf.clientWebPort).filter(_ > 0))
-      .addIf("-network", conf.clientNetworkMask, !RestApiUtils.isRestAPIBased(conf))
-      .addIf("-ip", conf.clientIp, conf.clientNetworkMask.isEmpty && !RestApiUtils.isRestAPIBased(conf))
+      .addIf("-network", conf.clientNetworkMask, H2OClientUtils.isH2OClientBased(conf))
+      .addIf("-ip", conf.clientIp, conf.clientNetworkMask.isEmpty && H2OClientUtils.isH2OClientBased(conf))
       .addAsString(conf.clientExtraProperties)
       .buildArgs()
   }

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -287,15 +287,15 @@ class H2OContext private(private val conf: H2OConf) extends H2OContextExtensions
       // In internal backend, Spark takes care of stopping executors automatically
       // In manual mode of external backend, the H2O cluster is managed by the user
       if (conf.runsInExternalClusterMode && conf.isAutoClusterStartUsed) {
-        if (RestApiUtils.isRestAPIBased(Some(this))) {
-          RestApiUtils.shutdownCluster(conf)
-        } else {
+        if (H2OClientUtils.isH2OClientBased(this)) {
           H2O.orderlyShutdown(conf.externalBackendStopTimeout)
+        } else {
+          RestApiUtils.shutdownCluster(conf)
         }
       }
       H2OContext.instantiatedContext.set(null)
       stopped = true
-      if (stopJvm && !RestApiUtils.isRestAPIBased(Some(this))) {
+      if (stopJvm && H2OClientUtils.isH2OClientBased(this)) {
         H2O.exit(0)
       }
     } else {
@@ -369,7 +369,7 @@ class H2OContext private(private val conf: H2OConf) extends H2OContextExtensions
   private def connectToH2OCluster(): Array[NodeDesc] = {
     logInfo("Connecting to H2O cluster.")
     val nodes = getAndVerifyWorkerNodes(conf)
-    if (!RestApiUtils.isRestAPIBased(this)) {
+    if (H2OClientUtils.isH2OClientBased(this)) {
       H2OClientUtils.startH2OClient(this, conf, nodes)
     }
     nodes
@@ -388,10 +388,10 @@ class H2OContext private(private val conf: H2OConf) extends H2OContextExtensions
                 logError("External H2O cluster not healthy!")
                 if (conf.isKillOnUnhealthyClusterEnabled) {
                   logError("Stopping external H2O cluster as it is not healthy.")
-                  if (RestApiUtils.isRestAPIBased(Some(H2OContext.this))) {
-                    H2OContext.this.stop(stopSparkContext = false, stopJvm = false, inShutdownHook = false)
-                  } else {
+                  if (H2OClientUtils.isH2OClientBased(H2OContext.this)) {
                     H2OContext.this.stop(true)
+                  } else {
+                    H2OContext.this.stop(stopSparkContext = false, stopJvm = false, inShutdownHook = false)
                   }
                 }
               }
@@ -458,7 +458,7 @@ object H2OContext extends Logging {
    */
   def getOrCreate(conf: H2OConf): H2OContext = synchronized {
     val isExternalBackend = conf.runsInExternalClusterMode
-    if (isExternalBackend && RestApiUtils.isRestAPIBased(conf)) {
+    if (isExternalBackend && !H2OClientUtils.isH2OClientBased(conf)) {
       val existingContext = instantiatedContext.get()
       if (existingContext != null) {
         val startedManually = existingContext.conf.isManualClusterStartUsed

--- a/core/src/test/scala/ai/h2o/sparkling/frame/H2OFrameTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/frame/H2OFrameTestSuite.scala
@@ -16,6 +16,7 @@
 */
 package ai.h2o.sparkling.frame
 
+import ai.h2o.sparkling.backend.utils.H2OClientUtils
 import ai.h2o.sparkling.{H2OColumnType, H2OFrame}
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.utils.SharedH2OTestContext
@@ -27,8 +28,7 @@ import water.api.TestUtils
 @RunWith(classOf[JUnitRunner])
 class H2OFrameTestSuite extends FunSuite with SharedH2OTestContext {
   override def createSparkContext: SparkContext = new SparkContext("local[*]", "test-local",
-    conf = defaultSparkConf
-      .set("spark.ext.h2o.rest.api.based.client", "true"))
+    conf = defaultSparkConf.set(H2OClientUtils.PROP_SCALA_H2O_CLIENT_BASED._1, "false"))
 
   private def uploadH2OFrame(): H2OFrame = {
     // since we did not ask Spark to infer schema, all columns have been parsed as Strings

--- a/core/src/test/scala/org/apache/spark/h2o/ConfigurationPropertiesTestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/h2o/ConfigurationPropertiesTestSuite.scala
@@ -21,6 +21,7 @@ import java.net.{HttpURLConnection, URL}
 import java.nio.file.{Files, Path}
 import java.security.Permission
 
+import ai.h2o.sparkling.backend.utils.H2OClientUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.h2o.utils.{SparkTestContext, TestFrameUtils}
 import org.apache.spark.sql.SparkSession
@@ -191,7 +192,7 @@ abstract class ConfigurationPropertiesTestSuite_ExternalCommunicationCompression
     test(s"Convert dataset from Spark to H2O and back with $compressionType compression") {
       val h2oConf = new H2OConf()
       h2oConf.setExternalCommunicationCompression(compressionType)
-      h2oConf.set("spark.ext.h2o.rest.api.based.client", "true")
+      h2oConf.set(H2OClientUtils.PROP_SCALA_H2O_CLIENT_BASED._1, "false")
       h2oConf.setClusterSize(1)
       hc = H2OContext.getOrCreate(h2oConf)
       val dataset = spark.read

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -89,7 +89,7 @@ class H2OContext(object):
             selected_conf = conf
         else:
             selected_conf = H2OConf()
-        selected_conf.set("spark.ext.h2o.rest.api.based.client", "true")
+        selected_conf.set("spark.ext.h2o.scala.api.client.based", "false")
 
         h2o_context = H2OContext()
 

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -48,7 +48,7 @@ H2OContext.getOrCreate <- function(sc = NULL, conf = NULL) {
   } else if (is.null(conf)) {
     conf <- H2OConf()
   }
-  conf$set("spark.ext.h2o.rest.api.based.client", "true")
+  conf$set("spark.ext.h2o.scala.api.client.based", "false")
 
   sc <- spark_connection_find()[[1]]
   jhc <- invoke_static(sc, "org.apache.spark.h2o.H2OContext", "getOrCreate", conf$jconf)


### PR DESCRIPTION
As R/Py ( the majority)clients are rest api based, I propose moving the option to H2OClientUtils. We are moving to rest api as standard, so I think it makes sense to capture the second case as exception instead of otherwise