### PR TITLE
[SW-2168] The AWS java sdk s3 in SW throws the exception: java.lang.IllegalStateException: Socket not created by this factory.

### DIFF
--- a/assembly/build.gradle
+++ b/assembly/build.gradle
@@ -61,6 +61,7 @@ shadowJar {
   relocate 'org.eclipse.jetty.orbit', 'ai.h2o.org.eclipse.jetty.orbit'
   relocate 'scala.compat.java8', 'ai.h2o.scala.compat.java8'
   relocate 'scala.concurrent.java8', 'ai.h2o.scala.concurrent.java8'
+  relocate 'com.amazonaws', 'ai.h2o.com.amazonaws'
   from "$project.buildDir/reports/" include '**/*'
   exclude 'www/flow/packs/test-*/**'
 


### PR DESCRIPTION
We should shadow the AWS libraries used in SW