### PR TITLE
[SW-2193] on Spark 2.4.5, build python docker image fails as apk is not found

### DIFF
--- a/kubernetes/build.gradle
+++ b/kubernetes/build.gradle
@@ -45,9 +45,7 @@ task createPythonDockerfile(type: Dockerfile) {
   copyFile("h2o_pysparkling_${sparkMajorVersion}-${version}.zip", "/opt/spark/pyspark/python/lib/h2o_pysparkling_${sparkMajorVersion}-${version}.zip")
   runCommand """\\
                 pip install /opt/spark/pyspark/python/lib/h2o_pysparkling_${sparkMajorVersion}-${version}.zip && \\
-                apk add build-base python-dev && \\
-                pip install numpy && \\
-                apk del build-base python-dev
+                pip install numpy
                 """
 }
 


### PR DESCRIPTION
As we discussed, what do you think of supporting just latest Spark in our images for Kubernetes? 

Enterprise customers will probably have their own images