### PR TITLE
[SW-2107] Introduce client-less ai.h2o.sparkling.H2OContext

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ The Sparkling Shell supports creation of an |H2O| cloud and execution of |H2O| a
 
    .. code:: scala
 
-      import org.apache.spark.h2o._
+      import ai.h2o.sparkling._
       val hc = H2OContext.getOrCreate()
 
    ``H2OContext`` starts H2O services on top of Spark cluster and provides primitives for transformations between |H2O| and Spark data structures.

--- a/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/BenchmarkBase.scala
+++ b/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/BenchmarkBase.scala
@@ -20,20 +20,20 @@ package ai.h2o.sparkling.benchmarks
 import java.io.{OutputStream, PrintWriter}
 import java.net.URI
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.ml.algos.{H2OGBM, H2OGLM, H2OSupervisedAlgorithm}
 import hex.glm.GLM
 import hex.glm.GLMModel.GLMParameters
 import hex.tree.gbm.GBM
 import hex.tree.gbm.GBMModel.GBMParameters
 import hex.{Model, ModelBuilder}
-import org.apache.spark.h2o.{H2OContext, H2OFrame}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.storage.StorageLevel
 import water.MRTask
-import water.fvec.{Chunk, Frame, Vec}
+import water.fvec.{Chunk, Frame, H2OFrame, Vec}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
@@ -107,7 +107,7 @@ abstract class BenchmarkBase[TInput](context: BenchmarkContext) {
 
   def loadRegularH2OFrame(): H2OFrame = {
     val uri = new URI(context.datasetDetails.url.get)
-    val frame = new H2OFrame(uri)
+    val frame = H2OFrame(uri)
     frame
   }
 

--- a/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/H2OFrameToDataFrameConversionBenchmark.scala
+++ b/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/H2OFrameToDataFrameConversionBenchmark.scala
@@ -17,7 +17,7 @@
 
 package ai.h2o.sparkling.benchmarks
 
-import org.apache.spark.h2o.H2OFrame
+import water.fvec.H2OFrame
 
 class H2OFrameToDataFrameConversionBenchmark(context: BenchmarkContext) extends BenchmarkBase[H2OFrame](context) {
 

--- a/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/H2OFrameToDataFrameConversionBenchmark.scala
+++ b/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/H2OFrameToDataFrameConversionBenchmark.scala
@@ -23,5 +23,5 @@ class H2OFrameToDataFrameConversionBenchmark(context: BenchmarkContext) extends 
 
   override protected def initialize(): H2OFrame = loadDataToH2OFrame()
 
-  override protected def body(frame: H2OFrame): Unit = context.hc.asSparkFrame(frame).foreach(_ => {})
+  override protected def body(frame: H2OFrame): Unit = context.hc.asSparkFrame(frame.key.toString).foreach(_ => {})
 }

--- a/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/Runner.scala
+++ b/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/Runner.scala
@@ -20,9 +20,9 @@ package ai.h2o.sparkling.benchmarks
 import java.io.{File, FileOutputStream, InputStreamReader}
 import java.lang.reflect.Modifier
 
+import ai.h2o.sparkling.H2OContext
 import com.google.common.reflect.ClassPath
 import org.apache.spark.SparkConf
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.SparkSession
 import org.json4s._
 import org.json4s.jackson.Serialization._

--- a/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/TrainAlgorithmFromH2OFrameBenchmark.scala
+++ b/benchmarks/src/main/scala/ai/h2o/sparkling/benchmarks/TrainAlgorithmFromH2OFrameBenchmark.scala
@@ -17,7 +17,7 @@
 
 package ai.h2o.sparkling.benchmarks
 
-import org.apache.spark.h2o.H2OFrame
+import water.fvec.H2OFrame
 
 class TrainAlgorithmFromH2OFrameBenchmark(context: BenchmarkContext, algorithmBundle: AlgorithmBundle)
   extends AlgorithmBenchmarkBase[H2OFrame](context, algorithmBundle) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -130,13 +130,7 @@ task createSparklingWaterVersionFile {
 }
 test.dependsOn testJar
 
-test {
-  systemProperty "spark.ext.h2o.rest.api.based.client", "false"
-}
-
 integTest {
-  systemProperty "spark.ext.h2o.rest.api.based.client", "false"
-
   if (detectBackendClusterMode() == "external") {
     exclude 'ai/h2o/sparkling/internal/**'
   }
@@ -150,8 +144,6 @@ processResources.dependsOn ':sparkling-water-assembly-extensions:embeddedAssembl
 
 bench {
   systemProperty "spark.ext.h2o.backend.cluster.mode", detectBackendClusterMode()
-  systemProperty "spark.ext.h2o.rest.api.based.client", "false"
-
   systemProperty "spark.testing", "true"
   systemProperty "spark.test.home", "${sparkHome}"
 }

--- a/core/src/bench/scala/ai/h2o/sparkling/bench/DataFrameConverterBenchSuite.scala
+++ b/core/src/bench/scala/ai/h2o/sparkling/bench/DataFrameConverterBenchSuite.scala
@@ -78,7 +78,7 @@ class DataFrameConverterBenchSuite extends BenchSuite with SharedH2OTestContext 
   private def testPerSchema(schemaHolder: TestUtils.SchemaHolder): Unit = {
     val df = TestUtils.generateDataFrame(spark, schemaHolder, settings)
     val hf = hc.asH2OFrame(df)
-    hf.remove()
+    hf.delete()
   }
 
   private def testflattenOnlyPerSchema(schemaHolder: TestUtils.SchemaHolder): Unit = {
@@ -107,7 +107,7 @@ class DataFrameConverterBenchSuite extends BenchSuite with SharedH2OTestContext 
     val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
 
     val hf = hc.asH2OFrame(df)
-    hf.remove()
+    hf.delete()
   }
 
   benchTest("Measure performance of conversion to H2OFrame on a data frame with wide dense vectors") {
@@ -120,7 +120,7 @@ class DataFrameConverterBenchSuite extends BenchSuite with SharedH2OTestContext 
     val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
 
     val hf = hc.asH2OFrame(df)
-    hf.remove()
+    hf.delete()
   }
 
   benchTest(
@@ -136,7 +136,7 @@ class DataFrameConverterBenchSuite extends BenchSuite with SharedH2OTestContext 
     val df = sc.parallelize((0 until numberOfRows).map(row => rowGenerator(row)), partitions).toDF()
 
     val hf = hc.asH2OFrame(df)
-    hf.remove()
+    hf.delete()
   }
 
   private def sparseVector(len: Int, elements: Int, rng: Random = Random): SparseVector = {

--- a/core/src/integTest/scala/ai/h2o/sparkling/IntegrationTestSuite.scala
+++ b/core/src/integTest/scala/ai/h2o/sparkling/IntegrationTestSuite.scala
@@ -18,7 +18,6 @@
 package ai.h2o.sparkling
 
 import ai.h2o.sparkling.TestUtils.{assertRDDHolderProperties, assertVectorIntValues}
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import org.apache.spark.sql.SparkSession
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -40,7 +39,7 @@ class IntegrationTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("Convert H2OFrame to DataFrame when H2OFrame was changed in DKV in distributed environment") {
     val rdd = sc.parallelize(1 to 100, 2)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(h2oFrame.chunks.length == 2)
     val updatedFrame = h2oFrame.add(h2oFrame)
 
@@ -63,7 +62,7 @@ class IntegrationTestSuite extends FunSuite with SharedH2OTestContext {
       }
     }
 
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDHolderProperties(h2oFrame, rdd)
     assertVectorIntValues(h2oFrame.collectInts(0), data)
     h2oFrame.delete()

--- a/core/src/integTest/scala/ai/h2o/sparkling/internal/H2OContextConversionOnSubsetExecutors.scala
+++ b/core/src/integTest/scala/ai/h2o/sparkling/internal/H2OContextConversionOnSubsetExecutors.scala
@@ -38,7 +38,7 @@ class H2OContextConversionOnSubsetExecutors extends FunSuite with SharedH2OTestC
     assert(hc.getH2ONodes().length == 1)
     val data = 1 to 1000
     val rdd = sc.parallelize(data, 100).map(v => Some(v))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDHolderProperties(h2oFrame, rdd)
     assertVectorIntValues(h2oFrame.collectInts(0), data)
     h2oFrame.delete()

--- a/core/src/main/scala/ai/h2o/sparkling/DefaultSource.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/DefaultSource.scala
@@ -18,7 +18,6 @@
 package ai.h2o.sparkling
 
 import ai.h2o.sparkling.backend.H2OFrameRelation
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}

--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.h2o.sparkling
+
+import ai.h2o.sparkling.backend.external.ExternalBackendConf
+import ai.h2o.sparkling.backend.internal.InternalBackendConf
+import ai.h2o.sparkling.repl.H2OInterpreter
+import ai.h2o.sparkling.utils.SparkSessionUtils
+import org.apache.spark.SparkConf
+import org.apache.spark.expose.Logging
+
+/**
+  * Configuration holder which is representing
+  * properties passed from user to Sparkling Water.
+  */
+class H2OConf(val sparkConf: SparkConf)
+  extends Logging
+  with InternalBackendConf
+  with ExternalBackendConf
+  with Serializable {
+
+  def this() = this(SparkSessionUtils.active.sparkContext.getConf)
+
+  H2OConf.checkDeprecatedOptions(sparkConf)
+  // Precondition
+  require(sparkConf != null, "Spark conf was null")
+
+  /** Copy this object */
+  override def clone: H2OConf = {
+    val conf = new H2OConf(sparkConf)
+    conf.setAll(getAll)
+    conf
+  }
+
+  /** Set a configuration variable. */
+  def set(key: String, value: String): H2OConf = {
+    sparkConf.set(key, value)
+    this
+  }
+
+  def set(key: String, value: Boolean): H2OConf = {
+    sparkConf.set(key, value.toString)
+    this
+  }
+
+  /** Remove a parameter from the configuration */
+  def remove(key: String): H2OConf = {
+    sparkConf.remove(key)
+    this
+  }
+
+  def contains(key: String): Boolean = sparkConf.contains(key)
+
+  /** Get a parameter; throws a NoSuchElementException if it's not set */
+  def get(key: String): String = sparkConf.get(key)
+
+  /** Get a parameter, falling back to a default if not set */
+  def get(key: String, defaultValue: String): String = sparkConf.get(key, defaultValue)
+
+  /** Get a parameter as an Option */
+  def getOption(key: String): Option[String] = sparkConf.getOption(key)
+
+  /** Get all parameters as a list of pairs */
+  def getAll: Array[(String, String)] = {
+    sparkConf.getAll
+  }
+
+  /** Set multiple parameters together */
+  def setAll(settings: Traversable[(String, String)]): H2OConf = {
+    sparkConf.setAll(settings)
+    this
+  }
+
+  /** Get a parameter as an integer, falling back to a default if not set */
+  def getInt(key: String, defaultValue: Int): Int = sparkConf.getInt(key, defaultValue)
+
+  /** Get a parameter as a long, falling back to a default if not set */
+  def getLong(key: String, defaultValue: Long): Long = sparkConf.getLong(key, defaultValue)
+
+  /** Get a parameter as a double, falling back to a default if not set */
+  def getDouble(key: String, defaultValue: Double): Double = sparkConf.getDouble(key, defaultValue)
+
+  /** Get a parameter as a boolean, falling back to a default if not set */
+  def getBoolean(key: String, defaultValue: Boolean): Boolean = sparkConf.getBoolean(key, defaultValue)
+
+  override def toString: String = {
+    if (runsInExternalClusterMode) {
+      externalConfString
+    } else {
+      internalConfString
+    }
+  }
+
+  def getScheme(): String = {
+    if (jks.isDefined && jksPass.isDefined) {
+      "https"
+    } else {
+      "http"
+    }
+  }
+}
+
+object H2OConf extends Logging {
+  def apply(): H2OConf = new H2OConf()
+
+  def apply(sparkConf: SparkConf): H2OConf = new H2OConf(sparkConf)
+
+  private val deprecatedOptions = Map[String, String]()
+
+  private def checkDeprecatedOptions(sparkConf: SparkConf): Unit = {
+    deprecatedOptions.foreach {
+      case (deprecated, current) =>
+        val deprecatedValue = sparkConf.getOption(deprecated)
+        if (deprecatedValue.isDefined) {
+          val currentValue = sparkConf.getOption(current)
+          if (currentValue.isDefined) {
+            logWarning(
+              s"Both options '$deprecated' and '$current' are specified. " +
+                s"Using value '${currentValue.get}' of '$current' as the later one is deprecated.")
+          } else {
+            logWarning(
+              s"Please use '$current' as '$deprecated' is deprecated. Passing the value '${deprecatedValue.get}' to '$current'.")
+            sparkConf.set(current, deprecatedValue.get)
+          }
+        }
+    }
+  }
+
+  private var _sparkConfChecked = false
+
+  def sparkConfChecked = _sparkConfChecked
+
+  def checkSparkConf(sparkConf: SparkConf): SparkConf = {
+    _sparkConfChecked = true
+    sparkConf.set("spark.repl.class.outputDir", H2OInterpreter.classOutputDirectory.getAbsolutePath)
+    sparkConf
+  }
+}

--- a/core/src/main/scala/ai/h2o/sparkling/H2OContext.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OContext.scala
@@ -459,8 +459,4 @@ object H2OContext extends Logging {
           s" Spark and re-run the application.")
     }
   }
-
-  private def getSparkHome(conf: SparkConf): String = {
-    conf.getOption("spark.home").orElse(Option(System.getenv("SPARK_HOME"))).getOrElse("SPARK_HOME is not defined!")
-  }
 }

