### PR TITLE
[SW-2044] Introduce method asSparkFrame on H2OContext.scala and deprecate asDataFrame

### DIFF
--- a/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/H2OFrameToDataFrameConversionBenchmark.scala
+++ b/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/H2OFrameToDataFrameConversionBenchmark.scala
@@ -23,5 +23,5 @@ class H2OFrameToDataFrameConversionBenchmark(context: BenchmarkContext) extends 
 
   override protected def initialize(): H2OFrame = loadDataToH2OFrame()
 
-  override protected def body(frame: H2OFrame): Unit = context.hc.asDataFrame(frame).foreach(_ => {})
+  override protected def body(frame: H2OFrame): Unit = context.hc.asSparkFrame(frame).foreach(_ => {})
 }

--- a/core/src/integTest/scala/ai/h2o/sparkling/IntegrationTestSuite.scala
+++ b/core/src/integTest/scala/ai/h2o/sparkling/IntegrationTestSuite.scala
@@ -43,7 +43,7 @@ class IntegrationTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.anyVec().nChunks() == 2)
     val updatedFrame = h2oFrame.add(h2oFrame)
 
-    val convertedDf = hc.asDataFrame(updatedFrame)
+    val convertedDf = hc.asSparkFrame(updatedFrame)
     convertedDf.collect()
 
     assert(convertedDf.count() == h2oFrame.numRows())

--- a/core/src/integTest/scala/ai/h2o/sparkling/internal/H2OContextConversionOnSubsetExecutors.scala
+++ b/core/src/integTest/scala/ai/h2o/sparkling/internal/H2OContextConversionOnSubsetExecutors.scala
@@ -48,12 +48,12 @@ class H2OContextConversionOnSubsetExecutors extends FunSuite with SharedH2OTestC
     h2oFrame.delete()
   }
 
