### PR TITLE
[SW-1569] Sparkling water fails to detect newer version of colorama

### DIFF
--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -59,7 +59,11 @@ function getJarsArg() {
 
 
 function checkPythonPackages() {
-    packages=$(pip list --format=freeze)
+    PYTHON_BINARY=python
+    if [ -n "$PYSPARK_PYTHON" ]; then
+      PYTHON_BINARY=$PYSPARK_PYTHON
+    fi
+    packages=$($PYTHON_BINARY -m pip list --format=freeze)
     error=0
     checkPythonPackage "$packages" "colorama" "0.3.8"
     checkPythonPackage "$packages" "requests"


### PR DESCRIPTION
We need to respect Spark python environment even for the python libraries checks