--- a/core/src/main/scala/ai/h2o/sparkling/H2OContext.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OContext.scala
@@ -1,0 +1,466 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.h2o.sparkling
+
+import java.util.concurrent.atomic.AtomicReference
+
+import ai.h2o.sparkling.backend._
+import ai.h2o.sparkling.backend.converters._
+import ai.h2o.sparkling.backend.exceptions.{H2OClusterNotReachableException, RestApiException, WrongSparkVersion}
+import ai.h2o.sparkling.backend.external._
+import ai.h2o.sparkling.backend.utils._
+import ai.h2o.sparkling.utils.SparkSessionUtils
+import org.apache.spark.expose.{Logging, Utils}
+import org.apache.spark.h2o.SparkSpecificUtils
+import org.apache.spark.h2o.backends.internal.InternalH2OBackend
+import org.apache.spark.h2o.ui._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.{SparkConf, SparkContext}
+import water._
+import water.util.PrettyPrint
+
+import scala.language.{implicitConversions, postfixOps}
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+/**
+  * Main entry point for Sparkling Water functionality. H2O Context represents connection to H2O cluster and allows us
+  * to operate with it.
+  *
+  * H2O Context provides conversion methods from RDD/DataFrame to H2OFrame and back and also provides implicits
+  * conversions for desired transformations
+  *
+  * Sparkling Water can run in two modes. External cluster mode and internal cluster mode. When using external cluster
+  * mode, it tries to connect to existing H2O cluster using the provided spark
+  * configuration properties. In the case of internal cluster mode,it creates H2O cluster living in Spark - that means
+  * that each Spark executor will have one h2o instance running in it.  This mode is not
+  * recommended for big clusters and clusters where Spark executors are not stable.
+  *
+  * Cluster mode can be set using the spark configuration
+  * property spark.ext.h2o.mode which can be set in script starting sparkling-water or
+  * can be set in H2O configuration class H2OConf
+  */
+/**
+  * Create new H2OContext based on provided H2O configuration
+  *
+  * @param conf H2O configuration
+  */
+class H2OContext private[sparkling] (private val conf: H2OConf) extends H2OContextExtensions {
+  self =>
+  val sparkContext: SparkContext = SparkSessionUtils.active.sparkContext
+  private val backendHeartbeatThread = createHeartBeatEventThread()
+
+  private var stopped = false
+
+  /** Here the client means Python or R H2O client */
+  private var clientConnected = false
+
+  /** Used backend */
+  protected val backend: SparklingBackend = if (conf.runsInExternalClusterMode) {
+    new ExternalH2OBackend(this)
+  } else {
+    new InternalH2OBackend(this)
+  }
+  H2OContext.logStartingInfo(conf)
+  H2OContext.verifySparkVersion()
+  backend.startH2OCluster(conf)
+  logInfo("Connecting to H2O cluster.")
+  private val nodes = getAndVerifyWorkerNodes(conf)
+  if (H2OClientUtils.isH2OClientBased(conf)) {
+    H2OClientUtils.startH2OClient(this, conf, nodes)
+  }
+  RestApiUtils.setTimeZone(conf, "UTC")
+  // The lowest priority used by Spark is 25 (removing temp dirs). We need to perform cleaning up of H2O
+  // resources before Spark does as we run as embedded application inside the Spark
+  private val shutdownHookRef = Utils.addShutdownHook(10) { () =>
+    logWarning("Spark shutdown hook called, stopping H2OContext!")
+    stop(stopSparkContext = false, stopJvm = false, inShutdownHook = true)
+  }
+  private val leaderNode = RestApiUtils.getLeaderNode(conf)
+  if (conf.getBoolean("spark.ui.enabled", defaultValue = true)) {
+    SparkSpecificUtils.addSparklingWaterTab(sparkContext)
+  }
+  private val (flowIp, flowPort) = {
+    val uri = ProxyStarter.startFlowProxy(conf)
+    (uri.getHost, uri.getPort)
+  }
+  updateUIAfterStart() // updates the spark UI
+  backendHeartbeatThread.start() // start backend heartbeats
+  logInfo(s"Sparkling Water ${BuildInfo.SWVersion} started, status of context: $this ")
+
+  def getH2ONodes(): Array[NodeDesc] = nodes
+
+  private[this] def updateUIAfterStart(): Unit = {
+    val cloudV3 = RestApiUtils.getClusterInfo(conf)
+    val h2oBuildInfo = H2OBuildInfo(
+      cloudV3.version,
+      cloudV3.branch_name,
+      cloudV3.last_commit_hash,
+      cloudV3.describe,
+      cloudV3.compiled_by,
+      cloudV3.compiled_on)
+    val h2oClusterInfo = H2OClusterInfo(
+      s"$flowIp:$flowPort",
+      cloudV3.cloud_healthy,
+      cloudV3.internal_security_enabled,
+      nodes.map(_.ipPort()),
+      backend.backendUIInfo,
+      cloudV3.cloud_uptime_millis)
+    val swPropertiesInfo = conf.getAll.filter(_._1.startsWith("spark.ext.h2o"))
+
+    val swHeartBeatEvent = getSparklingWaterHeartbeatEvent()
+    Utils.postToListenerBus(swHeartBeatEvent)
+    Utils.postToListenerBus(H2OContextStartedEvent(h2oClusterInfo, h2oBuildInfo, swPropertiesInfo))
+  }
+
+  /**
+    * Return a copy of this H2OContext's configuration. The configuration ''cannot'' be changed at runtime.
+    */
+  def getConf: H2OConf = conf.clone()
+
+  /** Transforms RDD[Supported type] to H2OFrame */
+  def asH2OFrame(rdd: SupportedRDD): H2OFrame = asH2OFrame(rdd, None)
+
+  def asH2OFrame(rdd: SupportedRDD, frameName: String): H2OFrame = asH2OFrame(rdd, Option(frameName))
+
+  def asH2OFrame(rdd: SupportedRDD, frameName: Option[String]): H2OFrame = {
+    withConversionDebugPrints(sparkContext, "SupportedRDD", {
+      SupportedRDDConverter.toH2OFrame(this, rdd, frameName)
+    })
+  }
+
+  /** Transform DataFrame to H2OFrame */
+  def asH2OFrame(df: DataFrame): H2OFrame = asH2OFrame(df, None)
+
+  def asH2OFrame(df: DataFrame, frameName: String): H2OFrame = asH2OFrame(df, Option(frameName))
+
+  def asH2OFrame(df: DataFrame, frameName: Option[String]): H2OFrame = {
+    withConversionDebugPrints(sparkContext, "Dataframe", SparkDataFrameConverter.toH2OFrame(this, df, frameName))
+  }
+
+  /** Transforms Dataset[Supported type] to H2OFrame */
+  def asH2OFrame(ds: SupportedDataset): H2OFrame = asH2OFrame(ds, None)
+
+  def asH2OFrame(ds: SupportedDataset, frameName: String): H2OFrame = asH2OFrame(ds, Option(frameName))
+
+  def asH2OFrame(ds: SupportedDataset, frameName: Option[String]): H2OFrame = {
+    withConversionDebugPrints(sparkContext, "SupportedDataset", {
+      SupportedDatasetConverter.toH2OFrame(this, ds, frameName)
+    })
+  }
+
+  /** Create a new H2OFrame based on existing Frame referenced by its id. */
+  def asH2OFrame(s: String): H2OFrame = H2OFrame(s)
+
+  /** Convert given H2O frame into a Product RDD type
+    *
+    * Consider using asH2OFrame since asRDD has several limitations such as that asRDD can't be used in Spark REPL
+    * in case we are RDD[T] where T is class defined in REPL. This is because class T is created as inner class
+    * and we are not able to create instance of class T without outer scope - which is impossible to get.
+    * */
+  def asRDD[A <: Product: TypeTag: ClassTag](fr: H2OFrame): RDD[A] = SupportedRDDConverter.toRDD[A](this, fr)
+
+  /** A generic convert of Frame into Product RDD type
+    *
+    * Consider using asH2OFrame since asRDD has several limitations such as that asRDD can't be used in Spark REPL
+    * in case we are RDD[T] where T is class defined in REPL. This is because class T is created as inner class
+    * and we are not able to create instance of class T without outer scope - which is impossible to get.
+    *
+    * This code: hc.asRDD[PUBDEV458Type](rdd) will need to be call as hc.asRDD[PUBDEV458Type].apply(rdd)
+    */
+  def asRDD[A <: Product: TypeTag: ClassTag] = new {
+    def apply(fr: H2OFrame): RDD[A] = SupportedRDDConverter.toRDD[A](H2OContext.this, fr)
+  }
+
+  def asSparkFrame(fr: H2OFrame, copyMetadata: Boolean = true): DataFrame = {
+    SparkDataFrameConverter.toDataFrame(this, fr, copyMetadata)
+  }
+
+  def asSparkFrame(s: String, copyMetadata: Boolean): DataFrame = {
+    SparkDataFrameConverter.toDataFrame(this, H2OFrame(s), copyMetadata)
+  }
+
+  def asSparkFrame(s: String): DataFrame = asSparkFrame(s, copyMetadata = true)
+
+  /** Returns location of REST API of H2O client */
+  def h2oLocalClient: String = leaderNode.hostname + ":" + leaderNode.port + conf.contextPath.getOrElse("")
+
+  /** Returns IP of H2O client */
+  def h2oLocalClientIp: String = leaderNode.hostname
+
+  /** Returns port where H2O REST API is exposed */
+  def h2oLocalClientPort: Int = leaderNode.port
+
+  def setH2OLogLevel(level: String): Unit = {
+    if (H2OClientUtils.isH2OClientBased(conf)) {
+      water.util.Log.setLogLevel(level)
+    }
+    RestApiUtils.setLogLevel(conf, level)
+  }
+
+  def getH2OLogLevel(): String = RestApiUtils.getLogLevel(conf)
+
+  private def stop(stopSparkContext: Boolean, stopJvm: Boolean, inShutdownHook: Boolean): Unit = synchronized {
+    if (!inShutdownHook) {
+      Utils.removeShutdownHook(shutdownHookRef)
+    }
+    if (!stopped) {
+      backendHeartbeatThread.interrupt()
+      if (stopSparkContext) {
+        sparkContext.stop()
+      }
+      // Run orderly shutdown only in case of automatic mode of external backend, because:
+      // In internal backend, Spark takes care of stopping executors automatically
+      // In manual mode of external backend, the H2O cluster is managed by the user
+      if (conf.runsInExternalClusterMode && conf.isAutoClusterStartUsed) {
+        if (H2OClientUtils.isH2OClientBased(conf)) {
+          H2O.orderlyShutdown(conf.externalBackendStopTimeout)
+        } else {
+          RestApiUtils.shutdownCluster(conf)
+        }
+      }
+      H2OContext.instantiatedContext.set(null)
+      stopped = true
+      if (stopJvm && H2OClientUtils.isH2OClientBased(conf)) {
+        H2O.exit(0)
+      }
+    } else {
+      logWarning("H2OContext is already stopped!")
+    }
+  }
+
+  /** Stops H2O context.
+    *
+    * @param stopSparkContext stop also spark context
+    */
+  def stop(stopSparkContext: Boolean = false): Unit = {
+    stop(stopSparkContext, stopJvm = true, inShutdownHook = false)
+  }
+
+  def flowURL(): String = {
+    if (AzureDatabricksUtils.isRunningOnAzureDatabricks(conf)) {
+      AzureDatabricksUtils.flowURL(conf)
+    } else if (conf.clientFlowBaseurlOverride.isDefined) {
+      conf.clientFlowBaseurlOverride.get + conf.contextPath.getOrElse("")
+    } else {
+      "%s://%s:%d%s".format(conf.getScheme(), flowIp, flowPort, conf.contextPath.getOrElse(""))
+    }
+  }
+
+  /** Open H2O Flow running in this client. */
+  def openFlow(): Unit = openURI(flowURL())
+
+  override def toString: String = {
+    val basic =
+      s"""
+         |Sparkling Water Context:
+         | * Sparkling Water Version: ${BuildInfo.SWVersion}
+         | * H2O name: ${H2O.ARGS.name}
+         | * cluster size: ${nodes.length}
+         | * list of used nodes:
+         |  (executorId, host, port)
+         |  ------------------------
+         |  ${nodes.mkString("\n  ")}
+         |  ------------------------
+         |
+         |  Open H2O Flow in browser: ${flowURL()} (CMD + click in Mac OSX)
+         |
+    """.stripMargin
+    val sparkYarnAppId = if (sparkContext.master.toLowerCase.startsWith("yarn")) {
+      s"""
+         | * Yarn App ID of Spark application: ${sparkContext.applicationId}
+    """.stripMargin
+    } else {
+      ""
+    }
+
+    basic ++ sparkYarnAppId ++ backend.epilog
+  }
+
+  /** Define implicits available via h2oContext.implicits._ */
+  object implicits extends H2OContextImplicits with Serializable {
+    protected override def hc: H2OContext = self
+  }
+
+  private def getSparklingWaterHeartbeatEvent(): SparklingWaterHeartbeatEvent = {
+    val ping = RestApiUtils.getPingInfo(conf)
+    val memoryInfo = ping.nodes.map(node => (node.ip_port, PrettyPrint.bytes(node.free_mem)))
+    SparklingWaterHeartbeatEvent(ping.cloud_healthy, ping.cloud_uptime_millis, memoryInfo)
+  }
+
+  private def createHeartBeatEventThread(): Thread = {
+    new Thread {
+      setDaemon(true)
+
+      override def run(): Unit = {
+        while (!Thread.interrupted()) {
+          try {
+            val swHeartBeatInfo = getSparklingWaterHeartbeatEvent()
+            if (conf.runsInExternalClusterMode) {
+              if (!swHeartBeatInfo.cloudHealthy) {
+                logError("External H2O cluster not healthy!")
+                if (conf.isKillOnUnhealthyClusterEnabled) {
+                  logError("Stopping external H2O cluster as it is not healthy.")
+                  if (H2OClientUtils.isH2OClientBased(conf)) {
+                    H2OContext.this.stop(true)
+                  } else {
+                    H2OContext.this.stop(stopSparkContext = false, stopJvm = false, inShutdownHook = false)
+                  }
+                }
+              }
+            }
+            Utils.postToListenerBus(swHeartBeatInfo)
+          } catch {
+            case cause: RestApiException =>
+              if (H2OContext.get().isDefined) {
+                H2OContext.get().head.stop(stopSparkContext = false, stopJvm = false, inShutdownHook = false)
+              }
+              if (!Utils.inShutdown()) {
+                throw new H2OClusterNotReachableException(
+                  s"""External H2O cluster ${conf.h2oCluster.get + conf.contextPath
+                       .getOrElse("")} - ${conf.cloudName.get} is not reachable,
+                     |H2OContext has been closed! Please create a new H2OContext to a healthy and reachable (web enabled)
+                     |external H2O cluster.""".stripMargin,
+                  cause)
+              }
+          }
+
+          try {
+            Thread.sleep(conf.backendHeartbeatInterval)
+          } catch {
+            case _: InterruptedException => Thread.currentThread.interrupt()
+          }
+        }
+      }
+    }
+  }
+}
+
+object H2OContext extends Logging {
+  private[H2OContext] def setInstantiatedContext(h2oContext: H2OContext): Unit = {
+    synchronized {
+      val ctx = instantiatedContext.get()
+      if (ctx == null) {
+        instantiatedContext.set(h2oContext)
+      }
+    }
+  }
+
+  private val instantiatedContext = new AtomicReference[H2OContext]()
+
+  def get(): Option[H2OContext] = Option(instantiatedContext.get())
+
+  def ensure(onError: => String = "H2OContext has to be running."): H2OContext =
+    Option(instantiatedContext.get()) getOrElse {
+      throw new RuntimeException(onError)
+    }
+
+  private def connectingToNewCluster(hc: H2OContext, newConf: H2OConf): Boolean = {
+    val newCloudV3 = RestApiUtils.getClusterInfo(newConf)
+    val sameNodes = hc.getH2ONodes().map(_.ipPort()).sameElements(newCloudV3.nodes.map(_.ip_port))
+    !sameNodes
+  }
+
+  private def checkAndUpdateConf(conf: H2OConf): H2OConf = {
+    if (conf.runsInExternalClusterMode) {
+      ExternalH2OBackend.checkAndUpdateConf(conf)
+    } else {
+      InternalH2OBackend.checkAndUpdateConf(conf)
+    }
+  }
+
+  /**
+    * Get existing or create new H2OContext
+    *
+    * @param conf H2O configuration
+    * @return H2O Context
+    */
+  def getOrCreate(conf: H2OConf): H2OContext = synchronized {
+    if (H2OClientUtils.isH2OClientBased(conf)) {
+      if (instantiatedContext.get() == null)
+        if (H2O.API_PORT == 0) { // api port different than 0 means that client is already running
+          val checkedConf = checkAndUpdateConf(conf)
+          instantiatedContext.set(new H2OContext(checkedConf))
+        } else {
+          throw new IllegalArgumentException(
+            """
+              |H2O context hasn't been started successfully in the previous attempt and H2O client with previous configuration is already running.
+              |Because of the current H2O limitation that it can't be restarted within a running JVM,
+              |please restart your job or spark session and create new H2O context with new configuration.")
+          """.stripMargin)
+        }
+    } else {
+      val existingContext = instantiatedContext.get()
+      if (existingContext != null) {
+        val isExternalBackend = conf.runsInExternalClusterMode
+        val startedManually = existingContext.getConf.isManualClusterStartUsed
+        if (isExternalBackend && startedManually) {
+          if (conf.h2oCluster.isEmpty) {
+            throw new IllegalArgumentException("H2O cluster endpoint has to be specified!")
+          }
+          if (connectingToNewCluster(existingContext, conf)) {
+            val checkedConf = checkAndUpdateConf(conf)
+            instantiatedContext.set(new H2OContext(checkedConf))
+            logWarning(s"Connecting to a new external H2O cluster : ${checkedConf.h2oCluster.get}")
+          }
+        }
+      } else {
+        val checkedConf = checkAndUpdateConf(conf)
+        instantiatedContext.set(new H2OContext(checkedConf))
+      }
+    }
+    instantiatedContext.get()
+  }
+
+  /**
+    * Get existing or create new H2OContext
+    *
+    * @return H2O Context
+    */
+  def getOrCreate(): H2OContext = {
+    getOrCreate(Option(instantiatedContext.get()).map(_.getConf).getOrElse(new H2OConf()))
+  }
+
+  private def logStartingInfo(conf: H2OConf): Unit = {
+    logInfo("Sparkling Water version: " + BuildInfo.SWVersion)
+    logInfo("Spark version: " + SparkSessionUtils.active.version)
+    logInfo("Integrated H2O version: " + BuildInfo.H2OVersion)
+    logInfo("The following Spark configuration is used: \n    " + conf.getAll.mkString("\n    "))
+  }
+
+  /** Checks whether version of provided Spark is the same as Spark's version designated for this Sparkling Water version.
+    * We check for correct version in shell scripts and during the build but we need to do the check also in the code in cases when the user
+    * executes for example spark-shell command with sparkling water assembly jar passed as --jars and initiates H2OContext.
+    * (Because in that case no check for correct Spark version has been done so far.)
+    */
+  private def verifySparkVersion(): Unit = {
+    val sc = SparkSessionUtils.active.sparkContext
+    val runningOnCorrectSpark = sc.version.startsWith(BuildInfo.buildSparkMajorVersion)
+    if (!runningOnCorrectSpark) {
+      throw new WrongSparkVersion(
+        s"You are trying to use Sparkling Water built for Spark ${BuildInfo.buildSparkMajorVersion}," +
+          s" but your Spark is of version ${sc.version}. Please make sure to use correct Sparkling Water for your" +
+          s" Spark and re-run the application.")
+    }
+  }
+
+  private def getSparkHome(conf: SparkConf): String = {
+    conf.getOption("spark.home").orElse(Option(System.getenv("SPARK_HOME"))).getOrElse("SPARK_HOME is not defined!")
+  }
+}

--- a/core/src/main/scala/ai/h2o/sparkling/H2OFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OFrame.scala
@@ -30,7 +30,6 @@ import ai.h2o.sparkling.utils.Base64Encoding
 import ai.h2o.sparkling.utils.ScalaUtils.withResource
 import com.google.gson.{Gson, JsonElement}
 import org.apache.commons.io.IOUtils
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.api.schemas3.FrameChunksV3.FrameChunkV3
 import water.api.schemas3.FrameV3.ColV3
 import water.api.schemas3._
@@ -171,7 +170,7 @@ class H2OFrame private (
     val anotherFrame = hc.asSparkFrame(another.frameId)
     val sameCols = anotherFrame.columns.intersect(currentFrame.columns)
     val joined = currentFrame.join(anotherFrame, sameCols, method)
-    H2OFrame(hc.asH2OFrameKeyString(joined))
+    hc.asH2OFrame(joined)
   }
 
   /**

--- a/core/src/main/scala/ai/h2o/sparkling/SparklingWaterDriver.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/SparklingWaterDriver.scala
@@ -19,7 +19,6 @@ package ai.h2o.sparkling
 
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkConf
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 
 /**
   * A simple wrapper to allow launching H2O itself on the

--- a/core/src/main/scala/ai/h2o/sparkling/SparklingWaterWithHiveDriver.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/SparklingWaterWithHiveDriver.scala
@@ -19,7 +19,6 @@ package ai.h2o.sparkling
 
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkConf
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 
 /**
   * A simple wrapper to allow launching H2O itself on the

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OAwareBaseRDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OAwareBaseRDD.scala
@@ -16,7 +16,7 @@
  */
 package ai.h2o.sparkling.backend
 
-import org.apache.spark.h2o.H2OContext
+import ai.h2o.sparkling.H2OContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{OneToOneDependency, Partition, SparkContext}
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OChunk.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OChunk.scala
@@ -19,12 +19,12 @@ package ai.h2o.sparkling.backend
 
 import java.io.{InputStream, OutputStream}
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestCommunication}
 import ai.h2o.sparkling.extensions.rest.api.Paths
 import ai.h2o.sparkling.extensions.serde.ExpectedTypes.ExpectedType
 import ai.h2o.sparkling.utils.ScalaUtils.withResource
 import ai.h2o.sparkling.utils.{Base64Encoding, Compression}
-import org.apache.spark.h2o.H2OConf
 import water.AutoBuffer
 
 private[sparkling] case class H2OChunk(index: Int, numberOfRows: Int, location: NodeDesc)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OContextImplicits.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OContextImplicits.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.h2o.sparkling.backend