-  test("asDataFrame conversion on subset of executors") {
+  test("asSparkFrame conversion on subset of executors") {
     assert(hc.getH2ONodes().length == 1)
     val originalRdd = sc.parallelize(1 to 1000, 100).map(v => Some(v))
     val hf = hc.asH2OFrame(originalRdd)
 
-    val convertedDf = hc.asDataFrame(hf)
+    val convertedDf = hc.asSparkFrame(hf)
     import spark.implicits._
     TestUtils.assertDataFramesAreIdentical(originalRdd.toDF, convertedDf.toDF())
   }

--- a/core/src/main/scala/ai/h2o/sparkling/H2OFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OFrame.scala
@@ -148,8 +148,8 @@ class H2OFrame private (
 
   private def joinUsingSpark(another: H2OFrame, method: String): H2OFrame = {
     val hc = H2OContext.ensure()
-    val currentFrame = hc.asDataFrame(this.frameId)
-    val anotherFrame = hc.asDataFrame(another.frameId)
+    val currentFrame = hc.asSparkFrame(this.frameId)
+    val anotherFrame = hc.asSparkFrame(another.frameId)
     val sameCols = anotherFrame.columns.intersect(currentFrame.columns)
     val joined = currentFrame.join(anotherFrame, sameCols, method)
     H2OFrame(hc.asH2OFrameKeyString(joined))

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/h2oframes/H2OFramesHandler.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/h2oframes/H2OFramesHandler.scala
@@ -43,7 +43,7 @@ class H2OFramesHandler(val sc: SparkContext, val h2oContext: H2OContext) extends
       case name if name.equals(classOf[H2OFrame].getName) => value.get[H2OFrame]()
     }
 
-    val dataFrame = h2oContext.asDataFrame(h2oFrame)
+    val dataFrame = h2oContext.asSparkFrame(h2oFrame)
     dataFrame.rdd.cache()
     if (s.dataframe_id == null) {
       s.dataframe_id = "df_" + dataFrame.rdd.id.toString

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -24,6 +24,7 @@ import ai.h2o.sparkling.backend.converters.{DatasetConverter, SparkDataFrameConv
 import ai.h2o.sparkling.backend.exceptions.{H2OClusterNotReachableException, RestApiException}
 import ai.h2o.sparkling.backend.external._
 import ai.h2o.sparkling.backend.utils._
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.h2o.backends.internal.InternalH2OBackend
 import org.apache.spark.h2o.ui._
@@ -239,17 +240,25 @@ class H2OContext private (private val conf: H2OConf) extends H2OContextExtension
     SupportedRDDConverter.toRDD[A](this, fr)
   }
 
-  /** Convert given H2O frame into DataFrame type */
-  def asDataFrame[T <: Frame](fr: T, copyMetadata: Boolean = true): DataFrame = {
+  @DeprecatedMethod("asSparkFrame", "3.32")
+  def asDataFrame[T <: Frame](fr: T, copyMetadata: Boolean = true): DataFrame = asSparkFrame(fr, copyMetadata)
+
+  def asSparkFrame[T <: Frame](fr: T, copyMetadata: Boolean = true): DataFrame = {
     SparkDataFrameConverter.toDataFrame(this, fr, copyMetadata)
   }
 
-  def asDataFrame(s: String, copyMetadata: Boolean): DataFrame = {
+  @DeprecatedMethod("asSparkFrame", "3.32")
+  def asDataFrame(s: String, copyMetadata: Boolean): DataFrame = asSparkFrame(s, copyMetadata)
+
+  def asSparkFrame(s: String, copyMetadata: Boolean): DataFrame = {
     val frame = ai.h2o.sparkling.H2OFrame(s)
     SparkDataFrameConverter.toDataFrame(this, frame, copyMetadata)
   }
 
-  def asDataFrame(s: String): DataFrame = asDataFrame(s, true)
+  @DeprecatedMethod("asSparkFrame", "3.32")
+  def asDataFrame(s: String): DataFrame = asSparkFrame(s)
+
+  def asSparkFrame(s: String): DataFrame = asSparkFrame(s, copyMetadata = true)
 
   /** Returns location of REST API of H2O client */
   def h2oLocalClient = leaderNode.hostname + ":" + leaderNode.port + conf.contextPath.getOrElse("")

--- a/core/src/main/scala/org/apache/spark/h2o/JavaH2OContext.java
+++ b/core/src/main/scala/org/apache/spark/h2o/JavaH2OContext.java
@@ -126,7 +126,12 @@ public class JavaH2OContext {
    * @return a new RDD
    */
   public JavaRDD<Row> asRDD(H2OFrame fr) {
-    return hc.asDataFrame(fr, true).toJavaRDD();
+    return hc.asSparkFrame(fr, true).toJavaRDD();
+  }
+
+  @Deprecated
+  public Dataset<Row> asDataFrame(Frame fr) {
+    return asSparkFrame(fr);
   }
 
   /**
@@ -135,8 +140,13 @@ public class JavaH2OContext {
    * @param fr the frame to be used
    * @return a new data frame
    */
-  public Dataset<Row> asDataFrame(Frame fr) {
-    return asDataFrame(fr, true);
+  public Dataset<Row> asSparkFrame(Frame fr) {
+    return asSparkFrame(fr, true);
+  }
+
+  @Deprecated
+  public Dataset<Row> asDataFrame(Frame fr, boolean copyMetadata) {
+    return asSparkFrame(fr, copyMetadata);
   }
 
   /**
@@ -146,8 +156,13 @@ public class JavaH2OContext {
    * @param copyMetadata true if metadata should be copied
    * @return Spark dataset
    */
-  public Dataset<Row> asDataFrame(Frame fr, boolean copyMetadata) {
-    return hc.asDataFrame(fr, copyMetadata);
+  public Dataset<Row> asSparkFrame(Frame fr, boolean copyMetadata) {
+    return hc.asSparkFrame(fr, copyMetadata);
+  }
+
+  @Deprecated
+  public Dataset<Row> asDataFrame(String key) {
+    return asSparkFrame(key);
   }
 
   /**
@@ -156,8 +171,13 @@ public class JavaH2OContext {
    * @param key key of H2O frame to convert
    * @return Spark dataset
    */
-  public Dataset<Row> asDataFrame(String key) {
-    return asDataFrame(key, true);
+  public Dataset<Row> asSparkFrame(String key) {
+    return asSparkFrame(key, true);
+  }
+
+  @Deprecated
+  public Dataset<Row> asDataFrame(String key, boolean copyMetadata) {
+    return asSparkFrame(key, copyMetadata);
   }
 
   /**
@@ -167,8 +187,8 @@ public class JavaH2OContext {
    * @param copyMetadata true if metadata should be copied
    * @return Spark dataset
    */
-  public Dataset<Row> asDataFrame(String key, boolean copyMetadata) {
-    return hc.asDataFrame(key, copyMetadata);
+  public Dataset<Row> asSparkFrame(String key, boolean copyMetadata) {
+    return hc.asSparkFrame(key, copyMetadata);
   }
 
   /**

--- a/core/src/test/scala/ai/h2o/sparkling/ConfigurationPropertiesTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/ConfigurationPropertiesTestSuite.scala
@@ -212,7 +212,7 @@ abstract class ConfigurationPropertiesTestSuite_ExternalCommunicationCompression
       .csv(TestUtils.locate("smalldata/prostate/prostate.csv"))
 
     val frameKey = hc.asH2OFrameKeyString(dataset)
-    val result = hc.asDataFrame(frameKey)
+    val result = hc.asSparkFrame(frameKey)
 
     TestUtils.assertDataFramesAreIdentical(dataset, result)
   }

--- a/core/src/test/scala/ai/h2o/sparkling/H2OFrameTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/H2OFrameTestSuite.scala
@@ -172,7 +172,7 @@ class H2OFrameTestSuite extends FunSuite with SharedH2OTestContext {
   }
 
   private def assertAfterJoin(result: H2OFrame, expected: DataFrame): Unit = {
-    val resultDF = hc.asDataFrame(result.frameId).select("name", "age", "city", "salary")
+    val resultDF = hc.asSparkFrame(result.frameId).select("name", "age", "city", "salary")
     TestUtils.assertDataFramesAreIdentical(resultDF, expected)
   }
 }

--- a/core/src/test/scala/ai/h2o/sparkling/backend/api/dataframes/DataFramesHandlerTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/api/dataframes/DataFramesHandlerTestSuite.scala
@@ -67,7 +67,7 @@ class DataFramesHandlerTestSuite extends FunSuite with SharedH2OTestContext {
 
     val h2oframe = new H2OFrame(new File(TestUtils.locate("smalldata/prostate/prostate.csv")))
     // we have created dataFrame from already existing h2oFrame, metadata are included
-    val df = hc.asDataFrame(h2oframe)
+    val df = hc.asSparkFrame(h2oframe)
     val name = "prostate"
     df.createOrReplaceTempView(name)
     val percentiles = df.schema.fields(0).metadata.getDoubleArray("percentiles")

--- a/core/src/test/scala/ai/h2o/sparkling/backend/api/scalainterpreter/ScalaCodeHandlerTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/api/scalainterpreter/ScalaCodeHandlerTestSuite.scala
@@ -168,7 +168,7 @@ class ScalaCodeHandlerTestSuite extends FunSuite with SharedH2OTestContext with 
     val req3 = new ScalaCodeV3
     req3.session_id = reqSession.session_id
     // this code is using implicitly sqlContext
-    req3.code = "val dataframe = h2oContext.asDataFrame(h2oFrame)"
+    req3.code = "val dataframe = h2oContext.asSparkFrame(h2oFrame)"
     val result3 = scalaCodeHandler.interpret(3, req3)
     assert(result3.output.equals(""), "Printed output should be empty")
     assert(result3.status.equals("Success"), "Status should be Success 3")

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataExchangeTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataExchangeTestSuite.scala
@@ -118,7 +118,7 @@ class DataExchangeTestSuite extends FunSuite with Matchers with SharedH2OTestCon
 
       val expectedDataFrame = getExpectedDataFrame(dataFrame, numberOfRows)
       val h2oFrame = hc.asH2OFrame(dataFrame)
-      val result = hc.asDataFrame(h2oFrame)
+      val result = hc.asSparkFrame(h2oFrame)
 
       TestUtils.assertDataFramesAreIdentical(expectedDataFrame, result)
     }

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
@@ -47,7 +47,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("Creation of H2ODataFrame") {
     val h2oFrame = new H2OFrame(new File(TestUtils.locate("smalldata/prostate/prostate.csv")))
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(
       h2oFrame.numRows() == dataFrame.count(),
@@ -84,7 +84,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.vec(0).chunkForChunkIdx(0).at8(0) == 1)
     assert(h2oFrame.vec(0).isCategorical)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     assert(dataFrame.take(4)(3)(0) == "ONE")
@@ -106,7 +106,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.vec(0).chunkForChunkIdx(1).at8(1) == 1428517566L)
     assert(h2oFrame.vec(0).isTime)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     val localtime = DateTimeUtils.toUTCTime(1428517566L * 1000, TimeZone.getDefault.getID) / 1000
@@ -129,7 +129,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.vec(0).chunkForChunkIdx(1).at8(4) == 8)
     assert(h2oFrame.vec(0).isNumeric)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     assert(dataFrame.take(8)(7)(0) == 8)
@@ -152,7 +152,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.vec(0).chunkForChunkIdx(1).at8(4) == 208)
     assert(h2oFrame.vec(0).isNumeric)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     assert(dataFrame.take(8)(7)(0) == 208)
@@ -175,7 +175,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.vec(0).chunkForChunkIdx(1).at8(4) == 100008)
     assert(h2oFrame.vec(0).isNumeric)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     assert(dataFrame.take(8)(7)(0) == 100008)
@@ -197,7 +197,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.vec(0).chunkForChunkIdx(1).at8(1) == -8589934595L)
     assert(h2oFrame.vec(0).isNumeric)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     assert(dataFrame.take(4)(3)(0) == -8589934595L)
@@ -219,7 +219,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.vec(0).chunkForChunkIdx(1).atd(1) == 100.00012)
     assert(h2oFrame.vec(0).isNumeric)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     assert(dataFrame.take(4)(3)(0) == 100.00012)
@@ -242,7 +242,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(h2oFrame.vec(0).chunkForChunkIdx(2).atStr(new BufferedString(), 1).toString.equals("string8"))
     assert(h2oFrame.vec(0).isString)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     assert(dataFrame.take(8)(7)(0) == "string8")
@@ -276,7 +276,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
           h2oFrame.vec(0).chunkForChunkIdx(0).at16h(0))
     assert(h2oFrame.vec(0).isUUID)
 
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.count == h2oFrame.numRows())
     assert(dataFrame.schema.fields(0) match {
@@ -377,7 +377,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.vec(0).isString)
 
-    val resultDF = hc.asDataFrame(h2oFrame)
+    val resultDF = hc.asSparkFrame(h2oFrame)
     TestUtils.assertDataFramesAreIdentical(df, resultDF)
   }
 
@@ -388,7 +388,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.vec(0).isCategorical)
 
-    val resultDF = hc.asDataFrame(h2oFrame)
+    val resultDF = hc.asSparkFrame(h2oFrame)
     TestUtils.assertDataFramesAreIdentical(df, resultDF)
   }
 
@@ -708,7 +708,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val chunkLayout: Array[Long] = Array(50L, 50L)
     val data: Array[Array[Long]] = Array((1L to 50L).toArray, (51L to 100L).toArray)
     val h2oFrame = makeH2OFrame(fname, colNames, chunkLayout, data, Vec.T_NUM)
-    val dataFrame = hc.asDataFrame(h2oFrame)
+    val dataFrame = hc.asSparkFrame(h2oFrame)
 
     assert(dataFrame.schema("C0").metadata.getDouble("min") == 1L)
     assert(dataFrame.schema("C0").metadata.getLong("count") == 100L)
@@ -717,7 +717,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
     val h2oFrameEnum =
       makeH2OFrame(fname, colNames, chunkLayout, data, Vec.T_CAT, colDomains = Array(Array("ZERO", "ONE")))
-    val dataFrameEnum = hc.asDataFrame(h2oFrameEnum)
+    val dataFrameEnum = hc.asSparkFrame(h2oFrameEnum)
     assert(dataFrameEnum.schema("C0").metadata.getLong("cardinality") == 2L)
     h2oFrameEnum.delete()
   }
@@ -805,7 +805,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val wideDF = df.withColumn("_tmp", split($"value", ",")).select(cols: _*).drop("_tmp")
 
     val hf = hc.asH2OFrame(wideDF)
-    val resultDF = hc.asDataFrame(hf)
+    val resultDF = hc.asSparkFrame(hf)
 
     assert(hf.numCols() == numCols)
     resultDF.foreach(_ => {})

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/SupportedRDDConverterTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/SupportedRDDConverterTestSuite.scala
@@ -417,7 +417,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     val timestamp = DateTimeUtils.toUTCTime(h2oFrame.vec(0).at8(0) * 1000, SparkTimeZone.current().getID) / 1000
     assert(rdd.first().getTime == timestamp)
     // the rdd back should have spark time zone set up because the h2o frame -> rdd respects the Spark timezone
-    val rddBack = hc.asDataFrame(h2oFrame)
+    val rddBack = hc.asSparkFrame(h2oFrame)
     val rddBackData = rddBack.collect().map(_.getTimestamp(0))
     assert(rdd.collect.sameElements(rddBackData))
     h2oFrame.delete()

--- a/doc/src/site/sphinx/deployment/use_on_zeppelin.rst
+++ b/doc/src/site/sphinx/deployment/use_on_zeppelin.rst
@@ -40,4 +40,4 @@ Creating a Spark ``DataFrame`` from an ``H2OFrame``:
 .. code:: scala
 
     %spark
-    val df = hc.asDataFrame(hf)
+    val df = hc.asSparkFrame(hf)

--- a/doc/src/site/sphinx/devel/integ_tests.rst
+++ b/doc/src/site/sphinx/devel/integ_tests.rst
@@ -151,4 +151,4 @@ The following code reflects the use cases listed above. The code is executed in 
     import spark.implicits._
     val df = spark.sparkContext.parallelize(1 to 1000, 100).map(v => IntHolder(Some(v))).toDF
     val hf = h2oContext.asH2OFrame(df)
-    val newRdd = h2oContext.asDataFrame(hf)
+    val newRdd = h2oContext.asSparkFrame(hf)

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -99,6 +99,9 @@ From 3.30 to 3.32
 - Methods ``setH2ONodeLogLevel`` and ``setH2OClientLogLevel`` are removed on ``H2OContext``. Please use ``setH2OLogLevel``
   instead.
 
+- Methods ``asDataFrame`` on Scala ``H2OContext`` has been replaced by methods ``asSparkFrame`` with same arguments.
+  This was done to ensure full consistency between Scala, Python and R APIs.
+
 From 3.28.1 to 3.30
 -------------------
 

--- a/doc/src/site/sphinx/tutorials/shap_values.rst
+++ b/doc/src/site/sphinx/tutorials/shap_values.rst
@@ -36,7 +36,7 @@ To get SHAP values(=contributions) from H2OXGBoost model, please do:
         .. code:: scala
 
             val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asDataFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Train the model. You can configure all the available XGBoost arguments using provided setters, such as the label column.

--- a/doc/src/site/sphinx/tutorials/spark_h2o_conversions.rst
+++ b/doc/src/site/sphinx/tutorials/spark_h2o_conversions.rst
@@ -31,11 +31,11 @@ Example
 Converting an H2OFrame into a DataFrame
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``H2OContext`` class provides the method ``asDataFrame``, which creates a DataFrame-like wrapper around the provided H2OFrame:
+The ``H2OContext`` class provides the method ``asSparkFrame``, which creates a DataFrame-like wrapper around the provided H2OFrame:
 
 .. code:: scala
 
-    def asDataFrame(fr: H2OFrame): DataFrame
+    def asSparkFrame(fr: H2OFrame): DataFrame
 
 The schema of the created instance of the ``DataFrame`` is derived from the column names and types of the specified ``H2OFrame``.
 
@@ -44,7 +44,7 @@ Example
 
 .. code:: scala
 
-    val dataFrame = asDataFrame(h2oFrame)
+    val dataFrame = asSparkFrame(h2oFrame)
 
 Converting an RDD[T] into an H2OFrame
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/src/site/sphinx/tutorials/sw_automl.rst
+++ b/doc/src/site/sphinx/tutorials/sw_automl.rst
@@ -28,7 +28,7 @@ The following sections describe how to train an AutoML model in Sparkling Water 
         .. code:: scala
 
             val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asDataFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Create a H2OAutoML instance and configure it according your use case via provided setters. If feature columns are not specified explicitly,

--- a/doc/src/site/sphinx/tutorials/sw_drf.rst
+++ b/doc/src/site/sphinx/tutorials/sw_drf.rst
@@ -30,7 +30,7 @@ The following sections describe how to train DRF model in Sparkling Water in bot
         .. code:: scala
 
             val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asDataFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Train the model. You can configure all the available DRF arguments using provided setters, such as the label column.

--- a/doc/src/site/sphinx/tutorials/sw_kmeans.rst
+++ b/doc/src/site/sphinx/tutorials/sw_kmeans.rst
@@ -30,7 +30,7 @@ The following sections describe how to train KMeans model in Sparkling Water in 
         .. code:: scala
 
             val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/iris/iris_wheader.csv"))
-            val sparkDF = hc.asDataFrame(frame)
+            val sparkDF = hc.asSparkFrame(frame)
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Train the model. You can configure all the available KMeans arguments using provided setters.

--- a/doc/src/site/sphinx/tutorials/sw_target_encoder.rst
+++ b/doc/src/site/sphinx/tutorials/sw_target_encoder.rst
@@ -110,7 +110,7 @@ and prepare the environment:
         .. code:: scala
 
             val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asDataFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
     .. tab-container:: Python

--- a/doc/src/site/sphinx/tutorials/sw_xgboost.rst
+++ b/doc/src/site/sphinx/tutorials/sw_xgboost.rst
@@ -28,7 +28,7 @@ The following sections describe how to train XGBoost model in Sparkling Water in
         .. code:: scala
 
             val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asDataFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Train the model. You can configure all the available XGBoost arguments using provided setters, such as the label column.

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala
@@ -78,7 +78,7 @@ class H2OTargetEncoderModel(override val uid: String, targetEncoderModel: H2OMod
       "seed" -> getNoiseSeed())
     val frameKeyV3 = request[FrameKeyV3](endpoint, "GET", s"/3/TargetEncoderTransform", conf, params)
     val outputColumnsOnlyFrame = H2OFrame(frameKeyV3.name).subframe(outputFrameColumns)
-    val outputColumnsOnlyDF = hc.asDataFrame(outputColumnsOnlyFrame.frameId)
+    val outputColumnsOnlyDF = hc.asSparkFrame(outputColumnsOnlyFrame.frameId)
     val renamedOutputColumnsOnlyDF = getOutputCols().zip(internalOutputColumns).foldLeft(outputColumnsOnlyDF) {
       case (df, (to, from)) => df.withColumnRenamed(from, to)
     }

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -170,7 +170,7 @@ class H2OContext(object):
 
         if isinstance(h2oFrame, H2OFrame):
             frame_id = h2oFrame.frame_id
-            jdf = self._jhc.asDataFrame(frame_id, copyMetadata)
+            jdf = self._jhc.asSparkFrame(frame_id, copyMetadata)
             sqlContext = SparkSession.builder.getOrCreate()._wrapped
             df = DataFrame(jdf, sqlContext)
             # Attach h2o_frame to dataframe which forces python not to delete the frame when we leave the scope of this

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -87,7 +87,7 @@ H2OContext <- setRefClass("H2OContext", fields = list(jhc = "ANY"), methods = li
     h2o.getFrame(key)
   },
   asSparkFrame = function(h2oFrame, copyMetaData = TRUE) {
-    sparkFrame <- invoke(.self$jhc, "asDataFrame", h2o.getId(h2oFrame), copyMetaData)
+    sparkFrame <- invoke(.self$jhc, "asSparkFrame", h2o.getId(h2oFrame), copyMetaData)
     # Register returned spark_jobj as a table for dplyr
     sdf_register(sparkFrame)
   },


### PR DESCRIPTION
To be fully consistent with our Python and R APIs