### PR TITLE
[SW-2139] Deprecate ModelSerializationSupport

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/package.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/package.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark
 
-import hex.Model
 import org.apache.spark.sql._
 
 /** Type shortcuts to simplify work in Sparkling REPL */
@@ -32,8 +31,6 @@ package object h2o {
   type RDD[X] = org.apache.spark.rdd.RDD[X]
 
   type Dataset[X] = org.apache.spark.sql.Dataset[X]
-
-  type H2OBaseModel = Model[_, _ <: Model.Parameters, _ <: Model.Output]
 
   /**
     * Adds a method, `h2o`, to DataFrameWriter that allows you to write h2o frames using

--- a/core/src/main/scala/water/support/ModelMetricsSupport.scala
+++ b/core/src/main/scala/water/support/ModelMetricsSupport.scala
@@ -28,8 +28,6 @@ import water.fvec.Frame
 @Deprecated
 trait ModelMetricsSupport extends Logging {
 
-  type H2OBaseModel = Model[_, _ <: Model.Parameters, _ <: Model.Output]
-
   /** Helper class to have nice API. The purpose of this class is to fetch model metrics from the specified model */
   @Deprecated
   class ModelMetricsExtractor[T <: ModelMetrics] {

--- a/core/src/main/scala/water/support/ModelMetricsSupport.scala
+++ b/core/src/main/scala/water/support/ModelMetricsSupport.scala
@@ -28,6 +28,8 @@ import water.fvec.Frame
 @Deprecated
 trait ModelMetricsSupport extends Logging {
 
+  type H2OBaseModel = Model[_, _ <: Model.Parameters, _ <: Model.Output]
+
   /** Helper class to have nice API. The purpose of this class is to fetch model metrics from the specified model */
   @Deprecated
   class ModelMetricsExtractor[T <: ModelMetrics] {

--- a/core/src/main/scala/water/support/ModelSerializationSupport.scala
+++ b/core/src/main/scala/water/support/ModelSerializationSupport.scala
@@ -19,8 +19,10 @@ package water.support
 import java.io._
 import java.net.URI
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import hex.Model
 import hex.genmodel.{ModelMojoReader, MojoModel, MojoReaderBackendFactory}
+import org.apache.spark.expose.Logging
 import org.apache.spark.h2o.H2OBaseModel
 import water.H2O
 import water.persist.Persist
@@ -28,7 +30,8 @@ import water.persist.Persist
 /**
   * Helper trait containing methods to export and import models from and to Sparkling Water
   */
-trait ModelSerializationSupport {
+@Deprecated
+trait ModelSerializationSupport extends Logging {
 
   /**
     * Export binary model to specified directory
@@ -38,6 +41,7 @@ trait ModelSerializationSupport {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it as model.write.save.")
   def exportH2OModel(model: H2OBaseModel, destination: URI, force: Boolean = false): URI = {
     model.exportBinaryModel(destination.toString, force)
     destination
@@ -51,6 +55,7 @@ trait ModelSerializationSupport {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it as model.write.save.")
   def exportH2OModel(model: H2OBaseModel, destination: String, force: Boolean): String = {
     exportH2OModel(model, new URI(destination), force).toString
   }
@@ -62,6 +67,7 @@ trait ModelSerializationSupport {
     * @tparam M Model Type
     * @return imported model
     */
+  @DeprecatedMethod("Export the model as mojo and read it using H2OMOJOModel.createFromMojo")
   def loadH2OModel[M <: H2OBaseModel](source: URI): M = {
     Model.importBinaryModel[M](source.toString)
   }
@@ -73,6 +79,7 @@ trait ModelSerializationSupport {
     * @tparam M Model Type
     * @return imported model
     */
+  @DeprecatedMethod("Export the model as mojo and read it using H2OMOJOModel.createFromMojo")
   def loadH2OModel[M <: H2OBaseModel](source: String): M = {
     Model.importBinaryModel[M](source)
   }
@@ -85,6 +92,7 @@ trait ModelSerializationSupport {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
+  @DeprecatedMethod("POJOs are no longer supported in Sparkling Water. Please use MOJOs.")
   def exportPOJOModel(model: H2OBaseModel, destination: URI, force: Boolean = false): URI = {
     val p: Persist = H2O.getPM.getPersistForURI(destination)
     val os: OutputStream = p.create(destination.toString, force)
@@ -102,6 +110,7 @@ trait ModelSerializationSupport {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
+  @DeprecatedMethod("POJOs are no longer supported in Sparkling Water. Please use MOJOs.")
   def exportPOJOModel(model: H2OBaseModel, destination: String, force: Boolean): String = {
     exportPOJOModel(model, new URI(destination), force).toString
   }
@@ -114,6 +123,7 @@ trait ModelSerializationSupport {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it as model.write.save.")
   def exportMOJOModel(model: H2OBaseModel, destination: URI, force: Boolean = false): URI = {
     model.exportMojo(destination.toString, force)
     destination
@@ -127,6 +137,7 @@ trait ModelSerializationSupport {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it as model.write.save.")
   def exportMOJOModel(model: H2OBaseModel, destination: String, force: Boolean): String = {
     exportMOJOModel(model, new URI(destination), force).toString
   }
@@ -137,11 +148,13 @@ trait ModelSerializationSupport {
     * @param source source URI
     * @return H2O's Mojo model
     */
+  @DeprecatedMethod("H2OMOJOModel.createFromMojo")
   def loadMOJOModel(source: URI): MojoModel = {
     hex.genmodel.MojoModel.load(source.getPath)
   }
 }
 
+@Deprecated
 object ModelSerializationSupport extends ModelSerializationSupport {
 
   /**
@@ -150,6 +163,7 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get MOJO from
     * @return tuple containing MOJO model and binary bytes representing the MOJO
     */
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API which provides you with the MOJO model.")
   def getMojo(model: H2OBaseModel): (MojoModel, Array[Byte]) = {
     val mojoData = getMojoData(model)
     val bais = new ByteArrayInputStream(mojoData)
@@ -163,6 +177,7 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get MOJO from
     * @return MOJO model
     */
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API which provides you with the MOJO model.")
   def getMojoModel(model: H2OBaseModel): MojoModel = {
     val mojoData = getMojoData(model)
     val bais = new ByteArrayInputStream(mojoData)
@@ -176,6 +191,7 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param mojoData data representing the MOJO model
     * @return MOJO model
     */
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API which provides you with the MOJO model.")
   def getMojoModel(mojoData: Array[Byte]): MojoModel = {
     val is = new ByteArrayInputStream(mojoData)
     val reader = MojoReaderBackendFactory.createReaderBackend(is, MojoReaderBackendFactory.CachingStrategy.MEMORY)
@@ -188,6 +204,7 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get the binary representation of a MOJO from
     * @return byte array representing the MOJO
     */
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API which provides you with the MOJO model.")
   def getMojoData(model: H2OBaseModel): Array[Byte] = {
     val baos = new ByteArrayOutputStream()
     model.getMojo.writeTo(baos)

--- a/core/src/main/scala/water/support/ModelSerializationSupport.scala
+++ b/core/src/main/scala/water/support/ModelSerializationSupport.scala
@@ -164,8 +164,8 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get MOJO from
     * @return tuple containing MOJO model and binary bytes representing the MOJO
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API which provides you with the MOJO model.")
-  def getMojo(model: H2OBaseModel): (MojoModel, Array[Byte]) = {
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
+    " produces the MOJO model.")  def getMojo(model: H2OBaseModel): (MojoModel, Array[Byte]) = {
     val mojoData = getMojoData(model)
     val bais = new ByteArrayInputStream(mojoData)
     val reader = MojoReaderBackendFactory.createReaderBackend(bais, MojoReaderBackendFactory.CachingStrategy.MEMORY)
@@ -178,8 +178,8 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get MOJO from
     * @return MOJO model
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API which provides you with the MOJO model.")
-  def getMojoModel(model: H2OBaseModel): MojoModel = {
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
+    " produces the MOJO model.")  def getMojoModel(model: H2OBaseModel): MojoModel = {
     val mojoData = getMojoData(model)
     val bais = new ByteArrayInputStream(mojoData)
     val reader = MojoReaderBackendFactory.createReaderBackend(bais, MojoReaderBackendFactory.CachingStrategy.MEMORY)
@@ -192,8 +192,8 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param mojoData data representing the MOJO model
     * @return MOJO model
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API which provides you with the MOJO model.")
-  def getMojoModel(mojoData: Array[Byte]): MojoModel = {
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
+    " produces the MOJO model.")  def getMojoModel(mojoData: Array[Byte]): MojoModel = {
     val is = new ByteArrayInputStream(mojoData)
     val reader = MojoReaderBackendFactory.createReaderBackend(is, MojoReaderBackendFactory.CachingStrategy.MEMORY)
     ModelMojoReader.readFrom(reader)
@@ -205,7 +205,8 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get the binary representation of a MOJO from
     * @return byte array representing the MOJO
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API which provides you with the MOJO model.")
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
+    " produces the MOJO model.")
   def getMojoData(model: H2OBaseModel): Array[Byte] = {
     val baos = new ByteArrayOutputStream()
     model.getMojo.writeTo(baos)

--- a/core/src/main/scala/water/support/ModelSerializationSupport.scala
+++ b/core/src/main/scala/water/support/ModelSerializationSupport.scala
@@ -41,7 +41,7 @@ trait ModelSerializationSupport extends Logging {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it as model.write.save.")
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it using model.write.save.")
   def exportH2OModel(model: H2OBaseModel, destination: URI, force: Boolean = false): URI = {
     model.exportBinaryModel(destination.toString, force)
     destination
@@ -55,7 +55,7 @@ trait ModelSerializationSupport extends Logging {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it as model.write.save.")
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it using model.write.save.")
   def exportH2OModel(model: H2OBaseModel, destination: String, force: Boolean): String = {
     exportH2OModel(model, new URI(destination), force).toString
   }
@@ -123,7 +123,7 @@ trait ModelSerializationSupport extends Logging {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it as model.write.save.")
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it using model.write.save.")
   def exportMOJOModel(model: H2OBaseModel, destination: URI, force: Boolean = false): URI = {
     model.exportMojo(destination.toString, force)
     destination
@@ -137,7 +137,7 @@ trait ModelSerializationSupport extends Logging {
     * @param force       override the model if it already exist in the destination URI
     * @return destination URI
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it as model.write.save.")
+  @DeprecatedMethod("Train algorithm using the Sparkling Water API and export it using model.write.save.")
   def exportMOJOModel(model: H2OBaseModel, destination: String, force: Boolean): String = {
     exportMOJOModel(model, new URI(destination), force).toString
   }

--- a/core/src/main/scala/water/support/ModelSerializationSupport.scala
+++ b/core/src/main/scala/water/support/ModelSerializationSupport.scala
@@ -23,7 +23,6 @@ import ai.h2o.sparkling.macros.DeprecatedMethod
 import hex.Model
 import hex.genmodel.{ModelMojoReader, MojoModel, MojoReaderBackendFactory}
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.H2OBaseModel
 import water.H2O
 import water.persist.Persist
 
@@ -32,6 +31,8 @@ import water.persist.Persist
   */
 @Deprecated
 trait ModelSerializationSupport extends Logging {
+
+  type H2OBaseModel = Model[_, _ <: Model.Parameters, _ <: Model.Output]
 
   /**
     * Export binary model to specified directory

--- a/core/src/main/scala/water/support/ModelSerializationSupport.scala
+++ b/core/src/main/scala/water/support/ModelSerializationSupport.scala
@@ -164,8 +164,10 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get MOJO from
     * @return tuple containing MOJO model and binary bytes representing the MOJO
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
-    " produces the MOJO model.")  def getMojo(model: H2OBaseModel): (MojoModel, Array[Byte]) = {
+  @DeprecatedMethod(
+    "Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
+      " produces the MOJO model.")
+  def getMojo(model: H2OBaseModel): (MojoModel, Array[Byte]) = {
     val mojoData = getMojoData(model)
     val bais = new ByteArrayInputStream(mojoData)
     val reader = MojoReaderBackendFactory.createReaderBackend(bais, MojoReaderBackendFactory.CachingStrategy.MEMORY)
@@ -178,8 +180,10 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get MOJO from
     * @return MOJO model
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
-    " produces the MOJO model.")  def getMojoModel(model: H2OBaseModel): MojoModel = {
+  @DeprecatedMethod(
+    "Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
+      " produces the MOJO model.")
+  def getMojoModel(model: H2OBaseModel): MojoModel = {
     val mojoData = getMojoData(model)
     val bais = new ByteArrayInputStream(mojoData)
     val reader = MojoReaderBackendFactory.createReaderBackend(bais, MojoReaderBackendFactory.CachingStrategy.MEMORY)
@@ -192,8 +196,10 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param mojoData data representing the MOJO model
     * @return MOJO model
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
-    " produces the MOJO model.")  def getMojoModel(mojoData: Array[Byte]): MojoModel = {
+  @DeprecatedMethod(
+    "Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
+      " produces the MOJO model.")
+  def getMojoModel(mojoData: Array[Byte]): MojoModel = {
     val is = new ByteArrayInputStream(mojoData)
     val reader = MojoReaderBackendFactory.createReaderBackend(is, MojoReaderBackendFactory.CachingStrategy.MEMORY)
     ModelMojoReader.readFrom(reader)
@@ -205,8 +211,9 @@ object ModelSerializationSupport extends ModelSerializationSupport {
     * @param model model to get the binary representation of a MOJO from
     * @return byte array representing the MOJO
     */
-  @DeprecatedMethod("Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
-    " produces the MOJO model.")
+  @DeprecatedMethod(
+    "Train algorithm using the Sparkling Water API. The output model for the fitted algorithm" +
+      " produces the MOJO model.")
   def getMojoData(model: H2OBaseModel): Array[Byte] = {
     val baos = new ByteArrayOutputStream()
     model.getMojo.writeTo(baos)

--- a/doc/src/site/sphinx/deployment/load_mojo.rst
+++ b/doc/src/site/sphinx/deployment/load_mojo.rst
@@ -1,5 +1,5 @@
-Importing H2O MOJOs
--------------------
+Importing H2O MOJOs from H2O-3
+------------------------------
 
 H2O MOJOs can be imported to Sparkling Water from all data sources supported by Apache Spark such as local file, S3 or HDFS and the
 semantics of the import is the same as in the Spark API.
@@ -222,16 +222,16 @@ call the ``createFromMojo`` method on the specific MOJO model type.
     val specificModel = H2OTreeBasedSupervisedMOJOModel.createFromMojo("prostate_mojo.zip")
     println(s"Ntrees: ${specificModel.getNTrees()}") // Relevant only to GBM, DRF and XGBoost
 
-Exporting the trained MOJO model
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Exporting the loaded MOJO model using Sparkling Water
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To export the trained MOJO model, call ``model.write.save(path)``. In case of Hadoop enabled system, the command by default
+To export the MOJO model, call ``model.write.save(path)``. In case of Hadoop enabled system, the command by default
 uses HDFS.
 
-Importing the trained MOJO model
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Importing the previously exported MOJO model from Sparkling Water
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To import the trained MOJO model, call ``H2OMOJOModel.read.load(path)``. In case of Hadoop enabled system, the command by default
+To import the MOJO model, call ``H2OMOJOModel.read.load(path)``. In case of Hadoop enabled system, the command by default
 uses HDFS.
 
 Methods available on MOJO Model

--- a/doc/src/site/sphinx/deployment/load_mojo.rst
+++ b/doc/src/site/sphinx/deployment/load_mojo.rst
@@ -222,6 +222,18 @@ call the ``createFromMojo`` method on the specific MOJO model type.
     val specificModel = H2OTreeBasedSupervisedMOJOModel.createFromMojo("prostate_mojo.zip")
     println(s"Ntrees: ${specificModel.getNTrees()}") // Relevant only to GBM, DRF and XGBoost
 
+Exporting the trained MOJO model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To export the trained MOJO model, call ``model.write.save(path)``. In case of Hadoop enabled system, the command by default
+uses HDFS.
+
+Importing the trained MOJO model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To import the trained MOJO model, call ``H2OMOJOModel.read.load(path)``. In case of Hadoop enabled system, the command by default
+uses HDFS.
+
 Methods available on MOJO Model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -47,6 +47,40 @@ From 3.30 to 3.32
   than 0, validation metrics if validation frame has been specified ( splitRatio was set and lower than 1 ) and nfolds was 0
   and training metrics otherwise ( splitRatio is 1 and nfolds is 0).
 
+- The whole trait ``ModelSerializationSupport`` in Scala is removed. The MOJO is a first class citizen in Sparkling Water and
+  most code works with our Spark MOJO wrapper. Please use the following approaches to migrate from previous methods
+  in the model serialization support:
+
+    To crete Spark MOJO wrapper in Sparkling Water, you can load it from H2O-3 as:
+
+    .. code-block:: scala
+
+        val mojoModel = H2OMOJOModel.createFromMojo(path)
+
+    or train model using Sparkling Water API, such as
+
+    .. code-block:: scala
+
+        val gbm = H2OGBM().setLabelCol("label")
+        val mojoModel = gbm.fit(data)
+
+    In this case the ``mojoModel`` is Spark wrapper around the H2O's mojo providing Spark friendly API. This also
+    means that the such model can be embedded into Spark pipelines without any additional work.
+
+    To export it as, please call:
+
+        .. code-block:: scala
+
+            mojoModel.write.save("path")
+
+    The advantage is that this variant is H2O-version independent and when such model is loaded, H2O run-time is not required.
+
+    You can load the exported model from Sparkling Water as:
+
+    .. code-block:: scala
+
+        val mojoModel = H2OMOJOModel.read.load("path")
+
 
 From 3.28.1 to 3.30
 -------------------

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -69,9 +69,9 @@ From 3.30 to 3.32
 
     To export it as, please call:
 
-        .. code-block:: scala
+    .. code-block:: scala
 
-            mojoModel.write.save("path")
+        mojoModel.write.save("path")
 
     The advantage is that this variant is H2O-version independent and when such model is loaded, H2O run-time is not required.
 

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -51,7 +51,7 @@ From 3.30 to 3.32
   most code works with our Spark MOJO wrapper. Please use the following approaches to migrate from previous methods
   in the model serialization support:
 
-    To crete Spark MOJO wrapper in Sparkling Water, you can load it from H2O-3 as:
+    To create Spark MOJO wrapper in Sparkling Water, you can load it from H2O-3 as:
 
     .. code-block:: scala
 
@@ -80,6 +80,9 @@ From 3.30 to 3.32
     .. code-block:: scala
 
         val mojoModel = H2OMOJOModel.read.load("path")
+
+    For additional information about how to load MOJO into Sparkling Water, please see
+    `Loading MOJOs into Sparkling Water <http://docs.h2o.ai/sparkling-water/2.2/latest-stable/doc/deployment/load_mojo.html>`_.
 
 
 From 3.28.1 to 3.30

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
@@ -112,10 +112,11 @@ class H2OAutoML(override val uid: String)
     amlKeyOption = Some(autoMLId)
     val model = H2OModel(getLeaderModelId(autoMLId))
     val mojoData = model.downloadMojoData()
+    val algoName = getLeaderboard().select("model_id").head().getString(0)
     val modelSettings = H2OMOJOSettings.createFromModelParams(this)
     H2OMOJOModel.createFromMojo(
       mojoData,
-      Identifiable.randomUID(ModelSerializationSupport.getMojoModel(mojoData)._algoName),
+      Identifiable.randomUID(algoName),
       modelSettings,
       internalFeatureCols)
   }

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
@@ -114,11 +114,7 @@ class H2OAutoML(override val uid: String)
     val mojoData = model.downloadMojoData()
     val algoName = getLeaderboard().select("model_id").head().getString(0)
     val modelSettings = H2OMOJOSettings.createFromModelParams(this)
-    H2OMOJOModel.createFromMojo(
-      mojoData,
-      Identifiable.randomUID(algoName),
-      modelSettings,
-      internalFeatureCols)
+    H2OMOJOModel.createFromMojo(mojoData, Identifiable.randomUID(algoName), modelSettings, internalFeatureCols)
   }
 
   private def determineIncludedAlgos(): Array[String] = {


### PR DESCRIPTION
This was last support class in SW which is somehow referencing client