### PR TITLE
[SW-2174] Don't do version check in case user is using databricks-connect

### DIFF
--- a/py/src/ai/h2o/sparkling/Initializer.py
+++ b/py/src/ai/h2o/sparkling/Initializer.py
@@ -193,6 +193,16 @@ class Initializer(object):
             loader = loader.getParent()
 
     @staticmethod
+    def isRunningViaDBCConnect():
+        import pkg_resources as pkg
+        try:
+            pkg.get_distribution('databricks-connect')
+            return True
+        except:
+            return False
+
+
+    @staticmethod
     def getVersion():
         here = path.abspath(path.dirname(__file__))
         if '.zip' in here:
@@ -208,7 +218,7 @@ class Initializer(object):
         sparkVersionFromPySparkling = pySparklingVersionComponents.sparkMajorMinorVersion
         sparkVersionFromPySpark = pySparkVersionComponents.sparkMajorMinorVersion
 
-        if not (sparkVersionFromPySpark == sparkVersionFromPySparkling):
+        if not Initializer.isRunningViaDBCConnect() and not (sparkVersionFromPySpark == sparkVersionFromPySparkling):
             raise Exception("""
             You are using PySparkling for Spark {}, but your PySpark is of version {}.
             Please make sure Spark and PySparkling versions are compatible.""".format(

--- a/py/src/ai/h2o/sparkling/Initializer.py
+++ b/py/src/ai/h2o/sparkling/Initializer.py
@@ -201,7 +201,6 @@ class Initializer(object):
         except:
             return False
 
-
     @staticmethod
     def getVersion():
         here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
In this case the pyspark version is actually version of databricks runtime.

According to DBC docs pyspark needs to be uninstalled and databricks-connect library installed ( which installs pyspark with the incompatible version) -> so we should not see any collisions for existing users