### PR TITLE
[SW-2144] Don't setup dependency on pyspark & numpy

### DIFF
--- a/doc/src/site/sphinx/pysparkling.rst
+++ b/doc/src/site/sphinx/pysparkling.rst
@@ -73,7 +73,8 @@ Dependencies
 
 Supported Python versions are Python 2.7 or Python 3+.
 
-In order to use PySparkling, it requires the following runtime python dependencies to be available on the system, all of which are available on PyPI:
+The major dependency is Spark. Please make sure that your Python environment has functional Spark with all its
+dependencies.
 
 .. code-block:: bash
 
@@ -81,9 +82,8 @@ In order to use PySparkling, it requires the following runtime python dependenci
   $ pip install tabulate
   $ pip install future
   $ pip install colorama>=0.3.8
-  $ pip install numpy>=1.9.2
 
-The required packages are installed automatically in case when PySparkling is installed from PyPI.
+These dependencies are installed automatically in case PySparkling is installed from PyPI.
 
 
 The Sparkling Water Python Module

--- a/py/src/setup.py
+++ b/py/src/setup.py
@@ -47,9 +47,7 @@ setup(
         'requests',
         'tabulate',
         'future',
-        'colorama>=0.3.8',
-        'numpy>=1.9.2',
-        'pyspark>=SUBST_SPARK_MAJOR_VERSION.0,<=SUBST_SPARK_VERSION'],
+        'colorama>=0.3.8'],
 
     # bundled binary packages
     package_data={'sparkling_water': ['*.jar'],


### PR DESCRIPTION
I'm limiting this change to minimum. 

We could also remove the test dependency on pyspark in py/build.gradle and use the already downloaded spark distribution, but that just improves tests and would require new docker image. Will do that in another PR.

For more info please see the jira