### PR TITLE
[SW-2126] Fix deprecation warning about duplicate paths in because of overwriting scala-editor.css file in Sparkling Water

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,6 +18,7 @@ sourceSets {
 }
 
 jar {
+    duplicatesStrategy = 'include'
     eachFile { f ->
         if (new File(cssResources, f.file.name).exists()) {
             f.path = "www/flow/css/$f.name"


### PR DESCRIPTION
Last minor fix before going to bed :)