### PR TITLE
[SW-2178] Reflect changes in log class on H2O side

### DIFF
--- a/core/src/main/scala/water/util/LogBridge.scala
+++ b/core/src/main/scala/water/util/LogBridge.scala
@@ -27,7 +27,7 @@ object LogBridge {
     * @param levelIdx log level specified by the index.
     */
   def setH2OLogLevel(levelIdx: Int): Unit = {
-    water.util.Log._level = levelIdx
+    water.util.Log.setLogLevel(water.util.Log.LVLS(levelIdx))
   }
 
   /**
@@ -35,5 +35,5 @@ object LogBridge {
     *
     * @return index of the log level
     */
-  def getH2OLogLevel() = water.util.Log._level
+  def getH2OLogLevel() = water.util.Log.getLogLevel
 }


### PR DESCRIPTION
`_level` became private in H2O.

I plan to replace the internal functionality by rest api in 3.32, but in the meanwhile created this PR to ensure master tests are green