+
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
+import org.apache.spark._
+import org.apache.spark.h2o.RDD
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.sql.{DataFrame, Dataset}
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+/**
+  * Implicit transformations available on [[ai.h2o.sparkling.H2OContext]]
+  */
+abstract class H2OContextImplicits {
+
+  protected def hc: H2OContext
+
+  implicit def asH2OFrameFromRDDProduct[A <: Product: ClassTag: TypeTag](rdd: RDD[A]): H2OFrame =
+    hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDString(rdd: RDD[String]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDBool(rdd: RDD[Boolean]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDDouble(rdd: RDD[Double]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDLong(rdd: RDD[Long]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDByte(rdd: RDD[Byte]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDShort(rdd: RDD[Short]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDTimeStamp(rdd: RDD[java.sql.Timestamp]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDLabeledPoint(rdd: RDD[LabeledPoint]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDMLlibVector(rdd: RDD[mllib.linalg.Vector]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromRDDMlVector(rdd: RDD[ml.linalg.Vector]): H2OFrame = hc.asH2OFrame(rdd, None)
+
+  implicit def asH2OFrameFromDataFrame(df: DataFrame): H2OFrame = hc.asH2OFrame(df, None)
+
+  implicit def asH2OFrameFromDataset[T <: Product: ClassTag: TypeTag](ds: Dataset[T]): H2OFrame =
+    hc.asH2OFrame(ds, None)
+
+  implicit def symbolToString(sy: scala.Symbol): String = sy.name
+}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OContextImplicits.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OContextImplicits.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.backend
 
 import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import org.apache.spark._
-import org.apache.spark.h2o.RDD
 import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset}
 
 import scala.reflect.ClassTag

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OContextImplicits.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OContextImplicits.scala
@@ -60,6 +60,4 @@ abstract class H2OContextImplicits {
 
   implicit def asH2OFrameFromDataset[T <: Product: ClassTag: TypeTag](ds: Dataset[T]): H2OFrame =
     hc.asH2OFrame(ds, None)
-
-  implicit def symbolToString(sy: scala.Symbol): String = sy.name
 }

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2ODataFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2ODataFrame.scala
@@ -18,12 +18,10 @@
 package ai.h2o.sparkling.backend
 
 import ai.h2o.sparkling.backend.utils.SupportedTypes._
-import ai.h2o.sparkling.SparkTimeZone
+import ai.h2o.sparkling.{H2OContext, H2OFrame, SparkTimeZone}
 import ai.h2o.sparkling.backend.converters.DataTypeConverter
 import ai.h2o.sparkling.backend.utils.ReflectionUtils
-import ai.h2o.sparkling.H2OFrame
 import ai.h2o.sparkling.extensions.serde.ExpectedTypes.ExpectedType
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.{Partition, TaskContext}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OFrameRelation.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OFrameRelation.scala
@@ -18,8 +18,7 @@
 package ai.h2o.sparkling.backend
 
 import ai.h2o.sparkling.backend.utils.ReflectionUtils
-import ai.h2o.sparkling.{H2OColumn, H2OColumnType, H2OFrame}
-import org.apache.spark.h2o.H2OContext
+import ai.h2o.sparkling.{H2OColumn, H2OColumnType, H2OContext, H2OFrame}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.{BaseRelation, PrunedScan, TableScan}
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField, StructType}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2OJob.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2OJob.scala
@@ -17,10 +17,10 @@
 
 package ai.h2o.sparkling.backend
 
+import ai.h2o.sparkling.{H2OConf, H2OContext}
 import ai.h2o.sparkling.backend.utils.RestApiUtils.getClusterEndpoint
 import ai.h2o.sparkling.backend.utils.RestCommunication
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.api.schemas3.{JobV3, JobsV3}
 
 private[sparkling] class H2OJob private (val id: String) extends Logging {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/H2ORDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/H2ORDD.scala
@@ -22,8 +22,7 @@ import java.lang.reflect.Constructor
 import ai.h2o.sparkling.backend.converters.DataTypeConverter
 import ai.h2o.sparkling.backend.utils.ProductType
 import ai.h2o.sparkling.extensions.serde.ExpectedTypes.ExpectedType
-import ai.h2o.sparkling.{H2OFrame, SparkTimeZone}
-import org.apache.spark.h2o.H2OContext
+import ai.h2o.sparkling.{H2OContext, H2OFrame, SparkTimeZone}
 import org.apache.spark.{Partition, TaskContext}
 
 import scala.annotation.meta.{field, getter, param}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/Reader.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/Reader.scala
@@ -19,12 +19,12 @@ package ai.h2o.sparkling.backend
 
 import java.util.TimeZone
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.converters.TimeZoneConversions
 import ai.h2o.sparkling.backend.utils.SupportedTypes
 import ai.h2o.sparkling.backend.utils.SupportedTypes._
 import ai.h2o.sparkling.extensions.serde.ChunkAutoBufferReader
 import ai.h2o.sparkling.extensions.serde.ExpectedTypes.ExpectedType
-import org.apache.spark.h2o.H2OConf
 import org.apache.spark.unsafe.types.UTF8String
 
 private[backend] class Reader(

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -17,7 +17,7 @@
 
 package ai.h2o.sparkling.backend
 
-import org.apache.spark.h2o.H2OConf
+import ai.h2o.sparkling.H2OConf
 
 import scala.collection.JavaConverters._
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SparklingBackend.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SparklingBackend.scala
@@ -17,7 +17,7 @@
 
 package ai.h2o.sparkling.backend
 
-import org.apache.spark.h2o.H2OConf
+import ai.h2o.sparkling.H2OConf
 
 trait SparklingBackend {
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/Writer.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/Writer.scala
@@ -19,7 +19,7 @@ package ai.h2o.sparkling.backend
 
 import java.io.Closeable
 
-import ai.h2o.sparkling.H2OFrame
+import ai.h2o.sparkling.{H2OConf, H2OFrame}
 import ai.h2o.sparkling.H2OFrame.query
 import ai.h2o.sparkling.backend.utils.RestApiUtils.getClusterEndpoint
 import ai.h2o.sparkling.extensions.rest.api.Paths
@@ -28,7 +28,7 @@ import ai.h2o.sparkling.backend.converters.{CategoricalDomainBuilder, TimeZoneCo
 import ai.h2o.sparkling.extensions.serde.{ChunkAutoBufferWriter, ExpectedTypes, SerdeUtils}
 import ai.h2o.sparkling.utils.ScalaUtils.withResource
 import ai.h2o.sparkling.utils.SparkSessionUtils
-import org.apache.spark.h2o.{H2OConf, RDD}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 import org.apache.spark.{ExposeUtils, TaskContext, ml, mllib}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/WriterMetadata.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/WriterMetadata.scala
@@ -18,8 +18,8 @@ package ai.h2o.sparkling.backend
 
 import java.util.TimeZone
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.extensions.serde.ExpectedTypes.ExpectedType
-import org.apache.spark.h2o.H2OConf
 
 case class WriterMetadata(
     conf: H2OConf,

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/ServletRegister.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/ServletRegister.scala
@@ -17,8 +17,8 @@
 
 package ai.h2o.sparkling.backend.api
 
+import ai.h2o.sparkling.H2OConf
 import javax.servlet.Servlet
-import org.apache.spark.h2o.H2OConf
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder, ServletMapping}
 
 private[api] trait ServletRegister {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/dataframes/DataFramesRestApi.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/dataframes/DataFramesRestApi.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.backend.api.dataframes
 
 import java.net.URI
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.backend.utils.RestApiUtils
-import org.apache.spark.h2o.H2OContext
 
 trait DataFramesRestApi extends RestApiUtils {
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/dataframes/DataFramesServlet.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/dataframes/DataFramesServlet.scala
@@ -16,12 +16,11 @@
  */
 package ai.h2o.sparkling.backend.api.dataframes
 
-import ai.h2o.sparkling.H2OFrame
 import ai.h2o.sparkling.backend.api.{ServletBase, ServletRegister}
 import ai.h2o.sparkling.utils.SparkSessionUtils
+import ai.h2o.sparkling.{H2OConf, H2OContext}
 import javax.servlet.Servlet
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.exceptions.H2ONotFoundArgumentException
 
 /**
@@ -70,7 +69,7 @@ private[api] class DataFramesServlet extends ServletBase {
 
   def toH2OFrame(dataFrameId: String, h2oFrameId: Option[String]): DataFrameToH2OFrame = {
     val dataFrame = sqlContext.table(dataFrameId)
-    val h2oFrame = H2OFrame(H2OContext.ensure().asH2OFrameKeyString(dataFrame, h2oFrameId))
+    val h2oFrame = H2OContext.ensure().asH2OFrame(dataFrame, h2oFrameId)
     DataFrameToH2OFrame(dataFrameId, h2oFrame.frameId)
   }
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/h2oframes/H2OFramesRestApi.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/h2oframes/H2OFramesRestApi.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.backend.api.h2oframes
 
 import java.net.URI
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestEncodingUtils}
-import org.apache.spark.h2o.H2OContext
 
 trait H2OFramesRestApi extends RestApiUtils with RestEncodingUtils {
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/h2oframes/H2OFramesServlet.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/h2oframes/H2OFramesServlet.scala
@@ -16,11 +16,11 @@
  */
 package ai.h2o.sparkling.backend.api.h2oframes
 
+import ai.h2o.sparkling.{H2OConf, H2OContext}
 import ai.h2o.sparkling.backend.api.{ServletBase, ServletRegister}
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import javax.servlet.Servlet
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.exceptions.H2ONotFoundArgumentException
 
 /**

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/rdds/RDDsRestApi.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/rdds/RDDsRestApi.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.backend.api.rdds
 
 import java.net.URI
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.backend.utils.RestApiUtils
-import org.apache.spark.h2o.H2OContext
 
 trait RDDsRestApi extends RestApiUtils {
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/rdds/RDDsServlet.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/rdds/RDDsServlet.scala
@@ -17,12 +17,11 @@
 
 package ai.h2o.sparkling.backend.api.rdds
 
-import ai.h2o.sparkling.H2OFrame
+import ai.h2o.sparkling.{H2OConf, H2OContext, H2OFrame}
 import ai.h2o.sparkling.backend.api.{ServletBase, ServletRegister}
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import javax.servlet.Servlet
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
@@ -77,18 +76,18 @@ private[api] class RDDsServlet extends ServletBase {
   private def convertToH2OFrame(rdd: RDD[_], name: Option[String]): H2OFrame = {
     if (rdd.isEmpty()) {
       // transform empty Seq in order to create empty H2OFrame
-      H2OFrame(hc.asH2OFrameKeyString(sc.parallelize(Seq.empty[Int]), name))
+      hc.asH2OFrame(sc.parallelize(Seq.empty[Int]), name)
     } else {
       rdd.first() match {
-        case _: Double => H2OFrame(hc.asH2OFrameKeyString(rdd.asInstanceOf[RDD[Double]], name))
-        case _: LabeledPoint => H2OFrame(hc.asH2OFrameKeyString(rdd.asInstanceOf[RDD[LabeledPoint]], name))
-        case _: Boolean => H2OFrame(hc.asH2OFrameKeyString(rdd.asInstanceOf[RDD[Boolean]], name))
-        case _: String => H2OFrame(hc.asH2OFrameKeyString(rdd.asInstanceOf[RDD[String]], name))
-        case _: Int => H2OFrame(hc.asH2OFrameKeyString(rdd.asInstanceOf[RDD[Int]], name))
-        case _: Float => H2OFrame(hc.asH2OFrameKeyString(rdd.asInstanceOf[RDD[Float]], name))
-        case _: Long => H2OFrame(hc.asH2OFrameKeyString(rdd.asInstanceOf[RDD[Long]], name))
+        case _: Double => hc.asH2OFrame(rdd.asInstanceOf[RDD[Double]], name)
+        case _: LabeledPoint => hc.asH2OFrame(rdd.asInstanceOf[RDD[LabeledPoint]], name)
+        case _: Boolean => hc.asH2OFrame(rdd.asInstanceOf[RDD[Boolean]], name)
+        case _: String => hc.asH2OFrame(rdd.asInstanceOf[RDD[String]], name)
+        case _: Int => hc.asH2OFrame(rdd.asInstanceOf[RDD[Int]], name)
+        case _: Float => hc.asH2OFrame(rdd.asInstanceOf[RDD[Float]], name)
+        case _: Long => hc.asH2OFrame(rdd.asInstanceOf[RDD[Long]], name)
         case _: java.sql.Timestamp =>
-          H2OFrame(hc.asH2OFrameKeyString(rdd.asInstanceOf[RDD[java.sql.Timestamp]], name))
+          hc.asH2OFrame(rdd.asInstanceOf[RDD[java.sql.Timestamp]], name)
         case _: Product =>
           val first = rdd.asInstanceOf[RDD[Product]].first()
           val fields = ScalaReflection.getConstructorParameters(first.getClass).map { v =>
@@ -97,7 +96,7 @@ private[api] class RDDsServlet extends ServletBase {
           }
           val df = SparkSessionUtils.active
             .createDataFrame(rdd.asInstanceOf[RDD[Product]].map(Row.fromTuple), StructType(fields))
-          H2OFrame(hc.asH2OFrameKeyString(df, name))
+          hc.asH2OFrame(df, name)
         case t => throw new IllegalArgumentException(s"Do not understand type $t")
       }
     }

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/scalainterpreter/ScalaInterpretJob.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/scalainterpreter/ScalaInterpretJob.scala
@@ -17,11 +17,11 @@
 
 package ai.h2o.sparkling.backend.api.scalainterpreter
 
-import java.util.concurrent.{Callable, ExecutorService, Executors}
+import java.util.concurrent.{Callable, ExecutorService}
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestCommunication}
 import ai.h2o.sparkling.repl.H2OInterpreter
-import org.apache.spark.h2o.H2OConf
 import water.api.schemas3.JobV3
 
 import scala.collection.concurrent.TrieMap

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/scalainterpreter/ScalaInterpreterRestApi.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/scalainterpreter/ScalaInterpreterRestApi.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.backend.api.scalainterpreter
 
 import java.net.URI
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.backend.utils.RestApiUtils
-import org.apache.spark.h2o.H2OContext
 
 trait ScalaInterpreterRestApi extends RestApiUtils {
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/api/scalainterpreter/ScalaInterpreterServlet.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/api/scalainterpreter/ScalaInterpreterServlet.scala
@@ -20,13 +20,13 @@ package ai.h2o.sparkling.backend.api.scalainterpreter
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{SynchronousQueue, ThreadPoolExecutor, TimeUnit}
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.api.{ServletBase, ServletRegister}
 import ai.h2o.sparkling.backend.utils.RestCommunication
 import ai.h2o.sparkling.repl.H2OInterpreter
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import javax.servlet.Servlet
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
-import org.apache.spark.h2o.H2OConf
 import water.exceptions.H2ONotFoundArgumentException
 
 import scala.collection.concurrent.TrieMap

--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/SparkDataFrameConverter.scala
@@ -17,12 +17,11 @@
 
 package ai.h2o.sparkling.backend.converters
 
-import ai.h2o.sparkling.{H2OFrame, SparkTimeZone}
 import ai.h2o.sparkling.backend.{H2OAwareRDD, H2OFrameRelation, Writer, WriterMetadata}
 import ai.h2o.sparkling.ml.utils.SchemaUtils._
 import ai.h2o.sparkling.utils.SparkSessionUtils
+import ai.h2o.sparkling.{H2OContext, H2OFrame, SparkTimeZone}
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.DataFrame
 
 object SparkDataFrameConverter extends Logging {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedDataset.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedDataset.scala
@@ -17,10 +17,9 @@
 
 package ai.h2o.sparkling.backend.converters
 
-import ai.h2o.sparkling.H2OFrame
 import ai.h2o.sparkling.utils.SparkSessionUtils
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import org.apache.spark._
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.sql.Dataset
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedDatasetConverter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedDatasetConverter.scala
@@ -17,9 +17,8 @@
 
 package ai.h2o.sparkling.backend.converters
 
-import ai.h2o.sparkling.H2OFrame
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.H2OContext
 
 object SupportedDatasetConverter extends Logging {
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedRDD.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedRDD.scala
@@ -17,10 +17,9 @@
 
 package ai.h2o.sparkling.backend.converters
 
-import ai.h2o.sparkling.H2OFrame
 import ai.h2o.sparkling.utils.SparkSessionUtils
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import org.apache.spark._
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedRDDConverter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/SupportedRDDConverter.scala
@@ -17,9 +17,8 @@
 
 package ai.h2o.sparkling.backend.converters
 
-import ai.h2o.sparkling.H2OFrame
 import ai.h2o.sparkling.backend.H2ORDD
-import org.apache.spark.h2o.H2OContext
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendConf.scala
@@ -17,10 +17,10 @@
 
 package ai.h2o.sparkling.backend.external
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.SharedBackendConf
 import ai.h2o.sparkling.utils.Compression
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.H2OConf
 
 import scala.collection.JavaConverters._
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
@@ -20,13 +20,13 @@ package ai.h2o.sparkling.backend.external
 import java.io.{File, FileInputStream, FileOutputStream}
 import java.util.Properties
 
+import ai.h2o.sparkling.{H2OConf, H2OContext}
 import ai.h2o.sparkling.backend.utils.{ArgumentBuilder, H2OClientUtils, SharedBackendUtils, ShellUtils}
 import ai.h2o.sparkling.backend.{SharedBackendConf, SparklingBackend}
 import ai.h2o.sparkling.utils.ScalaUtils._
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkFiles
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 
 import scala.io.Source
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
@@ -19,12 +19,12 @@ package ai.h2o.sparkling.backend.internal
 
 import java.io.{File, FileWriter}
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.SharedBackendConf
 import ai.h2o.sparkling.utils.ScalaUtils.withResource
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkEnv
 import org.apache.spark.expose.Utils
-import org.apache.spark.h2o.H2OConf
 
 /**
   * Internal backend configuration

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/AzureDatabricksUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/AzureDatabricksUtils.scala
@@ -19,9 +19,9 @@ package ai.h2o.sparkling.backend.utils
 
 import java.io.FileNotFoundException
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.SharedBackendConf
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.H2OConf
 
 object AzureDatabricksUtils extends Logging {
   private val externalFlowPort = 9009 // This port is exposed in Azure DBC

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OClientUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OClientUtils.scala
@@ -19,9 +19,9 @@ package ai.h2o.sparkling.backend.utils
 
 import java.net.{InetAddress, NetworkInterface}
 
+import ai.h2o.sparkling.{H2OConf, H2OContext}
 import ai.h2o.sparkling.backend.NodeDesc
 import org.apache.spark.SparkEnv
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import water.fvec.Frame
 import water.init.HostnameGuesser
 import water.{H2O, H2OStarter, Paxos}
@@ -32,7 +32,7 @@ import water.{H2O, H2OStarter, Paxos}
   */
 object H2OClientUtils extends SharedBackendUtils {
 
-  val PROP_REST_API_BASED_CLIENT: (String, Boolean) = ("spark.ext.h2o.rest.api.based.client", false)
+  val PROP_REST_API_BASED_CLIENT: (String, Boolean) = ("spark.ext.h2o.rest.api.based.client", true)
 
   def isH2OClientBased(conf: H2OConf): Boolean = {
     !conf.getBoolean(PROP_REST_API_BASED_CLIENT._1, PROP_REST_API_BASED_CLIENT._2)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/ProxyStarter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/ProxyStarter.scala
@@ -23,10 +23,10 @@ import ai.h2o.sparkling.backend.api.dataframes.DataFramesServlet
 import ai.h2o.sparkling.backend.api.h2oframes.H2OFramesServlet
 import ai.h2o.sparkling.backend.api.rdds.RDDsServlet
 import ai.h2o.sparkling.backend.api.scalainterpreter.ScalaInterpreterServlet
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkEnv
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.H2OConf
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.proxy.ProxyServlet.Transparent
 import org.eclipse.jetty.server.{HttpConnectionFactory, Server, ServerConnector}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
@@ -19,10 +19,10 @@ package ai.h2o.sparkling.backend.utils
 
 import java.net.URI
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.NodeDesc
 import ai.h2o.sparkling.extensions.rest.api.schema.LogLevelV3
 import org.apache.http.client.utils.URIBuilder
-import org.apache.spark.h2o.H2OConf
 import water.api.schemas3._
 
 trait RestApiUtils extends RestCommunication {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
@@ -20,6 +20,7 @@ package ai.h2o.sparkling.backend.utils
 import java.io._
 import java.net.{HttpURLConnection, URI, URL}
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.NodeDesc
 import ai.h2o.sparkling.backend.exceptions._
 import ai.h2o.sparkling.utils.ScalaUtils._
@@ -27,7 +28,6 @@ import ai.h2o.sparkling.utils.{Compression, FinalizingOutputStream}
 import com.google.gson.{ExclusionStrategy, FieldAttributes, GsonBuilder}
 import org.apache.commons.io.IOUtils
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.H2OConf
 
 import scala.collection.immutable.Map
 import scala.reflect.{ClassTag, classTag}

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/SecurityUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/SecurityUtils.scala
@@ -19,11 +19,11 @@ package ai.h2o.sparkling.backend.utils
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.SharedBackendConf
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkEnv
 import org.apache.spark.expose.Utils
-import org.apache.spark.h2o.H2OConf
 import water.network.SecurityUtils.SSLCredentials
 import water.network.{SecurityUtils => H2OSecurityUtils}
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/SharedBackendUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/SharedBackendUtils.scala
@@ -19,9 +19,9 @@ package ai.h2o.sparkling.backend.utils
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.{NodeDesc, SharedBackendConf}
 import org.apache.spark.expose.{Logging, Utils}
-import org.apache.spark.h2o.H2OConf
 import org.apache.spark.{SparkContext, SparkEnv, SparkFiles}
 
 /**

--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -17,9 +17,6 @@
 
 package org.apache.spark.h2o
 
-import ai.h2o.sparkling.backend.external.ExternalBackendConf
-import ai.h2o.sparkling.backend.internal.InternalBackendConf
-import ai.h2o.sparkling.repl.H2OInterpreter
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
@@ -28,91 +25,9 @@ import org.apache.spark.internal.Logging
   * Configuration holder which is representing
   * properties passed from user to Sparkling Water.
   */
-class H2OConf(val sparkConf: SparkConf)
-  extends Logging
-  with InternalBackendConf
-  with ExternalBackendConf
-  with Serializable {
-
+class H2OConf(sparkConf: SparkConf) extends ai.h2o.sparkling.H2OConf(sparkConf) {
+  this.set("spark.ext.h2o.rest.api.based.client", value = false)
   def this() = this(SparkSessionUtils.active.sparkContext.getConf)
-
-  H2OConf.checkDeprecatedOptions(sparkConf)
-  // Precondition
-  require(sparkConf != null, "Spark conf was null")
-
-  /** Copy this object */
-  override def clone: H2OConf = {
-    val conf = new H2OConf(sparkConf)
-    conf.setAll(getAll)
-    conf
-  }
-
-  /** Set a configuration variable. */
-  def set(key: String, value: String): H2OConf = {
-    sparkConf.set(key, value)
-    this
-  }
-
-  def set(key: String, value: Boolean): H2OConf = {
-    sparkConf.set(key, value.toString)
-    this
-  }
-
-  /** Remove a parameter from the configuration */
-  def remove(key: String): H2OConf = {
-    sparkConf.remove(key)
-    this
-  }
-
-  def contains(key: String): Boolean = sparkConf.contains(key)
-
-  /** Get a parameter; throws a NoSuchElementException if it's not set */
-  def get(key: String): String = sparkConf.get(key)
-
-  /** Get a parameter, falling back to a default if not set */
-  def get(key: String, defaultValue: String): String = sparkConf.get(key, defaultValue)
-
-  /** Get a parameter as an Option */
-  def getOption(key: String): Option[String] = sparkConf.getOption(key)
-
-  /** Get all parameters as a list of pairs */
-  def getAll: Array[(String, String)] = {
-    sparkConf.getAll
-  }
-
-  /** Set multiple parameters together */
-  def setAll(settings: Traversable[(String, String)]): H2OConf = {
-    sparkConf.setAll(settings)
-    this
-  }
-
-  /** Get a parameter as an integer, falling back to a default if not set */
-  def getInt(key: String, defaultValue: Int): Int = sparkConf.getInt(key, defaultValue)
-
-  /** Get a parameter as a long, falling back to a default if not set */
-  def getLong(key: String, defaultValue: Long): Long = sparkConf.getLong(key, defaultValue)
-
-  /** Get a parameter as a double, falling back to a default if not set */
-  def getDouble(key: String, defaultValue: Double): Double = sparkConf.getDouble(key, defaultValue)
-
-  /** Get a parameter as a boolean, falling back to a default if not set */
-  def getBoolean(key: String, defaultValue: Boolean): Boolean = sparkConf.getBoolean(key, defaultValue)
-
-  override def toString: String = {
-    if (runsInExternalClusterMode) {
-      externalConfString
-    } else {
-      internalConfString
-    }
-  }
-
-  def getScheme(): String = {
-    if (jks.isDefined && jksPass.isDefined) {
-      "https"
-    } else {
-      "http"
-    }
-  }
 }
 
 object H2OConf extends Logging {
@@ -120,34 +35,12 @@ object H2OConf extends Logging {
 
   def apply(sparkConf: SparkConf): H2OConf = new H2OConf(sparkConf)
 
-  private val deprecatedOptions = Map[String, String]()
-
-  private def checkDeprecatedOptions(sparkConf: SparkConf): Unit = {
-    deprecatedOptions.foreach {
-      case (deprecated, current) =>
-        val deprecatedValue = sparkConf.getOption(deprecated)
-        if (deprecatedValue.isDefined) {
-          val currentValue = sparkConf.getOption(current)
-          if (currentValue.isDefined) {
-            logWarning(
-              s"Both options '$deprecated' and '$current' are specified. " +
-                s"Using value '${currentValue.get}' of '$current' as the later one is deprecated.")
-          } else {
-            logWarning(
-              s"Please use '$current' as '$deprecated' is deprecated. Passing the value '${deprecatedValue.get}' to '$current'.")
-            sparkConf.set(current, deprecatedValue.get)
-          }
-        }
-    }
-  }
-
   private var _sparkConfChecked = false
 
   def sparkConfChecked = _sparkConfChecked
 
   def checkSparkConf(sparkConf: SparkConf): SparkConf = {
     _sparkConfChecked = true
-    sparkConf.set("spark.repl.class.outputDir", H2OInterpreter.classOutputDirectory.getAbsolutePath)
-    sparkConf
+    ai.h2o.sparkling.H2OConf.checkSparkConf(sparkConf)
   }
 }

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -47,10 +47,10 @@ class H2OContext private (val hc: ai.h2o.sparkling.H2OContext) {
   }
 
   def importHiveTable(
-                       database: String = HiveTableImporter.DEFAULT_DATABASE,
-                       table: String,
-                       partitions: Array[Array[String]] = null,
-                       allowMultiFormat: Boolean = false): H2OFrame = {
+      database: String = HiveTableImporter.DEFAULT_DATABASE,
+      table: String,
+      partitions: Array[Array[String]] = null,
+      allowMultiFormat: Boolean = false): H2OFrame = {
     new H2OFrame(hc.importHiveTable(database, table, partitions, allowMultiFormat).frameId)
   }
 

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -19,191 +19,108 @@ package org.apache.spark.h2o
 
 import java.util.concurrent.atomic.AtomicReference
 
-import ai.h2o.sparkling.backend._
+import ai.h2o.sparkling.backend.NodeDesc
 import ai.h2o.sparkling.backend.converters._
-import ai.h2o.sparkling.backend.exceptions.{H2OClusterNotReachableException, RestApiException, WrongSparkVersion}
-import ai.h2o.sparkling.backend.external._
-import ai.h2o.sparkling.backend.utils._
 import ai.h2o.sparkling.utils.SparkSessionUtils
-import org.apache.spark.expose.Utils
-import org.apache.spark.h2o.backends.internal.InternalH2OBackend
-import org.apache.spark.h2o.ui._
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql.DataFrame
-import water._
-import water.util.PrettyPrint
+import org.apache.spark.expose.Logging
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.{SparkContext, h2o}
+import water.api.ImportHiveTableHandler.HiveTableImporter
+import water.{DKV, Key}
 
 import scala.language.{implicitConversions, postfixOps}
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
-/**
-  * Main entry point for Sparkling Water functionality. H2O Context represents connection to H2O cluster and allows us
-  * to operate with it.
-  *
-  * H2O Context provides conversion methods from RDD/DataFrame to H2OFrame and back and also provides implicits
-  * conversions for desired transformations
-  *
-  * Sparkling Water can run in two modes. External cluster mode and internal cluster mode. When using external cluster
-  * mode, it tries to connect to existing H2O cluster using the provided spark
-  * configuration properties. In the case of internal cluster mode,it creates H2O cluster living in Spark - that means
-  * that each Spark executor will have one h2o instance running in it.  This mode is not
-  * recommended for big clusters and clusters where Spark executors are not stable.
-  *
-  * Cluster mode can be set using the spark configuration
-  * property spark.ext.h2o.mode which can be set in script starting sparkling-water or
-  * can be set in H2O configuration class H2OConf
-  */
-/**
-  * Create new H2OContext based on provided H2O configuration
-  *
-  * @param conf H2O configuration
-  */
-class H2OContext private (private val conf: H2OConf) extends H2OContextExtensions {
+class H2OContext private (val hc: ai.h2o.sparkling.H2OContext) {
   self =>
-  val sparkSession = SparkSessionUtils.active
-  val sparkContext = sparkSession.sparkContext
-  private val backendHeartbeatThread = createHeartBeatEventThread()
 
-  private var stopped = false
+  val sparkSession: SparkSession = SparkSessionUtils.active
+  val sparkContext: SparkContext = sparkSession.sparkContext
 
-  /** Here the client means Python or R H2O client */
-  private var clientConnected = false
+  def getH2ONodes(): Array[NodeDesc] = hc.getH2ONodes()
 
-  /** Used backend */
-  protected val backend: SparklingBackend = if (conf.runsInExternalClusterMode) {
-    new ExternalH2OBackend(this)
-  } else {
-    new InternalH2OBackend(this)
-  }
-  H2OContext.logStartingInfo(conf)
-  H2OContext.verifySparkVersion()
-  backend.startH2OCluster(conf)
-  private val nodes = connectToH2OCluster()
-  RestApiUtils.setTimeZone(conf, "UTC")
-  // The lowest priority used by Spark is 25 (removing temp dirs). We need to perform cleaning up of H2O
-  // resources before Spark does as we run as embedded application inside the Spark
-  private val shutdownHookRef = Utils.addShutdownHook(10) { () =>
-    logWarning("Spark shutdown hook called, stopping H2OContext!")
-    stop(stopSparkContext = false, stopJvm = false, inShutdownHook = true)
-  }
-  private val leaderNode = RestApiUtils.getLeaderNode(conf)
-  if (sparkContext.ui.isDefined) {
-    SparkSpecificUtils.addSparklingWaterTab(sparkContext)
-  }
-  private val (flowIp, flowPort) = {
-    val uri = ProxyStarter.startFlowProxy(conf)
-    (uri.getHost, uri.getPort)
-  }
-  updateUIAfterStart() // updates the spark UI
-  backendHeartbeatThread.start() // start backend heartbeats
-  logInfo(s"Sparkling Water ${BuildInfo.SWVersion} started, status of context: $this ")
+  def getConf: H2OConf = new h2o.H2OConf(hc.getConf.sparkConf)
 
-  def getH2ONodes(): Array[NodeDesc] = nodes
-
-  private[this] def updateUIAfterStart(): Unit = {
-    val cloudV3 = RestApiUtils.getClusterInfo(conf)
-    val h2oBuildInfo = H2OBuildInfo(
-      cloudV3.version,
-      cloudV3.branch_name,
-      cloudV3.last_commit_hash,
-      cloudV3.describe,
-      cloudV3.compiled_by,
-      cloudV3.compiled_on)
-    val h2oClusterInfo = H2OClusterInfo(
-      s"$flowIp:$flowPort",
-      cloudV3.cloud_healthy,
-      cloudV3.internal_security_enabled,
-      nodes.map(_.ipPort()),
-      backend.backendUIInfo,
-      cloudV3.cloud_uptime_millis)
-    val swPropertiesInfo = conf.getAll.filter(_._1.startsWith("spark.ext.h2o"))
-
-    Utils.postToListenerBus(getSparklingWaterHeartbeatEvent())
-    Utils.postToListenerBus(H2OContextStartedEvent(h2oClusterInfo, h2oBuildInfo, swPropertiesInfo))
+  def downloadH2OLogs(destinationDir: String, logContainer: String): String = {
+    hc.downloadH2OLogs(destinationDir, logContainer)
   }
 
-  /**
-    * Return a copy of this H2OContext's configuration. The configuration ''cannot'' be changed at runtime.
-    */
-  def getConf: H2OConf = conf.clone()
+  def importHiveTable(
+                       database: String = HiveTableImporter.DEFAULT_DATABASE,
+                       table: String,
+                       partitions: Array[Array[String]] = null,
+                       allowMultiFormat: Boolean = false): H2OFrame = {
+    new H2OFrame(hc.importHiveTable(database, table, partitions, allowMultiFormat).frameId)
+  }
 
-  /**
-    * The method transforms RDD to H2OFrame and returns String representation of its key.
-    *
-    * @param rdd Input RDD
-    * @return String representation of H2O Frame Key
-    */
+  object implicits extends H2OContextImplicits with Serializable {
+    protected override def _h2oContext: H2OContext = self
+  }
+
+  override def toString: String = hc.toString
+
+  def openFlow(): Unit = hc.openFlow()
+
+  def stop(stopSparkContext: Boolean = false): Unit = hc.stop(stopSparkContext)
+
+  def flowURL(): String = hc.flowURL()
+
+  def setH2OLogLevel(level: String): Unit = hc.setH2OLogLevel(level)
+
+  def getH2OLogLevel(): String = hc.getH2OLogLevel()
+
+  def h2oLocalClient: String = hc.h2oLocalClient
+
+  def h2oLocalClientIp: String = hc.h2oLocalClientIp
+
+  def h2oLocalClientPort: Int = hc.h2oLocalClientPort
+
   def asH2OFrameKeyString(rdd: SupportedRDD): String = asH2OFrameKeyString(rdd, None)
 
   def asH2OFrameKeyString(rdd: SupportedRDD, frameName: String): String = asH2OFrameKeyString(rdd, Some(frameName))
 
-  def asH2OFrameKeyString(rdd: SupportedRDD, frameName: Option[String]): String = {
-    SupportedRDDConverter.toH2OFrame(this, rdd, frameName).frameId
-  }
+  def asH2OFrameKeyString(rdd: SupportedRDD, frameName: Option[String]): String = hc.asH2OFrame(rdd, frameName).frameId
 
-  /** Transforms RDD[Supported type] to H2OFrame */
   def asH2OFrame(rdd: SupportedRDD): H2OFrame = asH2OFrame(rdd, None)
-
-  def asH2OFrame(rdd: SupportedRDD, frameName: Option[String]): H2OFrame =
-    withConversionDebugPrints(sparkContext, "SupportedRDD", {
-      val fr = SupportedRDDConverter.toH2OFrame(this, rdd, frameName)
-      new H2OFrame(fr.frameId)
-    })
 
   def asH2OFrame(rdd: SupportedRDD, frameName: String): H2OFrame = asH2OFrame(rdd, Option(frameName))
 
-  /** Transforms RDD[Supported type] to H2OFrame key */
-  def toH2OFrameKey(rdd: SupportedRDD): Key[_] = toH2OFrameKey(rdd, None)
+  def asH2OFrame(rdd: SupportedRDD, frameName: Option[String]): H2OFrame =
+    new H2OFrame(hc.asH2OFrame(rdd, frameName).frameId)
 
-  def toH2OFrameKey(rdd: SupportedRDD, frameName: Option[String]): Key[_] = asH2OFrame(rdd, frameName)._key
+  def toH2OFrameKey(rdd: SupportedRDD): Key[_] = toH2OFrameKey(rdd, None)
 
   def toH2OFrameKey(rdd: SupportedRDD, frameName: String): Key[_] = toH2OFrameKey(rdd, Option(frameName))
 
-  /** Transform DataFrame to H2OFrame */
-  def asH2OFrame(df: DataFrame): H2OFrame = asH2OFrame(df, None)
+  def toH2OFrameKey(rdd: SupportedRDD, frameName: Option[String]): Key[_] = asH2OFrame(rdd, frameName)._key
 
-  def asH2OFrame(df: DataFrame, frameName: Option[String]): H2OFrame =
-    withConversionDebugPrints(
-      sparkContext,
-      "DataFrame",
-      new H2OFrame(SparkDataFrameConverter.toH2OFrame(this, df, frameName).frameId))
+  def asH2OFrame(df: DataFrame): H2OFrame = asH2OFrame(df, None)
 
   def asH2OFrame(df: DataFrame, frameName: String): H2OFrame = asH2OFrame(df, Option(frameName))
 
-  /**
-    * The method transforms Spark DataFrame to H2OFrame and returns String representation of its key.
-    *
-    * @param df Input data frame
-    * @return String representation of H2O Frame Key
-    */
+  def asH2OFrame(df: DataFrame, frameName: Option[String]): H2OFrame =
+    new H2OFrame(hc.asH2OFrame(df, frameName).frameId)
+
   def asH2OFrameKeyString(df: DataFrame): String = asH2OFrameKeyString(df, None)
 
   def asH2OFrameKeyString(df: DataFrame, frameName: String): String = asH2OFrameKeyString(df, Some(frameName))
 
-  def asH2OFrameKeyString(df: DataFrame, frameName: Option[String]): String = {
-    SparkDataFrameConverter.toH2OFrame(this, df.toDF(), frameName).frameId
-  }
+  def asH2OFrameKeyString(df: DataFrame, frameName: Option[String]): String = hc.asH2OFrame(df, frameName).frameId
 
-  /** Transform DataFrame to H2OFrame key */
   def toH2OFrameKey(df: DataFrame): Key[Frame] = toH2OFrameKey(df, None)
-
-  def toH2OFrameKey(df: DataFrame, frameName: Option[String]): Key[Frame] = asH2OFrame(df, frameName)._key
 
   def toH2OFrameKey(df: DataFrame, frameName: String): Key[Frame] = toH2OFrameKey(df, Option(frameName))
 
-  /** Transforms Dataset[Supported type] to H2OFrame */
-  def asH2OFrame(ds: SupportedDataset): H2OFrame = asH2OFrame(ds, None)
+  def toH2OFrameKey(df: DataFrame, frameName: Option[String]): Key[Frame] = asH2OFrame(df, frameName)._key
 
-  def asH2OFrame(ds: SupportedDataset, frameName: Option[String]): H2OFrame =
-    withConversionDebugPrints(sparkContext, "SupportedDataset", {
-      val fr = SupportedDatasetConverter.toH2OFrame(this, ds, frameName)
-      new H2OFrame(fr.frameId)
-    })
+  def asH2OFrame(ds: SupportedDataset): H2OFrame = asH2OFrame(ds, None)
 
   def asH2OFrame(ds: SupportedDataset, frameName: String): H2OFrame = asH2OFrame(ds, Option(frameName))
 
-  /** Transforms Dataset[Supported type] to H2OFrame key */
+  def asH2OFrame(ds: SupportedDataset, frameName: Option[String]): H2OFrame =
+    new H2OFrame(hc.asH2OFrame(ds, frameName).frameId)
+
   def toH2OFrameKey(ds: SupportedDataset): Key[Frame] = toH2OFrameKey(ds, None)
 
   def toH2OFrameKey(ds: SupportedDataset, frameName: Option[String]): Key[Frame] =
@@ -217,329 +134,67 @@ class H2OContext private (private val conf: H2OConf) extends H2OContextExtension
   def asH2OFrameKeyString(ds: SupportedDataset, frameName: String): String = asH2OFrameKeyString(ds, Some(frameName))
 
   def asH2OFrameKeyString(ds: SupportedDataset, frameName: Option[String]): String = {
-    SupportedDatasetConverter.toH2OFrame(this, ds, frameName).frameId
+    hc.asH2OFrame(ds, frameName).frameId
   }
 
-  /** Create a new H2OFrame based on existing Frame referenced by its key. */
   def asH2OFrame(s: String): H2OFrame = new H2OFrame(s)
 
-  /** Create a new H2OFrame based on existing Frame */
   def asH2OFrame(fr: Frame): H2OFrame = new H2OFrame(fr)
 
-  /** Convert given H2O frame into a Product RDD type
-    *
-    * Consider using asH2OFrame since asRDD has several limitations such as that asRDD can't be used in Spark REPL
-    * in case we are RDD[T] where T is class defined in REPL. This is because class T is created as inner class
-    * and we are not able to create instance of class T without outer scope - which is impossible to get.
-    * */
   def asRDD[A <: Product: TypeTag: ClassTag](fr: H2OFrame): RDD[A] = {
     DKV.put(fr)
-    SupportedRDDConverter.toRDD[A](this, ai.h2o.sparkling.H2OFrame(fr._key.toString))
+    hc.asRDD(ai.h2o.sparkling.H2OFrame(fr._key.toString))
   }
 
-  /** A generic convert of Frame into Product RDD type
-    *
-    * Consider using asH2OFrame since asRDD has several limitations such as that asRDD can't be used in Spark REPL
-    * in case we are RDD[T] where T is class defined in REPL. This is because class T is created as inner class
-    * and we are not able to create instance of class T without outer scope - which is impossible to get.
-    *
-    * This code: hc.asRDD[PUBDEV458Type](rdd) will need to be call as hc.asRDD[PUBDEV458Type].apply(rdd)
-    */
   def asRDD[A <: Product: TypeTag: ClassTag] = new {
     def apply[T <: Frame](fr: T): RDD[A] = {
       DKV.put(fr)
-      SupportedRDDConverter.toRDD[A](H2OContext.this, ai.h2o.sparkling.H2OFrame(fr._key.toString))
+      hc.asRDD[A](ai.h2o.sparkling.H2OFrame(fr._key.toString))
     }
   }
 
   def asRDD[A <: Product: TypeTag: ClassTag](fr: ai.h2o.sparkling.H2OFrame): org.apache.spark.rdd.RDD[A] = {
-    SupportedRDDConverter.toRDD[A](this, fr)
+    SupportedRDDConverter.toRDD[A](hc, fr)
   }
 
   def asSparkFrame[T <: Frame](fr: T, copyMetadata: Boolean = true): DataFrame = {
     DKV.put(fr)
-    SparkDataFrameConverter.toDataFrame(this, ai.h2o.sparkling.H2OFrame(fr._key.toString), copyMetadata)
+    SparkDataFrameConverter.toDataFrame(hc, ai.h2o.sparkling.H2OFrame(fr._key.toString), copyMetadata)
   }
 
   def asSparkFrame(fr: ai.h2o.sparkling.H2OFrame): DataFrame = {
-    SparkDataFrameConverter.toDataFrame(this, fr, copyMetadata = true)
+    SparkDataFrameConverter.toDataFrame(hc, fr, copyMetadata = true)
   }
 
   def asSparkFrame(s: String, copyMetadata: Boolean): DataFrame = {
     val frame = ai.h2o.sparkling.H2OFrame(s)
-    SparkDataFrameConverter.toDataFrame(this, frame, copyMetadata)
+    SparkDataFrameConverter.toDataFrame(hc, frame, copyMetadata)
   }
 
   def asSparkFrame(s: String): DataFrame = asSparkFrame(s, copyMetadata = true)
-
-  /** Returns location of REST API of H2O client */
-  def h2oLocalClient = leaderNode.hostname + ":" + leaderNode.port + conf.contextPath.getOrElse("")
-
-  /** Returns IP of H2O client */
-  def h2oLocalClientIp = leaderNode.hostname
-
-  /** Returns port where H2O REST API is exposed */
-  def h2oLocalClientPort = leaderNode.port
-
-  def setH2OLogLevel(level: String): Unit = {
-    if (H2OClientUtils.isH2OClientBased(conf)) {
-      water.util.Log.setLogLevel(level)
-    }
-    RestApiUtils.setLogLevel(conf, level)
-  }
-
-  def getH2OLogLevel(): String = RestApiUtils.getLogLevel(conf)
-
-  private def stop(stopSparkContext: Boolean, stopJvm: Boolean, inShutdownHook: Boolean): Unit = synchronized {
-    if (!inShutdownHook) {
-      Utils.removeShutdownHook(shutdownHookRef)
-    }
-    if (!stopped) {
-      backendHeartbeatThread.interrupt()
-      if (stopSparkContext) {
-        sparkContext.stop()
-      }
-      // Run orderly shutdown only in case of automatic mode of external backend, because:
-      // In internal backend, Spark takes care of stopping executors automatically
-      // In manual mode of external backend, the H2O cluster is managed by the user
-      if (conf.runsInExternalClusterMode && conf.isAutoClusterStartUsed) {
-        if (H2OClientUtils.isH2OClientBased(conf)) {
-          H2O.orderlyShutdown(conf.externalBackendStopTimeout)
-        } else {
-          RestApiUtils.shutdownCluster(conf)
-        }
-      }
-      H2OContext.instantiatedContext.set(null)
-      stopped = true
-      if (stopJvm && H2OClientUtils.isH2OClientBased(conf)) {
-        H2O.exit(0)
-      }
-    } else {
-      logWarning("H2OContext is already stopped!")
-    }
-  }
-
-  /** Stops H2O context.
-    *
-    * @param stopSparkContext stop also spark context
-    */
-  def stop(stopSparkContext: Boolean = false): Unit = {
-    stop(stopSparkContext, stopJvm = true, inShutdownHook = false)
-  }
-
-  def flowURL(): String = {
-    if (AzureDatabricksUtils.isRunningOnAzureDatabricks(conf)) {
-      AzureDatabricksUtils.flowURL(conf)
-    } else if (conf.clientFlowBaseurlOverride.isDefined) {
-      conf.clientFlowBaseurlOverride.get + conf.contextPath.getOrElse("")
-    } else {
-      "%s://%s:%d%s".format(conf.getScheme(), flowIp, flowPort, conf.contextPath.getOrElse(""))
-    }
-  }
-
-  /** Open H2O Flow running in this client. */
-  def openFlow(): Unit = openURI(flowURL())
-
-  override def toString: String = {
-    val basic =
-      s"""
-         |Sparkling Water Context:
-         | * Sparkling Water Version: ${BuildInfo.SWVersion}
-         | * H2O name: ${H2O.ARGS.name}
-         | * cluster size: ${nodes.length}
-         | * list of used nodes:
-         |  (executorId, host, port)
-         |  ------------------------
-         |  ${nodes.mkString("\n  ")}
-         |  ------------------------
-         |
-         |  Open H2O Flow in browser: ${flowURL()} (CMD + click in Mac OSX)
-         |
-    """.stripMargin
-    val sparkYarnAppId = if (sparkContext.master.toLowerCase.startsWith("yarn")) {
-      s"""
-         | * Yarn App ID of Spark application: ${sparkContext.applicationId}
-    """.stripMargin
-    } else {
-      ""
-    }
-
-    basic ++ sparkYarnAppId ++ backend.epilog
-  }
-
-  // scalastyle:off
-  // Disable style checker so "implicits" object can start with lowercase i
-  /** Define implicits available via h2oContext.implicits._ */
-  object implicits extends H2OContextImplicits with Serializable {
-    protected override def _h2oContext: H2OContext = self
-  }
-
-  // scalastyle:on
-
-  private def getSparklingWaterHeartbeatEvent(): SparklingWaterHeartbeatEvent = {
-    val ping = RestApiUtils.getPingInfo(conf)
-    val memoryInfo = ping.nodes.map(node => (node.ip_port, PrettyPrint.bytes(node.free_mem)))
-    SparklingWaterHeartbeatEvent(ping.cloud_healthy, ping.cloud_uptime_millis, memoryInfo)
-  }
-
-  private def connectToH2OCluster(): Array[NodeDesc] = {
-    logInfo("Connecting to H2O cluster.")
-    val nodes = getAndVerifyWorkerNodes(conf)
-    if (H2OClientUtils.isH2OClientBased(conf)) {
-      H2OClientUtils.startH2OClient(this, conf, nodes)
-    }
-    nodes
-  }
-
-  private def createHeartBeatEventThread(): Thread = {
-    new Thread {
-      setDaemon(true)
-
-      override def run(): Unit = {
-        while (!Thread.interrupted()) {
-          try {
-            val swHeartBeatInfo = getSparklingWaterHeartbeatEvent()
-            if (conf.runsInExternalClusterMode) {
-              if (!swHeartBeatInfo.cloudHealthy) {
-                logError("External H2O cluster not healthy!")
-                if (conf.isKillOnUnhealthyClusterEnabled) {
-                  logError("Stopping external H2O cluster as it is not healthy.")
-                  if (H2OClientUtils.isH2OClientBased(conf)) {
-                    H2OContext.this.stop(true)
-                  } else {
-                    H2OContext.this.stop(stopSparkContext = false, stopJvm = false, inShutdownHook = false)
-                  }
-                }
-              }
-            }
-            Utils.postToListenerBus(swHeartBeatInfo)
-          } catch {
-            case cause: RestApiException =>
-              H2OContext.get().head.stop(stopSparkContext = false, stopJvm = false, inShutdownHook = false)
-              throw new H2OClusterNotReachableException(
-                s"""External H2O cluster ${conf.h2oCluster.get + conf.contextPath
-                     .getOrElse("")} - ${conf.cloudName.get} is not reachable,
-                   |H2OContext has been closed! Please create a new H2OContext to a healthy and reachable (web enabled)
-                   |external H2O cluster.""".stripMargin,
-                cause)
-          }
-
-          try {
-            Thread.sleep(conf.backendHeartbeatInterval)
-          } catch {
-            case _: InterruptedException => Thread.currentThread.interrupt()
-          }
-        }
-      }
-    }
-  }
 }
 
 object H2OContext extends Logging {
-  private[H2OContext] def setInstantiatedContext(h2oContext: H2OContext): Unit = {
-    synchronized {
-      val ctx = instantiatedContext.get()
-      if (ctx == null) {
-        instantiatedContext.set(h2oContext)
-      }
-    }
-  }
 
   private val instantiatedContext = new AtomicReference[H2OContext]()
 
-  def get(): Option[H2OContext] = Option(instantiatedContext.get())
-
-  def ensure(onError: => String = "H2OContext has to be running."): H2OContext =
-    Option(instantiatedContext.get()) getOrElse {
-      throw new RuntimeException(onError)
-    }
-
-  private def connectingToNewCluster(hc: H2OContext, newConf: H2OConf): Boolean = {
-    val newCloudV3 = RestApiUtils.getClusterInfo(newConf)
-    val sameNodes = hc.getH2ONodes().map(_.ipPort()).sameElements(newCloudV3.nodes.map(_.ip_port))
-    !sameNodes
-  }
-
-  private def checkAndUpdateConf(conf: H2OConf): H2OConf = {
-    if (conf.runsInExternalClusterMode) {
-      ExternalH2OBackend.checkAndUpdateConf(conf)
-    } else {
-      InternalH2OBackend.checkAndUpdateConf(conf)
-    }
-  }
-
-  /**
-    * Get existing or create new H2OContext
-    *
-    * @param conf H2O configuration
-    * @return H2O Context
-    */
-  def getOrCreate(conf: H2OConf): H2OContext = synchronized {
-    if (H2OClientUtils.isH2OClientBased(conf)) {
-      if (instantiatedContext.get() == null)
-        if (H2O.API_PORT == 0) { // api port different than 0 means that client is already running
-          val checkedConf = checkAndUpdateConf(conf)
-          instantiatedContext.set(new H2OContext(checkedConf))
-        } else {
-          throw new IllegalArgumentException(
-            """
-              |H2O context hasn't been started successfully in the previous attempt and H2O client with previous configuration is already running.
-              |Because of the current H2O limitation that it can't be restarted within a running JVM,
-              |please restart your job or spark session and create new H2O context with new configuration.")
-          """.stripMargin)
-        }
-    } else {
-      val existingContext = instantiatedContext.get()
-      if (existingContext != null) {
-        val isExternalBackend = conf.runsInExternalClusterMode
-        val startedManually = existingContext.conf.isManualClusterStartUsed
-        if (isExternalBackend && startedManually) {
-          if (conf.h2oCluster.isEmpty) {
-            throw new IllegalArgumentException("H2O cluster endpoint has to be specified!")
-          }
-          if (connectingToNewCluster(existingContext, conf)) {
-            val checkedConf = checkAndUpdateConf(conf)
-            instantiatedContext.set(new H2OContext(checkedConf))
-            logWarning(s"Connecting to a new external H2O cluster : ${checkedConf.h2oCluster.get}")
-          }
-        }
-      } else {
-        val checkedConf = checkAndUpdateConf(conf)
-        instantiatedContext.set(new H2OContext(checkedConf))
-      }
-    }
+  def getOrCreate(): H2OContext = {
+    val hc = ai.h2o.sparkling.H2OContext.getOrCreate()
+    instantiatedContext.set(new H2OContext(hc))
     instantiatedContext.get()
   }
 
-  /**
-    * Get existing or create new H2OContext
-    *
-    * @return H2O Context
-    */
-  def getOrCreate(): H2OContext = {
-    getOrCreate(Option(instantiatedContext.get()).map(_.getConf).getOrElse(new H2OConf()))
+  def getOrCreate(conf: H2OConf): H2OContext = synchronized {
+    val hc = ai.h2o.sparkling.H2OContext.getOrCreate(conf)
+    instantiatedContext.set(new H2OContext(hc))
+    instantiatedContext.get()
   }
 
-  private def logStartingInfo(conf: H2OConf): Unit = {
-    logInfo("Sparkling Water version: " + BuildInfo.SWVersion)
-    logInfo("Spark version: " + SparkSessionUtils.active.version)
-    logInfo("Integrated H2O version: " + BuildInfo.H2OVersion)
-    logInfo("The following Spark configuration is used: \n    " + conf.getAll.mkString("\n    "))
-  }
+  def get(): Option[H2OContext] = Option(instantiatedContext.get())
 
-  /** Checks whether version of provided Spark is the same as Spark's version designated for this Sparkling Water version.
-    * We check for correct version in shell scripts and during the build but we need to do the check also in the code in cases when the user
-    * executes for example spark-shell command with sparkling water assembly jar passed as --jars and initiates H2OContext.
-    * (Because in that case no check for correct Spark version has been done so far.)
-    */
-  private def verifySparkVersion(): Unit = {
-    val sc = SparkSessionUtils.active.sparkContext
-    val runningOnCorrectSpark = sc.version.startsWith(BuildInfo.buildSparkMajorVersion)
-    if (!runningOnCorrectSpark) {
-      throw new WrongSparkVersion(
-        s"You are trying to use Sparkling Water built for Spark ${BuildInfo.buildSparkMajorVersion}," +
-          s" but your Spark is of version ${sc.version}. Please make sure to use correct Sparkling Water for your" +
-          s" Spark and re-run the application.")
+  def ensure(onError: => String = "H2OContext has to be running."): H2OContext = {
+    Option(instantiatedContext.get()) getOrElse {
+      throw new RuntimeException(onError)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/H2ORpcEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/H2ORpcEndpoint.scala
@@ -19,8 +19,8 @@ package org.apache.spark.h2o.backends.internal
 
 import java.net.InetAddress
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.NodeDesc
-import org.apache.spark.h2o.H2OConf
 import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 import water.util.Log
 import water.{H2O, H2ONode}

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendUtils.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalBackendUtils.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.h2o.backends.internal
 
+import ai.h2o.sparkling.H2OConf
 import ai.h2o.sparkling.backend.SharedBackendConf
 import ai.h2o.sparkling.backend.utils.{ArgumentBuilder, ReflectionUtils, SharedBackendUtils}
-import org.apache.spark.h2o.H2OConf
 import org.apache.spark.scheduler.local.LocalSchedulerBackend
 import org.apache.spark.{SparkContext, SparkEnv}
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -18,22 +18,23 @@
 package org.apache.spark.h2o.backends.internal
 
 import java.io.File
+
 import ai.h2o.sparkling.backend.external.ExternalBackendConf
 import ai.h2o.sparkling.backend.utils.RestApiUtils
 import ai.h2o.sparkling.backend.{NodeDesc, SparklingBackend}
 import ai.h2o.sparkling.utils.SparkSessionUtils
+import ai.h2o.sparkling.{H2OConf, H2OContext}
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.expose.Utils
 import org.apache.spark.h2o.backends.internal.InternalH2OBackend._
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorAdded}
 import org.apache.spark.util.RpcUtils
 import org.apache.spark.{SparkContext, SparkEnv}
+import water.hive.DelegationTokenRefresher
 import water.util.Log
 import water.{H2O, H2OStarter}
-import water.hive.DelegationTokenRefresher
 
 class InternalH2OBackend(@transient val hc: H2OContext) extends SparklingBackend with Logging {
 

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/SpreadRDDBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/SpreadRDDBuilder.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.h2o.backends.internal
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.backend.utils.SharedBackendUtils
 import org.apache.spark.expose.Logging
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.rpc.{RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.scheduler.local.LocalSchedulerBackend

--- a/core/src/test/scala/ai/h2o/sparkling/ConfigurationPropertiesTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/ConfigurationPropertiesTestSuite.scala
@@ -21,7 +21,6 @@ import java.net.{HttpURLConnection, URL}
 import java.nio.file.{Files, Path}
 import java.security.Permission
 
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import org.apache.spark.sql.SparkSession
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -172,7 +171,7 @@ abstract class ConfigurationPropertiesTestSuite_ExternalCommunicationCompression
       .option("inferSchema", "true")
       .csv(TestUtils.locate("smalldata/prostate/prostate.csv"))
 
-    val frame = H2OFrame(hc.asH2OFrameKeyString(dataset))
+    val frame = hc.asH2OFrame(dataset)
     val result = hc.asSparkFrame(frame)
 
     TestUtils.assertDataFramesAreIdentical(dataset, result)

--- a/core/src/test/scala/ai/h2o/sparkling/DataSourceTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/DataSourceTestSuite.scala
@@ -33,7 +33,7 @@ class DataSourceTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("Reading H2OFrame using key option") {
     val rdd = sc.parallelize(1 to 1000)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     val df = spark.read.format("h2o").option("key", h2oFrame.frameId).load()
 
     assert(df.columns.length == h2oFrame.numberOfColumns, "Number of columns should match")
@@ -43,7 +43,7 @@ class DataSourceTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("Reading H2OFrame using key in load method ") {
     val rdd = sc.parallelize(1 to 1000)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     val df = spark.read.format("h2o").load(h2oFrame.frameId)
 
     assert(df.columns.length == h2oFrame.numberOfColumns, "Number of columns should match")

--- a/core/src/test/scala/ai/h2o/sparkling/H2OConfTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/H2OConfTestSuite.scala
@@ -17,7 +17,6 @@
 package ai.h2o.sparkling
 
 import org.apache.spark.SparkConf
-import org.apache.spark.h2o.H2OConf
 import org.apache.spark.sql.SparkSession
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite

--- a/core/src/test/scala/ai/h2o/sparkling/H2OFrameTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/H2OFrameTestSuite.scala
@@ -123,12 +123,12 @@ class H2OFrameTestSuite extends FunSuite with SharedH2OTestContext {
     val leftDf = sc
       .parallelize(Seq(("A", 12, "NYC"), ("B", 13, "SF"), ("C", 14, "PRG"), ("D", 15, "SYD")))
       .toDF("name", "age", "city")
-    H2OFrame(hc.asH2OFrameKeyString(leftDf)).convertColumnsToCategorical(Array("name"))
+    hc.asH2OFrame(leftDf).convertColumnsToCategorical(Array("name"))
   }
 
   private lazy val rightFrame = {
     val rightDf = sc.parallelize(Seq(("Y", 10000), ("B", 20000), ("X", 30000), ("D", 40000))).toDF("name", "salary")
-    H2OFrame(hc.asH2OFrameKeyString(rightDf)).convertColumnsToCategorical(Array("name"))
+    hc.asH2OFrame(rightDf).convertColumnsToCategorical(Array("name"))
   }
 
   test("Left join") {

--- a/core/src/test/scala/ai/h2o/sparkling/SharedH2OTestContext.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/SharedH2OTestContext.scala
@@ -19,7 +19,6 @@ package ai.h2o.sparkling
 
 import java.security.Permission
 
-import org.apache.spark.h2o.{H2OConf, H2OContext}
 import org.scalatest.Suite
 
 /**

--- a/core/src/test/scala/ai/h2o/sparkling/SparkTestContext.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/SparkTestContext.scala
@@ -18,7 +18,6 @@
 package ai.h2o.sparkling
 
 import io.netty.util.internal.logging.{InternalLoggerFactory, Slf4JLoggerFactory}
-import org.apache.spark.h2o.H2OConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{BeforeAndAfterAll, Suite}

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
@@ -53,7 +53,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("Convert Empty dataframe, empty schema") {
     val schema = StructType(Seq())
     val empty = spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
-    val fr = H2OFrame(hc.asH2OFrameKeyString(empty))
+    val fr = hc.asH2OFrame(empty)
 
     assert(fr.numberOfColumns == 0)
     assert(fr.numberOfRows == 0)
@@ -62,7 +62,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("Convert Empty dataframe, non-empty schema") {
     val schema = StructType(Seq(StructField("name", StringType), StructField("age", IntegerType)))
     val empty = spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
-    val fr = H2OFrame(hc.asH2OFrameKeyString(empty))
+    val fr = hc.asH2OFrame(empty)
 
     assert(fr.numberOfColumns == 2)
     assert(fr.numberOfRows == 0)
@@ -70,7 +70,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("PUBDEV-766 H2OFrame[T_ENUM] to DataFrame[StringType]") {
     val df = spark.sparkContext.parallelize(Array("ONE", "ZERO", "ZERO", "ONE")).toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     h2oFrame.convertColumnsToCategorical(Array(0))
     assert(h2oFrame.columns(0).isCategorical())
 
@@ -89,7 +89,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val rdd = spark.sparkContext
       .parallelize(Array(1428517563L, 1428517564L, 1428517565L, 1428517566L).map(v => Row(new Timestamp(v))))
     val df = spark.createDataFrame(rdd, StructType(Seq(StructField("C0", TimestampType, nullable = true))))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assert(h2oFrame.columns(0).isTime())
 
     val dataFrame = hc.asSparkFrame(h2oFrame)
@@ -105,7 +105,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("H2OFrame[T_NUM(Byte)] to DataFrame[ByteType]") {
     val df = spark.sparkContext.parallelize(Array(-1, 2, -3, 4, -5, 6, -7, 8).map(_.toByte)).toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assert(h2oFrame.columns(0).isNumeric())
 
     val dataFrame = hc.asSparkFrame(h2oFrame)
@@ -121,7 +121,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("H2OFrame[T_NUM(Short)] to DataFrame[ShortType]") {
     val df = spark.sparkContext.parallelize(Array(-200, 201, -202, -207, 208).map(_.toShort)).toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assert(h2oFrame.columns(0).isNumeric())
 
     val dataFrame = hc.asSparkFrame(h2oFrame)
@@ -139,7 +139,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val df = spark.sparkContext
       .parallelize(Array(-100000, 100001, -100002, 100004, -100005, 100006, -100007, 100008))
       .toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assert(h2oFrame.columns(0).isNumeric())
 
     val dataFrame = hc.asSparkFrame(h2oFrame)
@@ -157,7 +157,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val df = spark.sparkContext
       .parallelize(Array(-8589934592L, 8589934593L, 8589934594L, -8589934595L))
       .toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assert(h2oFrame.columns(0).isNumeric())
 
     val dataFrame = hc.asSparkFrame(h2oFrame)
@@ -173,7 +173,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("H2OFrame[T_NUM(Double)] to DataFrame[DoubleType]") {
     val df = spark.sparkContext.parallelize(Array(-1.7, 23.456, -99.9, 100.00012)).toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assert(h2oFrame.columns(0).isNumeric())
 
     val dataFrame = hc.asSparkFrame(h2oFrame)
@@ -191,7 +191,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val df = spark.sparkContext
       .parallelize(Array("string1", "string2", "string3", "string4", "string5", "string6", "string7", "string8"))
       .toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assert(h2oFrame.columns(0).isString())
 
     val dataFrame = hc.asSparkFrame(h2oFrame)
@@ -215,7 +215,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
       "6870f256-e145-4d75-adb0-99ccb77d5d3f")
 
     val df = spark.sparkContext.parallelize(data).toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assert(h2oFrame.columns(0).isString())
 
     val dataFrame = hc.asSparkFrame(h2oFrame)
@@ -232,7 +232,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("DataFrame[ByteField] to H2OFrame[Numeric]") {
     val df = sc.parallelize(-127 to 127).map(v => ByteField(v.asInstanceOf[Byte])).toDF()
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isNumeric())
@@ -240,7 +240,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("DataFrame[ShortField] to H2OFrame[Numeric]") {
     val df = sc.parallelize(-2048 to 4096).map(v => ShortField(v.asInstanceOf[Short])).toDF()
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isNumeric())
@@ -249,7 +249,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("DataFrame[IntField] to H2OFrame[Numeric]") {
     val values = Seq(Int.MinValue, Int.MaxValue, 0, -100, 200, -5000, 568901)
     val df = sc.parallelize(values).map(v => IntField(v)).toDF()
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isNumeric())
@@ -258,7 +258,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("DataFrame[LongField] to H2OFrame[Numeric]") {
     val values = Seq(Long.MinValue, Long.MaxValue, 0L, -100L, 200L, -5000L, 5689323201L, -432432433335L)
     val df = sc.parallelize(values).map(v => LongField(v)).toDF()
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isNumeric())
@@ -267,7 +267,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("DataFrame[FloatField] to H2OFrame[Numeric]") {
     val values = Seq(Float.MinValue, Float.MaxValue, -33.33.toFloat, 200.001.toFloat, -5000.34.toFloat)
     val df = sc.parallelize(values).map(v => FloatField(v)).toDF
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isNumeric())
@@ -276,7 +276,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("DataFrame[BooleanField] to H2OFrame[Numeric]") {
     val values = Seq(true, false, true, false)
     val df = sc.parallelize(values).toDF()
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isNumeric())
@@ -286,7 +286,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("DataFrame[DoubleField] to H2OFrame[Numeric]") {
     val values = Seq(Double.MinValue, Double.MaxValue, -33.33, 200.001, -5000.34)
     val df = sc.parallelize(values).map(v => DoubleField(v)).toDF
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isNumeric())
@@ -296,7 +296,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val domSize = 3000
     val values = (1 to domSize).map(v => StringField(v + "-value"))
     val df = sc.parallelize(values).toDF()
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isString())
@@ -309,7 +309,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("DataFrame[String] to H2OFrame[T_STRING] and back") {
     val df = Seq("one", "two", "three", "four", "five", "six", "seven").toDF("Strings").repartition(3)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isString())
@@ -320,7 +320,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("DataFrame[String] to H2OFrame[T_CAT] and back") {
     val df = Seq("one", "two", "three", "one", "two", "three", "one").toDF("Strings").repartition(3)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isCategorical())
@@ -333,7 +333,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val dates = Seq("2020-12-12", "2020-01-01", "2020-02-02", "2019-05-10")
     val df = dates.toDF("strings").select('strings.cast("date").alias("dates"))
 
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isTime())
@@ -348,7 +348,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val num = 20
     val values = (1 to num).map(v => new Timestamp(v))
     val df = sc.parallelize(values).map(v => TimestampField(v)).toDF
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isTime())
@@ -358,7 +358,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val num = 20
     val values = (1 to num).map(v => ComposedWithTimestamp(PrimitiveA(v, v.toString), TimestampField(new Timestamp(v))))
     val df = sc.parallelize(values).toDF
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
     assert(h2oFrame.columns(0).isNumeric())
@@ -371,7 +371,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val num = 20
     val values = (1 to num).map(x => PrimitiveA(x, "name=" + x))
     val df = sc.parallelize(values).toDF
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
   }
@@ -380,7 +380,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val num = 20
     val values = (1 to num).map(x => ComposedA(PrimitiveA(x, "name=" + x), x * 3.14))
     val df = sc.parallelize(values).toDF
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
   }
@@ -389,7 +389,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val values = 1 to 100
     val df = sc.parallelize(values, 2000).map(v => IntField(v)).toDF
 
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     h2oFrame.split(0.5, 0.3, 0.1)
   }
 
@@ -422,7 +422,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(expandedSchema === expected)
 
     // Verify transformation into dataframe
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     assertH2OFrameInvariants(df, h2oFrame)
 
     // Verify data stored in h2oFrame after transformation
@@ -450,7 +450,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
         StructField("f.4", IntegerType, nullable = true, metadatas(4))))
 
     // Verify transformation into dataframe
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     // Basic invariants
     assert(df.count == h2oFrame.numberOfRows, "Number of rows has to match")
     assert(5 == h2oFrame.numberOfColumns, "Number columns should match")
@@ -478,7 +478,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
         StructField("f2", DoubleType)))
 
     // Verify transformation into DataFrame
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     // Basic invariants
     assert(df.count == h2oFrame.numberOfRows, "Number of rows has to match")
     assert(expandedSchema.length == h2oFrame.numberOfColumns, "Number columns should match")
@@ -505,7 +505,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
         StructField("f2", DoubleType)))
 
     // Verify transformation into DataFrame
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     // Basic invariants
     assert(df.count == h2oFrame.numberOfRows, "Number of rows has to match")
     assert(expandedSchema.length == h2oFrame.numberOfColumns, "Number columns should match")
@@ -530,7 +530,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
         StructField("f2", DoubleType)))
 
     // Verify transformation into DataFrame
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     // Basic invariants
     assert(df.count == h2oFrame.numberOfRows, "Number of rows has to match")
     assert(expandedSchema.length == h2oFrame.numberOfColumns, "Number columns should match")
@@ -551,7 +551,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     assert(expandedSchema === Vector(StructField("f0", DoubleType), StructField("f1", DoubleType)))
 
     // Verify transformation into DataFrame
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     // Basic invariants
     assert(df.count == h2oFrame.numberOfRows, "Number of rows has to match")
     assert(expandedSchema.length == h2oFrame.numberOfColumns, "Number columns should match")
@@ -580,7 +580,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
         StructField("f2", DoubleType)))
 
     // Verify transformation into DataFrame
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     // Basic invariants
     assert(df.count == h2oFrame.numberOfRows, "Number of rows has to match")
     assert(expandedSchema.length == h2oFrame.numberOfColumns, "Number columns should match")
@@ -617,7 +617,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
         StructField("f21", DoubleType, nullable = true)))
 
     // Verify transformation into DataFrame
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
 
     // Basic invariants
     assert(df.count == h2oFrame.numberOfRows, "Number of rows has to match")
@@ -647,7 +647,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("Add metadata to Dataframe categorical column") {
     val df = spark.sparkContext.parallelize(Array("ZERO", "ONE")).toDF("C0")
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(df))
+    val h2oFrame = hc.asH2OFrame(df)
     val h2oFrameWithCat = h2oFrame.convertColumnsToCategorical(Array(0))
     assert(h2oFrameWithCat.columns(0).isCategorical())
     val dataFrameEnum = hc.asSparkFrame(h2oFrameWithCat)
@@ -659,14 +659,14 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val df = sc.parallelize(Array("ok", "bad", "ok", "bad", "bad")).toDF("status")
     df.createOrReplaceTempView("responses")
     val dfDouble = spark.sqlContext.sql("SELECT IF(r.status = 'ok', 0.0, 1.0) AS cancelled FROM responses AS r")
-    val frame = H2OFrame(hc.asH2OFrameKeyString(dfDouble))
+    val frame = hc.asH2OFrame(dfDouble)
     assertVectorDoubleValues(frame.collectDoubles(0), Seq(0.0, 1.0, 0.0, 1.0, 1.0))
   }
 
   test("SW-304 DateType column conversion failure") {
     import java.sql.Date
     val df = sc.parallelize(Seq(DateField(Date.valueOf("2016-12-24")))).toDF("created_date")
-    val hf = H2OFrame(hc.asH2OFrameKeyString(df))
+    val hf = hc.asH2OFrame(df)
     assert(hf.numberOfRows == 1)
     assert(hf.numberOfColumns == 1)
     val expectedValue = DateTimeUtils.fromUTCTime(Date.valueOf("2016-12-24").getTime * 1000, TimeZone.getDefault.getID) / 1000
@@ -677,7 +677,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val dfInput = sc.parallelize(1 to 6).map(v => (v, v * v)).toDF("single", "double")
     dfInput.createOrReplaceTempView("dfInput")
     val df = spark.sqlContext.sql("SELECT *, IF(double < 5, 1.0, 0.0) AS label FROM dfInput")
-    val hf = H2OFrame(hc.asH2OFrameKeyString(df))
+    val hf = hc.asH2OFrame(df)
     assert(hf.numberOfRows == 6)
     assert(hf.numberOfColumns == 3)
     assertVectorIntValues(hf.collectInts("single"), Seq(1, 2, 3, 4, 5, 6))
@@ -694,7 +694,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
       .toDF()
     // just verify that we are really testing the binary type case
     assert(df.schema.fields(0).dataType == BinaryType)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(df))
+    val hf = hc.asH2OFrame(df)
     assert(hf.numberOfRows == 3)
     assert(hf.numberOfColumns == 3) // max size of the array is 3
 
@@ -707,7 +707,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
   test("Convert DataFrame to H2OFrame with dot in column name") {
     import spark.implicits._
     val df = sc.parallelize(1 to 10).toDF("with.dot")
-    val hf = H2OFrame(hc.asH2OFrameKeyString(df))
+    val hf = hc.asH2OFrame(df)
     assert(hf.columnNames.head == "with.dot")
   }
 
@@ -723,7 +723,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     import spark.implicits._
     val df = sc.parallelize(Seq(Person(Name("Charles", "Dickens"), 58), Person(Name("Terry", "Prachett"), 66))).toDF()
     val renamedDF = spark.sqlContext.createDataFrame(df.rdd, personSchema)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(renamedDF))
+    val hf = hc.asH2OFrame(renamedDF)
 
     assert(hf.columnNames.sameElements(Array("name.given.name", "name.family", "person.age")))
   }
@@ -737,7 +737,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val df = sc.parallelize(Seq((1 to numCols).mkString(","))).toDF
     val wideDF = df.withColumn("_tmp", split($"value", ",")).select(cols: _*).drop("_tmp")
 
-    val hf = H2OFrame(hc.asH2OFrameKeyString(wideDF))
+    val hf = hc.asH2OFrame(wideDF)
     val resultDF = hc.asSparkFrame(hf)
 
     assert(hf.numberOfColumns == numCols)

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DatasetConverterTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DatasetConverterTestSuite.scala
@@ -70,8 +70,7 @@ class DatasetConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   private lazy val testSourceDatasetWithPartialData = spark.createDataset(samplePartialPeople)
 
-  private lazy val testH2oFrameWithPartialData: H2OFrame = H2OFrame(
-    hc.asH2OFrameKeyString(testSourceDatasetWithPartialData))
+  private lazy val testH2oFrameWithPartialData: H2OFrame = hc.asH2OFrame(testSourceDatasetWithPartialData)
 
   test("Dataset[SamplePerson] to H2OFrame and back") {
 
@@ -90,49 +89,49 @@ class DatasetConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
   test("Dataset[Byte] to H2OFrame") {
     val ds = spark.range(3).map(_.toByte)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(ds))
+    val hf = hc.asH2OFrame(ds)
     assertVectorIntValues(hf.collectInts(0), Seq(0, 1, 2))
   }
 
   test("Dataset[Short] to H2OFrame") {
     val ds = spark.range(3).map(_.toShort)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(ds))
+    val hf = hc.asH2OFrame(ds)
     assertVectorIntValues(hf.collectInts(0), Seq(0, 1, 2))
   }
 
   test("Dataset[Int] to H2OFrame") {
     val ds = spark.range(3).map(_.toInt)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(ds))
+    val hf = hc.asH2OFrame(ds)
     assertVectorIntValues(hf.collectInts(0), Seq(0, 1, 2))
   }
 
   test("Dataset[Long] to H2OFrame") {
     val ds = spark.range(3).map(_.toLong)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(ds))
+    val hf = hc.asH2OFrame(ds)
     assertVectorIntValues(hf.collectInts(0), Seq(0, 1, 2))
   }
 
   test("Dataset[Float] to H2OFrame") {
     val ds = spark.range(3).map(_.toFloat)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(ds))
+    val hf = hc.asH2OFrame(ds)
     assertVectorDoubleValues(hf.collectDoubles(0), Seq(0, 1.0, 2.0))
   }
 
   test("Dataset[Double] to H2OFrame") {
     val ds = spark.range(3).map(_.toDouble)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(ds))
+    val hf = hc.asH2OFrame(ds)
     assertVectorDoubleValues(hf.collectDoubles(0), Seq(0, 1.0, 2.0))
   }
 
   test("Dataset[String] to H2OFrame") {
     val ds = spark.range(3).map(_.toString)
-    val hf = H2OFrame(hc.asH2OFrameKeyString(ds))
+    val hf = hc.asH2OFrame(ds)
     assertVectorStringValues(hf.collectStrings(0), Seq("0", "1", "2"))
   }
 
   test("Dataset[Boolean] to H2OFrame") {
     val ds = spark.sparkContext.parallelize(Seq(true, false, true)).toDS()
-    val hf = H2OFrame(hc.asH2OFrameKeyString(ds))
+    val hf = hc.asH2OFrame(ds)
     assertVectorIntValues(hf.collectInts(0), Seq(1, 0, 1))
   }
 
@@ -194,7 +193,7 @@ class DatasetConverterTestSuite extends FunSuite with SharedH2OTestContext {
       val expected: List[SamplePerson] = samplePartialPeopleWithAges map (p =>
         SamplePerson(p.name.orNull, p.age.get, p.email.orNull))
       val extracted =
-        readWholeFrame[SamplePerson](H2OFrame(hc.asH2OFrameKeyString(testSourceDatasetWithPartialDataAgesPresent)))
+        readWholeFrame[SamplePerson](hc.asH2OFrame(testSourceDatasetWithPartialDataAgesPresent))
 
       matchData(extracted, expected)
 
@@ -232,14 +231,14 @@ class DatasetConverterTestSuite extends FunSuite with SharedH2OTestContext {
       samplePartialPeopleWithAges.flatMap(p =>
         SampleCat(p.name.orNull, p.age.get) :: SampleCat(p.name.orNull, p.age.get) :: Nil)
     val extracted =
-      readWholeFrame[SampleCat](H2OFrame(hc.asH2OFrameKeyString(testSourceDatasetWithPartialDataAgesPresent)))
+      readWholeFrame[SampleCat](hc.asH2OFrame(testSourceDatasetWithPartialDataAgesPresent))
 
     matchData(extracted, sampleCats) // the idea is, all sample people are there, the rest is ignored
   }
 
   private lazy val testSourceDataset = spark.createDataset(samplePeople)
 
-  private lazy val testH2oFrame: H2OFrame = H2OFrame(hc.asH2OFrameKeyString(testSourceDataset))
+  private lazy val testH2oFrame: H2OFrame = hc.asH2OFrame(testSourceDataset)
 
   private def readWholeFrame[T <: Product: TypeTag: ClassTag](frame: H2OFrame) = {
     val asrdd: RDD[T] = hc.asRDD[T](frame)

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/SupportedRDDConverterTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/SupportedRDDConverterTestSuite.scala
@@ -38,7 +38,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Byte type") {
     val rdd = sc.parallelize(Array.empty[Byte])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -46,7 +46,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Short type") {
     val rdd = sc.parallelize(Array.empty[Short])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -54,7 +54,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Integer type") {
     val rdd = sc.parallelize(Array.empty[Integer])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -62,7 +62,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Long type") {
     val rdd = sc.parallelize(Array.empty[Long])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -70,7 +70,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Float type") {
     val rdd = sc.parallelize(Array.empty[Float])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -78,7 +78,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Double type") {
     val rdd = sc.parallelize(Array.empty[Double])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -86,7 +86,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, String type") {
     val rdd = sc.parallelize(Array.empty[String])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -94,7 +94,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Boolean type") {
     val rdd = sc.parallelize(Array.empty[Boolean])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -102,7 +102,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Timestamp type") {
     val rdd = sc.parallelize(Array.empty[Timestamp])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -110,7 +110,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Product type") {
     val rdd = sc.parallelize(Array.empty[ByteField])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -118,7 +118,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("Empty RDD to H2O frame, Labeled point") {
     val rdd = sc.parallelize(Array.empty[LabeledPoint])
-    val fr = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val fr = hc.asH2OFrame(rdd)
 
     assert(fr.numberOfColumns == 1)
     assert(fr.numberOfRows == 0)
@@ -146,7 +146,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("RDD[Option[Int]] to H2OFrame and back") {
     val rdd = sc.parallelize(1 to 3, 100).map(v => Some(v))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDHolderProperties(h2oFrame, rdd)
     assertVectorIntValues(h2oFrame.collectInts(0), Seq(1, 2, 3))
     h2oFrame.delete()
@@ -155,7 +155,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("RDD[Option[Int]] with nulls, does it hold nulls?") {
     val rdd = sc.parallelize(Seq(Some(1), None, Some(2)))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDHolderProperties(h2oFrame, rdd)
     assertVectorIntValues(h2oFrame.collectInts(0), Seq(1, 0, 2))
     h2oFrame.delete()
@@ -164,7 +164,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("RDD[Option[Double]] to H2OFrame and back") {
     val rdd = sc.parallelize(1 to 3, 100).map(v => Some(v.toDouble))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDHolderProperties(h2oFrame, rdd)
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(1.0, 2.0, 3.0))
     h2oFrame.delete()
@@ -173,7 +173,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("RDD[Option[Byte]] to H2OFrame and back") {
     val rdd = sc.parallelize(1 to 3, 100).map(v => Some(v.toByte))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDHolderProperties(h2oFrame, rdd)
     assertVectorIntValues(h2oFrame.collectInts(0), Seq(1, 2, 3))
     h2oFrame.delete()
@@ -182,7 +182,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("RDD[Option[Short]] to H2OFrame and back") {
     val rdd = sc.parallelize(1 to 3, 100).map(v => Some(v.toShort))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDHolderProperties(h2oFrame, rdd)
     assertVectorIntValues(h2oFrame.collectInts(0), Seq(1, 2, 3))
     h2oFrame.delete()
@@ -191,7 +191,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("RDD[Option[String]] to H2OFrame[Enum] and back") {
     val rdd = sc.parallelize(Seq(Some("1"), Some("2"), Some("1")))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDHolderProperties(h2oFrame, rdd)
     assertVectorIntValues(h2oFrame.collectInts(0), Seq(0, 1, 0))
     assert(h2oFrame.columns.head.isCategorical())
@@ -203,7 +203,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[Option[String]] to H2OFrame[String] and back") {
     val data = (1 to (Categorical.MAX_CATEGORICAL_COUNT + 1)).map(_.toString)
     val rdd = sc.parallelize(data, 100)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(h2oFrame.columns.head.isString(), "The vector type should be of string type")
     assert(h2oFrame.columns.head.domain == null, "The vector domain should be <null>")
     assertRDDHolderProperties(h2oFrame, rdd)
@@ -214,7 +214,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("PUBDEV-458 - from Rdd[Option[Int]] to H2OFrame and back") {
     val rdd = sc.parallelize(1 to 1000000, 10).map(i => Some(i))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     val back2rdd = hc.asRDD[PUBDEV458Type](h2oFrame)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     assert(back2rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
@@ -224,7 +224,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     def almostDefined(i: Long) = Some(i.toInt) filter (_ % 31 != 0)
 
     val rdd = sc.parallelize(1 to 1000000, 10).map(i => OptionAndNot(Some(i), almostDefined(i)))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     val back2rdd = hc.asRDD[OptionAndNot](h2oFrame)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     assert(back2rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
@@ -237,7 +237,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("RDD[ByteField] to H2OFrame[Numeric]") {
     val rdd = sc.parallelize(-127 to 127).map(v => ByteField(v.asInstanceOf[Byte]))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
 
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assert(h2oFrame.columns.head.isNumeric())
@@ -245,7 +245,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
 
   test("RDD[ShortField] to H2OFrame[Numeric]") {
     val rdd = sc.parallelize(-2048 to 4096).map(v => ShortField(v.asInstanceOf[Short]))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
 
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assert(h2oFrame.columns.head.isNumeric())
@@ -254,7 +254,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[IntField] to H2OFrame[Numeric]") {
     val values = Seq(Int.MinValue, Int.MaxValue, 0, -100, 200, -5000, 568901)
     val rdd = sc.parallelize(values).map(v => IntField(v))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
 
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assert(h2oFrame.columns.head.isNumeric())
@@ -263,7 +263,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[LongField] to H2OFrame[Numeric]") {
     val values = Seq(Long.MinValue, Long.MaxValue, 0L, -100L, 200L, -5000L, 5689323201L, -432432433335L)
     val rdd = sc.parallelize(values).map(v => LongField(v))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
 
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assert(h2oFrame.columns.head.isNumeric())
@@ -272,7 +272,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[FloatField] to H2OFrame[Numeric]") {
     val values = Seq(Float.MinValue, Float.MaxValue, -33.33.toFloat, 200.001.toFloat, -5000.34.toFloat)
     val rdd = sc.parallelize(values).map(v => FloatField(v))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
 
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assert(h2oFrame.columns.head.isNumeric())
@@ -281,7 +281,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[DoubleField] to H2OFrame[Numeric]") {
     val values = Seq(Double.MinValue, Double.MaxValue, -33.33, 200.001, -5000.34)
     val rdd = sc.parallelize(values).map(v => DoubleField(v))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
 
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assert(h2oFrame.columns.head.isNumeric())
@@ -292,7 +292,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     // Create RDD with 100 Int values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10)
     // PUBDEV-1173
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     h2oFrame.delete()
   }
@@ -302,7 +302,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     // Create RDD with 100 Float values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10).map(v => v.toFloat)
     // PUBDEV-1173
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     h2oFrame.delete()
   }
@@ -312,7 +312,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     // Create RDD with 100 Double values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10).map(v => v.toDouble)
     // PUBDEV-1173
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     h2oFrame.delete()
   }
@@ -322,7 +322,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     // Create RDD with 100 String values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10).map(v => v.toString)
     // PUBDEV-1173
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     h2oFrame.delete()
   }
@@ -330,7 +330,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[Byte] to H2OFrame[Numeric]") {
     // Create RDD with 100 Byte values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10).map(v => v.toByte)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     h2oFrame.delete()
   }
@@ -338,7 +338,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[Short] to H2OFrame[Numeric]") {
     // Create RDD with 100 Short values, 10 values per 1 Spark partition
     val rdd = sc.parallelize(1 to 100, 10).map(v => v.toShort)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     h2oFrame.delete()
   }
@@ -346,7 +346,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[java.sql.Timestamp] to H2OFrame[Time] and back") {
     // Create RDD with timestamp value in default timezone
     val rdd = sc.parallelize(1 to 100, 10).map(v => new Timestamp(v.toLong))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count == h2oFrame.numberOfRows, "Number of rows should match")
     val timestamp = DateTimeUtils.toUTCTime(h2oFrame.collectLongs(0)(0) * 1000, SparkTimeZone.current().getID) / 1000
     assert(rdd.first().getTime == timestamp)
@@ -361,7 +361,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     val p1 = LabeledPoint(0, Vectors.dense(1, 2, 3, 4))
     val p2 = LabeledPoint(1, Vectors.dense(5, 6, 7, 8))
     val rdd = sc.parallelize(Seq(p1, p2), 10)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count() == h2oFrame.numberOfRows, "Number of rows should match")
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(0, 1))
     assertVectorDoubleValues(h2oFrame.collectDoubles(1), Seq(1, 5))
@@ -374,7 +374,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     val p1 = LabeledPoint(0, Vectors.dense(1, 2, 3))
     val p2 = LabeledPoint(1, Vectors.dense(4, 5))
     val rdd = sc.parallelize(Seq(p1, p2))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count() == h2oFrame.numberOfRows, "Number of rows should match")
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(0, 1))
     assertVectorDoubleValues(h2oFrame.collectDoubles(1), Seq(1, 4))
@@ -386,7 +386,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     val p1 = LabeledPoint(0, Vectors.sparse(4, Array(1, 3), Array(3.0, 8.1)))
     val p2 = LabeledPoint(1, Vectors.sparse(4, Array(0), Array(3.14)))
     val rdd = sc.parallelize(Seq(p1, p2), 10)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count() == h2oFrame.numberOfRows, "Number of rows should match")
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(0, 1))
     assertVectorDoubleValues(h2oFrame.collectDoubles(1), Seq(0, 3.14))
@@ -400,7 +400,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     val p1 = LabeledPoint(0, Vectors.sparse(1, Array(0), Array(3.0)))
     val p2 = LabeledPoint(1, Vectors.sparse(3, Array(0, 1), Array(1.0, 8)))
     val rdd = sc.parallelize(Seq(p1, p2))
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assert(rdd.count() == h2oFrame.numberOfRows, "Number of rows should match")
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(0, 1))
     assertVectorDoubleValues(h2oFrame.collectDoubles(1), Seq(3.0, 1.0))
@@ -412,7 +412,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     val dataDef = 1 to 10
     val data = dataDef.map(v => org.apache.spark.ml.linalg.Vectors.dense(v, 0, 0))
     val rdd = sc.parallelize(data)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), dataDef.map(_.toDouble))
     assertVectorDoubleValues(h2oFrame.collectDoubles(1), dataDef.map(_ => 0.0))
@@ -423,7 +423,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     val dataDef = 1 to 10
     val data = dataDef.map(v => org.apache.spark.mllib.linalg.Vectors.dense(v, 0, 0))
     val rdd = sc.parallelize(data)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), dataDef.map(_.toDouble))
     assertVectorDoubleValues(h2oFrame.collectDoubles(1), dataDef.map(_ => 0.0))
@@ -436,7 +436,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
       org.apache.spark.mllib.linalg.Vectors.dense(1, 2),
       org.apache.spark.mllib.linalg.Vectors.dense(1, 2, 3))
     val rdd = sc.parallelize(data)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(1, 1, 1))
     assertVectorDoubleValues(h2oFrame.collectDoubles(1), Seq(0, 2, 2))
@@ -446,7 +446,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[mllib.linalg.Vector](Sparse - same length, one vector empty) to H2OFrame") {
     val data = Seq(Vectors.sparse(2, Array(0), Array(1)), Vectors.sparse(2, Array(1), Array(0)))
     val rdd = sc.parallelize(data, 1)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
 
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(1, 0))
@@ -456,7 +456,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   test("RDD[mllib.linalg.Vector](Sparse - same length) to H2OFrame") {
     val data = Seq(Vectors.sparse(2, Array(0), Array(1)), Vectors.sparse(2, Array(1), Array(2)))
     val rdd = sc.parallelize(data, 1)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
 
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(1, 0))
@@ -468,7 +468,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
     val data = dataDef.map(v => Vectors.sparse(v, Array(v - 1), Array(42)))
 
     val rdd = sc.parallelize(data)
-    val h2oFrame = H2OFrame(hc.asH2OFrameKeyString(rdd))
+    val h2oFrame = hc.asH2OFrame(rdd)
     assertRDDH2OFrameInvariants(rdd, h2oFrame)
 
     assertVectorDoubleValues(h2oFrame.collectDoubles(0), Seq(42, 0, 0))
@@ -477,7 +477,7 @@ class SupportedRDDConverterTestSuite extends FunSuite with SharedH2OTestContext 
   }
 
   test("H2OFrame with categorical column into RDD") {
-    val hf = H2OFrame(hc.asH2OFrameKeyString(sc.parallelize(1 to 100).map(_.toString)))
+    val hf = hc.asH2OFrame(sc.parallelize(1 to 100).map(_.toString))
     hf.convertColumnsToCategorical(Array(0))
     val rdd = hc.asRDD[StringHolder](hf)
     assert(rdd.count() == hf.numberOfRows, "Number of row should match")

--- a/dist/src/index.html
+++ b/dist/src/index.html
@@ -450,7 +450,7 @@
             </p>
             <p>4. Create an H<sub>2</sub>O cloud inside the Spark cluster:</p>
             <p class="terminal">
-              import org.apache.spark.h2o._<br />
+              import ai.h2o.sparkling._<br />
               val h2oContext = H2OContext.getOrCreate() <br />
               import h2oContext._ <br />
             </p>
@@ -495,7 +495,7 @@
             </p>
             <p>5. Create an H<sub>2</sub>O cloud inside the Spark cluster:</p>
             <p class="terminal">
-              import org.apache.spark.h2o._ <br />
+              import ai.h2o.sparkling._ <br />
               val h2oContext = H2OContext.getOrCreate() <br />
               import h2oContext._ <br />
             </p>
@@ -536,7 +536,7 @@
             </p>
             <p>4. Create an H<sub>2</sub>O cloud inside the Spark cluster:</p>
             <p class="terminal">
-              import org.apache.spark.h2o._<br />
+              import ai.h2o.sparkling._<br />
               val h2oContext = H2OContext.getOrCreate() <br />
               import h2oContext._ <br />
             </p>
@@ -577,7 +577,7 @@
             <p>5. In your Sparkling Water application, create H2OContext:</p>
             <p>Scala</p>
             <p class="terminal">
-              import org.apache.spark.h2o._<br/>
+              import ai.h2o.sparkling._<br/>
               val conf = new H2OConf().setExternalClusterMode().useManualClusterStart().setCloudName("test")<br/>
               val hc = H2OContext.getOrCreate(conf)<br/>
             </p>
@@ -775,7 +775,7 @@
 
             <p>3. Create an H<sub>2</sub>O cloud inside the Spark cluster:</p>
             <p class="terminal">
-              import org.apache.spark.h2o._<br />
+              import ai.h2o.sparkling._<br />
               val h2oContext = H2OContext.getOrCreate() <br />
               import h2oContext._ <br />
             </p>

--- a/doc/src/site/sphinx/deployment/backends.rst
+++ b/doc/src/site/sphinx/deployment/backends.rst
@@ -28,7 +28,7 @@ Explicitly specify internal backend on ``H2OConf``:
 
          .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf().setInternalClusterMode()
             val hc = H2OContext.getOrCreate(conf)
 
@@ -54,7 +54,7 @@ line or on the ``SparkConf`` class,  we can call just the following as ``H2OCont
 
          .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val hc = H2OContext.getOrCreate()
 
     .. tab-container:: Python
@@ -76,7 +76,7 @@ We can however also explicitly pass the ``H2OConf``:
 
          .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf()
             val hc = H2OContext.getOrCreate(conf)
 
@@ -133,7 +133,7 @@ To start an H2O cluster and connect to it, run:
 
          .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf()
                         .setExternalClusterMode()
                         .useAutoClusterStart()
@@ -206,7 +206,7 @@ To connect to this external cluster, run the following commands:
 
          .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf()
                         .setExternalClusterMode()
                         .useManualClusterStart()
@@ -271,7 +271,7 @@ To connect to this external cluster, run the following commands:
 
          .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf()
                         .setExternalClusterMode()
                         .useManualClusterStart()
@@ -322,7 +322,7 @@ We can force the client to use the correct network or address using the followin
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val conf = new H2OConf()
                 .setExternalClusterMode()
                 .useManualClusterStart()

--- a/doc/src/site/sphinx/deployment/sw_azure_dbc.rst
+++ b/doc/src/site/sphinx/deployment/sw_azure_dbc.rst
@@ -41,7 +41,7 @@ To start Sparkling Water ``H2OContext`` on Databricks Azure, the steps are:
 
     .. code:: scala
 
-        import org.apache.spark.h2o._
+        import ai.h2o.sparkling._
         val hc = H2OContext.getOrCreate()
 
 6.  And voila, we should have ``H2OContext`` running

--- a/doc/src/site/sphinx/deployment/use_on_zeppelin.rst
+++ b/doc/src/site/sphinx/deployment/use_on_zeppelin.rst
@@ -24,7 +24,7 @@ The use of the Sparkling Water package is directly driven by the Sparkling Water
 .. code:: scala
 
     %spark
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val hc = H2OContext.getOrCreate()
 
 Creating an ``H2OFrame`` from a Spark ``DataFrame``:

--- a/doc/src/site/sphinx/design/basic_primitives.rst
+++ b/doc/src/site/sphinx/design/basic_primitives.rst
@@ -7,7 +7,7 @@ classes used by Spark components:
 +-------------------+--------------------------------------+--------------------------------------+
 | Concept           | Implementation class                 | Description                          |
 +===================+======================================+======================================+
-| H2O context       | ``org.apache.spark.h2o.H2OContext``  | H2O Context that holds state and     |
+| H2O context       | ``ai.h2o.sparkling.H2OContext``      | H2O Context that holds state and     |
 |                   |                                      | provides primitives to transfer      |
 |                   |                                      | RDD/DataFrames/Datasets into         |
 |                   |                                      | H2OFrame and vice versa. It follows  |

--- a/doc/src/site/sphinx/devel/integ_tests.rst
+++ b/doc/src/site/sphinx/devel/integ_tests.rst
@@ -52,7 +52,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
     import org.apache.spark.sql.SparkSession
     val spark = SparkSession.builder().getOrCreate()
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val h2oContext = H2OContext.getOrCreate()
     import h2oContext.implicits._
 
@@ -64,7 +64,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
         import org.apache.spark.sql.SparkSession
         val spark = SparkSession.builder().getOrCreate()
-        import org.apache.spark.h2o._
+        import ai.h2o.sparkling._
         val h2oContext = H2OContext.getOrCreate()
 
         import java.io.File
@@ -79,7 +79,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
         import org.apache.spark.sql.SparkSession
         val spark = SparkSession.builder().getOrCreate()
-        import org.apache.spark.h2o._
+        import ai.h2o.sparkling._
         val h2oContext = H2OContext.getOrCreate()
 
         val path = "hdfs://mr-0xd6.0xdata.loc/datasets/airlines_all.csv"
@@ -92,7 +92,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
         import org.apache.spark.sql.SparkSession
         val spark = SparkSession.builder().getOrCreate()
-        import org.apache.spark.h2o._
+        import ai.h2o.sparkling._
         val h2oContext = H2OContext.getOrCreate()
 
         val path = "s3n://h2o-airlines-unpacked/allyears2k.csv"
@@ -107,7 +107,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
     import org.apache.spark.sql.SparkSession
     val spark = SparkSession.builder().getOrCreate()
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val h2oContext = H2OContext.getOrCreate()
 
     val rdd = sc.parallelize(1 to 1000, 100).map( v => IntHolder(Some(v)))
@@ -119,7 +119,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
     import org.apache.spark.sql.SparkSession
     val spark = SparkSession.builder().getOrCreate()
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val h2oContext = H2OContext.getOrCreate()
 
     import spark.implicits._
@@ -132,7 +132,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
     import org.apache.spark.sql.SparkSession
     val spark = SparkSession.builder().getOrCreate()
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val h2oContext = H2OContext.getOrCreate()
 
     val rdd = spark.sparkContext.parallelize(1 to 1000, 100).map(v => IntHolder(Some(v)))
@@ -145,7 +145,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
     import org.apache.spark.sql.SparkSession
     val spark = SparkSession.builder().getOrCreate()
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val h2oContext = H2OContext.getOrCreate()
 
     import spark.implicits._

--- a/doc/src/site/sphinx/install/install_and_start.rst
+++ b/doc/src/site/sphinx/install/install_and_start.rst
@@ -35,7 +35,7 @@ This section describes how to quickly get started with Sparkling Water on your p
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val h2oContext = H2OContext.getOrCreate()
     import h2oContext._
 
@@ -80,7 +80,7 @@ This section describes how to launch Sparkling Water on Hadoop using YARN.
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val h2oContext = H2OContext.getOrCreate()
     import h2oContext._ 
 
@@ -118,7 +118,7 @@ This section describes how to launch H2O on a standalone Spark cluster.
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val h2oContext = H2OContext.getOrCreate()
     import h2oContext._ 
 
@@ -155,7 +155,7 @@ The H2O cluster needs to be started with a corresponding H2O, which can be downl
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val conf = new H2OConf().setExternalClusterMode().useManualClusterStart().setCloudName("test")
     val hc = H2OContext.getOrCreate(conf)
 
@@ -208,6 +208,6 @@ This section describes how to start Spark with Sparkling Water enabled via Spark
 
 .. code:: scala
 
-   import org.apache.spark.h2o._
+   import ai.h2o.sparkling._
    val h2oContext = H2OContext.getOrCreate()
    import h2oContext._ 

--- a/doc/src/site/sphinx/tutorials/grid_gbm_pipeline.rst
+++ b/doc/src/site/sphinx/tutorials/grid_gbm_pipeline.rst
@@ -36,7 +36,7 @@ Make sure ``H2OContext`` is available:
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     implicit val h2oContext = H2OContext.getOrCreate()
 
 

--- a/doc/src/site/sphinx/tutorials/hive_support.rst
+++ b/doc/src/site/sphinx/tutorials/hive_support.rst
@@ -119,7 +119,7 @@ To run Sparkling Water with Hive support for kerberized hadoop cluster, you must
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf()
             conf.setHiveSupportEnabled()
             conf.setHiveHost("hostname:10000") // The full address of HiveServer2

--- a/doc/src/site/sphinx/tutorials/import_export_s3.rst
+++ b/doc/src/site/sphinx/tutorials/import_export_s3.rst
@@ -72,7 +72,7 @@ Next, let's start ``H2OContext``. This context brings H2O support into Spark env
 
  .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val hc = H2OContext.getOrCreate()
 
 Finally, read the data:

--- a/doc/src/site/sphinx/tutorials/kerberos_auth.rst
+++ b/doc/src/site/sphinx/tutorials/kerberos_auth.rst
@@ -40,7 +40,7 @@ And later, you can create ``H2OContext`` as:
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val conf = new H2OConf().setUserName("username").setPassword("password")
     val hc = H2OContext.getOrCreate(conf)
 
@@ -49,7 +49,7 @@ Or, you can also use setters available on ``H2OConf`` as:
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val conf = new H2OConf().setLoginConf("kerberos.conf").setKerberosLoginEnabled().setUserName("username").setPassword("password")
     val hc = H2OContext.getOrCreate(conf)
 

--- a/doc/src/site/sphinx/tutorials/ldap.rst
+++ b/doc/src/site/sphinx/tutorials/ldap.rst
@@ -46,7 +46,7 @@ And later, you can create ``H2OContext`` as:
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     conf = new H2OConf().setUserName("username").setPassword("password")
     val hc = H2OContext.getOrCreate(conf)
 
@@ -54,7 +54,7 @@ Or, you can also use setters available on ``H2OConf`` as:
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val conf = new H2OConf().setLoginConf("ldap.conf").setLdapLoginEnabled().setUserName("username").setPassword("password")
     val hc = H2OContext.getOrCreate(conf)
 

--- a/doc/src/site/sphinx/tutorials/secured_flow.rst
+++ b/doc/src/site/sphinx/tutorials/secured_flow.rst
@@ -31,14 +31,14 @@ In order to use https correctly, the following two options need to be specified:
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val hc = H2OContext.getOrCreate()
 
         You can also start Sparkling shell without the configuration and specify it using the setters on ``H2OConf`` as:
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf().setJks("/path/to/keystore").setJksPass("password")
             val hc = H2OContext.getOrCreate(conf)
 
@@ -134,7 +134,7 @@ certificates are created.
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val hc = H2OContext.getOrCreate()
 
         You can also start Sparkling shell without the configuration
@@ -142,7 +142,7 @@ certificates are created.
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf().setAutoFlowSslEnabled().setVerifySslCertificates(false)
             val hc = H2OContext.getOrCreate(conf)
 

--- a/doc/src/site/sphinx/tutorials/shap_values.rst
+++ b/doc/src/site/sphinx/tutorials/shap_values.rst
@@ -27,7 +27,7 @@ To get SHAP values(=contributions) from H2OXGBoost model, please do:
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             import java.net.URI
             val hc = H2OContext.getOrCreate()
 

--- a/doc/src/site/sphinx/tutorials/ssl.rst
+++ b/doc/src/site/sphinx/tutorials/ssl.rst
@@ -30,7 +30,7 @@ This can be also achieved in programmatic way on the ``H2OConf``:
 
         .. code:: Scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf().setInternalSecureConnectionsEnabled()
             val hc = H2OContext.getOrCreate(conf)
 
@@ -75,7 +75,7 @@ This can be also achieved in programmatic way on the ``H2OConf``:
 
         .. code:: Scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             val conf = new H2OConf().setSslConf("/path/to/ssl/configuration")
             val hc = H2OContext.getOrCreate(conf)
 

--- a/doc/src/site/sphinx/tutorials/sw_automl.rst
+++ b/doc/src/site/sphinx/tutorials/sw_automl.rst
@@ -19,7 +19,7 @@ The following sections describe how to train an AutoML model in Sparkling Water 
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             import java.net.URI
             val hc = H2OContext.getOrCreate()
 

--- a/doc/src/site/sphinx/tutorials/sw_drf.rst
+++ b/doc/src/site/sphinx/tutorials/sw_drf.rst
@@ -21,7 +21,7 @@ The following sections describe how to train DRF model in Sparkling Water in bot
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             import java.net.URI
             val hc = H2OContext.getOrCreate()
 

--- a/doc/src/site/sphinx/tutorials/sw_kmeans.rst
+++ b/doc/src/site/sphinx/tutorials/sw_kmeans.rst
@@ -21,7 +21,7 @@ The following sections describe how to train KMeans model in Sparkling Water in 
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             import java.net.URI
             val hc = H2OContext.getOrCreate()
 

--- a/doc/src/site/sphinx/tutorials/sw_target_encoder.rst
+++ b/doc/src/site/sphinx/tutorials/sw_target_encoder.rst
@@ -101,7 +101,7 @@ and prepare the environment:
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             import java.net.URI
             val hc = H2OContext.getOrCreate()
 

--- a/doc/src/site/sphinx/tutorials/sw_xgboost.rst
+++ b/doc/src/site/sphinx/tutorials/sw_xgboost.rst
@@ -19,7 +19,7 @@ The following sections describe how to train XGBoost model in Sparkling Water in
 
         .. code:: scala
 
-            import org.apache.spark.h2o._
+            import ai.h2o.sparkling._
             import java.net.URI
             val hc = H2OContext.getOrCreate()
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -58,7 +58,7 @@ Step-by-Step Weather Data Example
 
 .. code:: scala
 
-    import org.apache.spark.h2o._
+    import ai.h2o.sparkling._
     val hc = H2OContext.getOrCreate()
     import spark.implicits._
 

--- a/examples/src/main/scala/ai/h2o/sparkling/examples/AirlinesWithWeatherDemo.scala
+++ b/examples/src/main/scala/ai/h2o/sparkling/examples/AirlinesWithWeatherDemo.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.examples
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.ml.algos.{H2ODeepLearning, H2OGBM}
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 

--- a/examples/src/main/scala/ai/h2o/sparkling/examples/ChicagoCrimeApp.scala
+++ b/examples/src/main/scala/ai/h2o/sparkling/examples/ChicagoCrimeApp.scala
@@ -19,9 +19,9 @@ package ai.h2o.sparkling.examples
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.ml.algos.{H2ODeepLearning, H2OGBM}
 import ai.h2o.sparkling.ml.models.H2OMOJOModel
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.{DataFrame, SparkSession}

--- a/examples/src/main/scala/ai/h2o/sparkling/examples/CityBikeSharingDemo.scala
+++ b/examples/src/main/scala/ai/h2o/sparkling/examples/CityBikeSharingDemo.scala
@@ -19,9 +19,9 @@ package ai.h2o.sparkling.examples
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.ml.algos.H2OGBM
 import ai.h2o.sparkling.ml.models.H2OMOJOModel
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{udf, _}
 import org.apache.spark.sql.types.IntegerType

--- a/examples/src/main/scala/ai/h2o/sparkling/examples/CraigslistJobTitlesApp.scala
+++ b/examples/src/main/scala/ai/h2o/sparkling/examples/CraigslistJobTitlesApp.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.examples
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.ml.algos.H2OGBM
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.ml.feature.{RegexTokenizer, StopWordsRemover, Word2Vec}
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}

--- a/examples/src/main/scala/ai/h2o/sparkling/examples/DeepLearningDemo.scala
+++ b/examples/src/main/scala/ai/h2o/sparkling/examples/DeepLearningDemo.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.examples
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.ml.algos.H2ODeepLearning
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.SparkSession
 
 object DeepLearningDemo {

--- a/examples/src/main/scala/ai/h2o/sparkling/examples/HamOrSpamDemo.scala
+++ b/examples/src/main/scala/ai/h2o/sparkling/examples/HamOrSpamDemo.scala
@@ -19,9 +19,9 @@ package ai.h2o.sparkling.examples
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.ml.algos._
 import ai.h2o.sparkling.ml.features.ColumnPruner
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.ml.feature.{HashingTF, IDF, _}
 import org.apache.spark.ml.{Pipeline, PipelineModel, PipelineStage}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}

--- a/examples/src/main/scala/ai/h2o/sparkling/examples/ProstateDemo.scala
+++ b/examples/src/main/scala/ai/h2o/sparkling/examples/ProstateDemo.scala
@@ -19,8 +19,8 @@ package ai.h2o.sparkling.examples
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.ml.algos.H2OKMeans
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.SparkSession
 
 object ProstateDemo {

--- a/gradle/itest.gradle
+++ b/gradle/itest.gradle
@@ -38,7 +38,6 @@ task integTest(type: Test) {
     systemProperty "spark.ext.h2o.client.log.dir", new File(project.getBuildDir(), "h2ologs-itest/client")
     systemProperty "spark.ext.h2o.external.disable.version.check", "true"
     systemProperty "spark.ext.h2o.backend.cluster.mode", detectBackendClusterMode()
-    systemProperty "spark.ext.h2o.rest.api.based.client", "true"
     systemProperty "spark.testing", "true"
     systemProperty "spark.test.home", "${sparkHome}"
 

--- a/gradle/sparkTest.gradle
+++ b/gradle/sparkTest.gradle
@@ -7,7 +7,6 @@ test {
     systemProperty "spark.ext.h2o.node.log.dir", new File(project.getBuildDir(), "h2ologs-test/nodes")
     systemProperty "spark.ext.h2o.client.log.dir", new File(project.getBuildDir(), "h2ologs-test/client")
     systemProperty "spark.ext.h2o.external.disable.version.check", "true"
-    systemProperty "spark.ext.h2o.rest.api.based.client", "true"
     systemProperty "spark.driver.memory", "1G"
     // Run with assertions ON
     enableAssertions = true

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
@@ -16,10 +16,9 @@
  */
 package ai.h2o.sparkling.ml.algos
 
-import ai.h2o.sparkling.H2OFrame
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import ai.h2o.sparkling.ml.params.H2OCommonParams
 import ai.h2o.sparkling.ml.utils.{EstimatorCommonUtils, SchemaUtils}
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.functions.col
 
@@ -47,7 +46,7 @@ trait H2OAlgoCommonUtils extends H2OCommonParams with EstimatorCommonUtils {
     val columns = featureColumns ++ excludedColumns
     val h2oContext = H2OContext.ensure(
       "H2OContext needs to be created in order to train the model. Please create one as H2OContext.getOrCreate().")
-    val trainFrame = H2OFrame(h2oContext.asH2OFrameKeyString(dataset.select(columns: _*).toDF()))
+    val trainFrame = h2oContext.asH2OFrame(dataset.select(columns: _*).toDF())
 
     // Our MOJO wrapper needs the full column name before the array/vector expansion in order to do predictions
     val internalFeatureCols = SchemaUtils.flattenStructsInDataFrame(dataset.select(featureColumns: _*)).columns

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
@@ -16,7 +16,7 @@
  */
 package ai.h2o.sparkling.ml.algos
 
-import ai.h2o.sparkling.H2OFrame
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestCommunication}
 import ai.h2o.sparkling.ml.internals.H2OModel
 import ai.h2o.sparkling.ml.models.{H2OMOJOModel, H2OMOJOSettings}
@@ -27,7 +27,6 @@ import ai.h2o.sparkling.utils.SparkSessionUtils
 import com.google.gson.{Gson, JsonElement}
 import org.apache.commons.io.IOUtils
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.ml.Estimator
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
@@ -18,7 +18,7 @@ package ai.h2o.sparkling.ml.algos
 
 import java.util
 
-import ai.h2o.sparkling.H2OFrame
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import ai.h2o.sparkling.backend.exceptions.RestApiCommunicationException
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestCommunication, RestEncodingUtils}
 import ai.h2o.sparkling.ml.internals.{H2OMetric, H2OModel, H2OModelCategory}
@@ -30,7 +30,6 @@ import hex.Model
 import hex.grid.HyperSpaceSearchCriteria
 import hex.schemas.GridSchemaV99
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.ml.Estimator
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.util._

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/features/H2OTargetEncoder.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/features/H2OTargetEncoder.scala
@@ -17,14 +17,13 @@
 
 package ai.h2o.sparkling.ml.features
 
-import ai.h2o.sparkling.H2OFrame
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.backend.utils.RestCommunication
 import ai.h2o.sparkling.ml.internals.H2OModel
 import ai.h2o.sparkling.ml.models.{H2OTargetEncoderBase, H2OTargetEncoderModel}
 import ai.h2o.sparkling.ml.params.H2OAlgoParamsHelper
 import ai.h2o.sparkling.ml.utils.EstimatorCommonUtils
 import ai.h2o.targetencoding._
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.ml.Estimator
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
@@ -46,7 +45,7 @@ class H2OTargetEncoder(override val uid: String)
     }
     val h2oContext = H2OContext.ensure(
       "H2OContext needs to be created in order to use target encoding. Please create one as H2OContext.getOrCreate().")
-    val input = H2OFrame(h2oContext.asH2OFrameKeyString(dataset.toDF()))
+    val input = h2oContext.asH2OFrame(dataset.toDF())
     convertRelevantColumnsToCategorical(input)
     val columnsToKeep = getInputCols() ++ Seq(getFoldCol(), getLabelCol()).map(Option(_)).flatten
     val ignoredColumns = dataset.columns.diff(columnsToKeep)

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/internals/H2OModel.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/internals/H2OModel.scala
@@ -19,10 +19,10 @@ package ai.h2o.sparkling.ml.internals
 
 import java.io.File
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestCommunication}
 import ai.h2o.sparkling.ml.models.{H2OMOJOModel, H2OMOJOSettings}
 import org.apache.spark.expose.Utils
-import org.apache.spark.h2o.H2OContext
 import water.api.schemas3.ModelsV3
 
 private[sparkling] class H2OModel private (val modelId: String) extends RestCommunication {

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala
@@ -17,12 +17,11 @@
 
 package ai.h2o.sparkling.ml.models
 
-import ai.h2o.sparkling.H2OFrame
+import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestCommunication}
 import ai.h2o.sparkling.ml.features.H2OTargetEncoderModelUtils
 import ai.h2o.sparkling.ml.internals.H2OModel
 import ai.h2o.sparkling.ml.utils.SchemaUtils
-import org.apache.spark.h2o.H2OContext
 import org.apache.spark.ml.Model
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.{MLWritable, MLWriter}
@@ -61,7 +60,7 @@ class H2OTargetEncoderModel(override val uid: String, targetEncoderModel: H2OMod
     val flatDF = SchemaUtils.flattenDataFrame(withIdDF)
     val relevantColumns = getInputCols() ++ Array(getLabelCol(), getFoldCol(), temporaryColumn).flatMap(Option(_))
     val relevantColumnsDF = flatDF.select(relevantColumns.map(col(_)): _*)
-    val input = H2OFrame(hc.asH2OFrameKeyString(relevantColumnsDF))
+    val input = hc.asH2OFrame(relevantColumnsDF)
     convertRelevantColumnsToCategorical(input)
     val internalOutputColumns = getInputCols().map(inputColumnNameToInternalOutputName)
     val outputFrameColumns = internalOutputColumns ++ Array(temporaryColumn)

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OKMeansParams.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OKMeansParams.scala
@@ -16,11 +16,11 @@
  */
 package ai.h2o.sparkling.ml.params
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import hex.kmeans.KMeans
 import hex.kmeans.KMeansModel.KMeansParameters
 import hex.schemas.GLMV3.GLMParametersV3
-import org.apache.spark.h2o.H2OContext
 
 trait H2OKMeansParams extends H2OAlgoUnsupervisedParams[KMeansParameters] {
 
@@ -114,7 +114,7 @@ trait H2OKMeansParams extends H2OAlgoUnsupervisedParams[KMeansParameters] {
       val hc = H2OContext.ensure(
         "H2OContext needs to be created in order to train the H2OKMeans model. " +
           "Please create one as H2OContext.getOrCreate().")
-      hc.asH2OFrameKeyString(df)
+      hc.asH2OFrame(df).frameId
     }
   }
 }

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/utils/EstimatorCommonUtils.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/utils/EstimatorCommonUtils.scala
@@ -16,10 +16,10 @@
  */
 package ai.h2o.sparkling.ml.utils
 
+import ai.h2o.sparkling.H2OContext
 import ai.h2o.sparkling.backend.H2OJob
 import ai.h2o.sparkling.backend.utils.{RestApiUtils, RestCommunication}
 import hex.schemas.ModelBuilderSchema
-import org.apache.spark.h2o.H2OContext
 
 trait EstimatorCommonUtils extends RestCommunication {
   protected def trainAndGetDestinationKey(

--- a/py/src/ai/h2o/sparkling/H2OConf.py
+++ b/py/src/ai/h2o/sparkling/H2OConf.py
@@ -27,6 +27,6 @@ class H2OConf(SharedBackendConf, InternalBackendConf, ExternalBackendConf):
         try:
             Initializer.load_sparkling_jar()
             _jvm = SparkSession._instantiatedSession.sparkContext._jvm
-            self._jconf = _jvm.org.apache.spark.h2o.H2OConf()
+            self._jconf = _jvm.ai.h2o.sparkling.H2OConf()
         except:
             raise

--- a/py/src/ai/h2o/sparkling/H2OContext.py
+++ b/py/src/ai/h2o/sparkling/H2OContext.py
@@ -79,13 +79,12 @@ class H2OContext(object):
             selected_conf = conf
         else:
             selected_conf = H2OConf()
-        selected_conf.set("spark.ext.h2o.rest.api.based.client", "true")
 
         h2o_context = H2OContext()
 
         # Create backing H2OContext
         h2o_context._jvm = jvm
-        package = getattr(jvm.org.apache.spark.h2o, "H2OContext$")
+        package = getattr(jvm.ai.h2o.sparkling, "H2OContext$")
         module = package.__getattr__("MODULE$")
         jhc = module.getOrCreate(selected_conf._jconf)
         h2o_context._jhc = jhc
@@ -123,7 +122,7 @@ class H2OContext(object):
 
     def stop(self):
         h2o.connection().close()
-        scalaStopMethod = getattr(self._jhc, "org$apache$spark$h2o$H2OContext$$stop")
+        scalaStopMethod = getattr(self._jhc, "ai$h2o$sparkling$H2OContext$$stop")
         scalaStopMethod(False, False, False) # stopSpark = False, stopJVM = False, inShutdownHook = False
 
     def downloadH2OLogs(self,  destination, container = "ZIP"):
@@ -201,9 +200,9 @@ class H2OContext(object):
 
         df = H2OContext.__prepareSparkDataForConversion(self._jvm, sparkFrame)
         if h2oFrameName is None:
-            key = self._jhc.asH2OFrameKeyString(df._jdf)
+            key = self._jhc.asH2OFrame(df._jdf).frameId()
         else:
-            key = self._jhc.asH2OFrameKeyString(df._jdf, h2oFrameName)
+            key = self._jhc.asH2OFrame(df._jdf, h2oFrameName).frameId()
         return H2OFrame.get_frame(key, full_cols=fullCols, light=True)
 
     @staticmethod

--- a/r/src/R/ai/h2o/sparkling/H2OConf.R
+++ b/r/src/R/ai/h2o/sparkling/H2OConf.R
@@ -27,7 +27,7 @@ H2OConf <- setRefClass("H2OConf", fields = list(jconf = "ANY"),
             print("Constructor H2OConf(spark) with the spark argument is deprecated. Please use just H2OConf(). The argument will be removed in release 3.32.")
         }
         sc <- spark_connection_find()[[1]]
-        .self$jconf <- invoke_new(sc, "org.apache.spark.h2o.H2OConf")
+        .self$jconf <- invoke_new(sc, "ai.h2o.sparkling.H2OConf")
     },
 
     set = function(option, value) { invoke(jconf, "set", option, value); .self },

--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -40,10 +40,9 @@ H2OContext.getOrCreate <- function(conf = NULL) {
   if (is.null(conf)) {
     conf <- H2OConf()
   }
-  conf$set("spark.ext.h2o.rest.api.based.client", "true")
 
   sc <- spark_connection_find()[[1]]
-  jhc <- invoke_static(sc, "org.apache.spark.h2o.H2OContext", "getOrCreate", conf$jconf)
+  jhc <- invoke_static(sc, "ai.h2o.sparkling.H2OContext", "getOrCreate", conf$jconf)
   hc <- H2OContext(jhc)
   returnedConf <- invoke(jhc, "getConf")
   # Because of checks in Sparkling Water, we are sure context path starts with one slash
@@ -78,11 +77,12 @@ H2OContext <- setRefClass("H2OContext", fields = list(jhc = "ANY"), methods = li
   asH2OFrame = function(sparkFrame, h2oFrameName = NULL) {
     # Ensure we are dealing with a Spark DataFrame (might be e.g. a tbl)
     sparkFrame <- spark_dataframe(sparkFrame)
-    key <- if (is.null(h2oFrameName)) {
-      invoke(.self$jhc, "asH2OFrameKeyString", sparkFrame)
+    frame <- if (is.null(h2oFrameName)) {
+      invoke(.self$jhc, "asH2OFrame", sparkFrame)
     } else {
-      invoke(.self$jhc, "asH2OFrameKeyString", sparkFrame, h2oFrameName)
+      invoke(.self$jhc, "asH2OFrame", sparkFrame, h2oFrameName)
     }
+    key <- invoke(frame, "frameId")
 
     h2o.getFrame(key)
   },

--- a/repl/src/main/scala/ai/h2o/sparkling/repl/BaseH2OInterpreter.scala
+++ b/repl/src/main/scala/ai/h2o/sparkling/repl/BaseH2OInterpreter.scala
@@ -117,7 +117,7 @@ private[repl] abstract class BaseH2OInterpreter(val sparkContext: SparkContext, 
       command(
         """
             @transient val h2oContext = {
-              val _h2oContext = org.apache.spark.h2o.H2OContext.ensure("H2OContext has to be started in order to use H2O REPL")
+              val _h2oContext = ai.h2o.sparkling.H2OContext.ensure("H2OContext has to be started in order to use H2O REPL")
               _h2oContext
             }
           """)
@@ -128,7 +128,7 @@ private[repl] abstract class BaseH2OInterpreter(val sparkContext: SparkContext, 
       command("import sqlContext.sql")
       command("import org.apache.spark.sql._")
       command("import org.apache.spark.sql.functions._")
-      command("import org.apache.spark.h2o._")
+      command("import ai.h2o.sparkling._")
       command("import org.apache.spark._")
 
     })


### PR DESCRIPTION
Sorry this change got this big, but should be mostly imports and doc changes

This change implements `ai.h2o.sparkling.H2OContext` and `ai.h2o.sparkling.H2OConf` and ensures all code and documentation points to the new methods.

The old classes `org.apache.spark.h2o.H2OContext` and `org.apache.spark.h2o.H2OConf` are still available and will be until probably 3.34 where we should have full parity. The old classes are using the H2O client in case of Scala so existing users are not affected. The new classes no longer use H2OClient even in Scala.

The migration guide was updated in https://0xdata.atlassian.net/browse/SW-2197

Depends on: https://0xdata.atlassian.net/browse/SW-2216. Without this JIRA the SW endopoints like DataFrames won't work