### PR TITLE
[SW-2170] Update description of spark.ext.h2o.external.cluster.size in SW Documentation

### DIFF
--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -298,11 +298,9 @@ External backend configuration properties
 | ``spark.ext.h2o.cloud.representative``                | ``None``       | ``setH2OCluster(String)``                       | ip:port of arbitrary H2O node to    |
 |                                                       |                |                                                 | identify external H2O cluster.      |
 +-------------------------------------------------------+----------------+-------------------------------------------------+-------------------------------------+
-| ``spark.ext.h2o.external.cluster.size``               | ``None``       | ``setClusterSize(Integer)``                     | Number of H2O nodes to start in     |
-|                                                       |                |                                                 | ``auto`` mode and wait for in       |
-|                                                       |                |                                                 | ``manual`` mode when starting       |
-|                                                       |                |                                                 | Sparkling Water in external H2O     |
-|                                                       |                |                                                 | cluster mode.                       |
+| ``spark.ext.h2o.external.cluster.size``               | ``None``       | ``setClusterSize(Integer)``                     | Number of H2O nodes to start when   |
+|                                                       |                |                                                 | ``auto`` mode of the external       |
+|                                                       |                |                                                 | backend is set.                     |
 +-------------------------------------------------------+----------------+-------------------------------------------------+-------------------------------------+
 | ``spark.ext.h2o.cluster.start.timeout``               | ``120s``       | ``setClusterStartTimeout(Integer)``             | Timeout in seconds for starting     |
 |                                                       |                |                                                 | H2O external cluster.               |

--- a/doc/src/site/sphinx/deployment/backends.rst
+++ b/doc/src/site/sphinx/deployment/backends.rst
@@ -211,7 +211,6 @@ To connect to this external cluster, run the following commands:
                         .setExternalClusterMode()
                         .useManualClusterStart()
                         .setH2OCluster("representant_ip", representant_port)
-                        .setClusterSize(3)
                         .setCloudName("test")
             val hc = H2OContext.getOrCreate(conf)
 
@@ -226,7 +225,6 @@ To connect to this external cluster, run the following commands:
                     .setExternalClusterMode()
                     .useManualClusterStart()
                     .setH2OCluster("representant_ip", representant_port)
-                    .setClusterSize(3)
                     .setCloudName("test")
             hc = H2OContext.getOrCreate(conf)
 


### PR DESCRIPTION
It seems that this property is only relevant to the external backend with the automatic start.