### PR TITLE
[SW-2234] Remove System.exit hack used in tests 

### DIFF
--- a/core/src/test/scala/ai/h2o/sparkling/ConfigurationPropertiesTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/ConfigurationPropertiesTestSuite.scala
@@ -19,7 +19,6 @@ package ai.h2o.sparkling
 
 import java.net.{HttpURLConnection, URL}
 import java.nio.file.{Files, Path}
-import java.security.Permission
 
 import org.apache.spark.sql.SparkSession
 import org.junit.runner.RunWith
@@ -35,42 +34,6 @@ abstract class ConfigurationPropertiesTestSuite
   with SparkTestContext {
 
   @transient var hc: H2OContext = _
-
-  override def afterEach(): Unit = {
-    // The method H2O.exit calls System.exit which confuses Gradle and marks the build
-    // as successful even though some tests failed.
-    // We can solve this by using security manager which forbids System.exit call.
-    // It is safe to use as all the methods closing H2O cloud and stopping operations have been
-    // already called and we just need to ensure that JVM with the client/driver doesn't call the System.exit method
-    try {
-      val securityManager = new NoExitCheckSecurityManager
-      System.setSecurityManager(securityManager)
-      if (hc != null) {
-        hc.stop()
-      }
-    } catch {
-      case _: SecurityException => // ignore
-    } finally {
-      super.afterAll()
-      System.setSecurityManager(null)
-    }
-
-  }
-
-  private class NoExitCheckSecurityManager extends SecurityManager {
-    override def checkPermission(perm: Permission): Unit = {
-      /* allow any */
-    }
-
-    override def checkPermission(perm: Permission, context: scala.Any): Unit = {
-      /* allow any */
-    }
-
-    override def checkExit(status: Int): Unit = {
-      super.checkExit(status)
-      throw new SecurityException()
-    }
-  }
 }
 
 abstract class ConfigurationPropertiesTestSuite_HttpHeadersBase extends ConfigurationPropertiesTestSuite {

--- a/core/src/test/scala/ai/h2o/sparkling/SharedH2OTestContext.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/SharedH2OTestContext.scala
@@ -17,13 +17,10 @@
 
 package ai.h2o.sparkling
 
-import java.security.Permission
-
 import org.scalatest.Suite
 
 /**
   * Helper trait to simplify initialization and termination of H2O contexts.
-  *
   */
 trait SharedH2OTestContext extends SparkTestContext {
   self: Suite =>
@@ -34,36 +31,4 @@ trait SharedH2OTestContext extends SparkTestContext {
     super.beforeAll()
     hc = H2OContext.getOrCreate(new H2OConf().setClusterSize(1))
   }
-
-  override def afterAll() {
-    // The method H2O.exit calls System.exit which confuses Gradle and marks the build
-    // as successful even though some tests failed.
-    // We can solve this by using security manager which forbids System.exit call.
-    // It is safe to use as all the methods closing H2O cloud and stopping operations have been
-    // already called and we just need to ensure that JVM with the client/driver doesn't call the System.exit method
-    try {
-      val securityManager = new NoExitCheckSecurityManager
-      System.setSecurityManager(securityManager)
-      super.afterAll()
-      System.setSecurityManager(null)
-    } catch {
-      case _: SecurityException => // ignore
-    }
-  }
-
-  private class NoExitCheckSecurityManager extends SecurityManager {
-    override def checkPermission(perm: Permission): Unit = {
-      /* allow any */
-    }
-
-    override def checkPermission(perm: Permission, context: scala.Any): Unit = {
-      /* allow any */
-    }
-
-    override def checkExit(status: Int): Unit = {
-      super.checkExit(status)
-      throw new SecurityException()
-    }
-  }
-
 }


### PR DESCRIPTION
As our tests our running in client-less mode in Scala as well, we no longer need this hack as H2O never calls System.exit on Spark driver.

As the side-effect the time of our unit tests after removing this is lowered by around 20 minutes 🎉 