### PR TITLE
[SW-2177] Context Path is Erased From Rest Calls

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
@@ -194,8 +194,10 @@ trait RestCommunication extends Logging with RestEncodingUtils {
   private def urlToString(url: URL) = s"${url.getHost}:${url.getPort}"
 
   private def resolveUrl(endpoint: URI, suffix: String): URL = {
-    val suffixWithDelimiter = if (suffix.startsWith("/")) suffix else s"/$suffix"
-    endpoint.resolve(suffixWithDelimiter).toURL
+    val endpointAsString = endpoint.toString
+    val endpointWithDelimiter = if (endpointAsString.endsWith("/")) endpointAsString else endpointAsString + "/"
+    val suffixWithoutDelimiter = suffix.stripPrefix("/")
+    new URI(endpointWithDelimiter).resolve(suffixWithoutDelimiter).toURL
   }
 
   private def setHeaders(


### PR DESCRIPTION
Calls like:
```
scala> val uri = new URI("http://127.0.0.1/mypath/")
scala> val url = uri.resolve("/3/CloudLock").toURL
url: java.net.URL = http://127.0.0.1/3/CloudLock
```
or
```
scala> val uri = new URI("http://127.0.0.1/mypath")
scala> val url = uri.resolve("3/CloudLock").toURL
url: java.net.URL = http://127.0.0.1/3/CloudLock
```
cause unwanted behavior.

The proposed solution tries to enforce the below case under all circumstances:
```
scala> val uri = new URI("http://127.0.0.1/mypath/")
scala> val url = uri.resolve("3/CloudLock").toURL
url: java.net.URL = http://127.0.0.1/mypath/3/CloudLock
```  
