### PR TITLE
[SW-2240] Ensure flow dir is specified also on worker nodes

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -124,7 +124,8 @@ object H2OConf extends Logging {
     "spark.ext.h2o.node.iced.dir" -> "spark.ext.h2o.iced.dir",
     "spark.ext.h2o.client.iced.dir" -> "spark.ext.h2o.iced.dir",
     "spark.ext.h2o.client.log.level" -> "spark.ext.h2o.log.level",
-    "spark.ext.h2o.node.log.level" -> "spark.ext.h2o.log.level")
+    "spark.ext.h2o.node.log.level" -> "spark.ext.h2o.log.level",
+    "spark.ext.h2o.client.flow.dir" -> "spark.ext.h2o.flow.dir")
 
   private def checkDeprecatedOptions(sparkConf: SparkConf): Unit = {
     deprecatedOptions.foreach {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -446,7 +446,7 @@ object SharedBackendConf {
   val PROP_NODE_EXTRA_PROPERTIES: (String, None.type) = ("spark.ext.h2o.node.extra", None)
 
   /** Path to flow dir. */
-  val PROP_FLOW_DIR: (String, None.type) = ("spark.ext.h2o.client.flow.dir", None)
+  val PROP_FLOW_DIR: (String, None.type) = ("spark.ext.h2o.flow.dir", None)
 
   /** Extra http headers for Flow UI */
   val PROP_FLOW_EXTRA_HTTP_HEADERS: (String, None.type) = ("spark.ext.h2o.flow.extra.http.headers", None)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalH2OBackend.scala
@@ -108,6 +108,7 @@ class ExternalH2OBackend(val hc: H2OContext) extends SparklingBackend with Shell
       .add("-nthreads", conf.nthreads)
       .add(Seq("-J", "-log_level", "-J", conf.logLevel))
       .add(conf.icedDir.map(dir => Seq("-J", "-ice_root", "-J", dir)).getOrElse(Seq()))
+      .add(conf.flowDir.map(dir => Seq("-J", "-flow_dir", "-J", dir)).getOrElse(Seq()))
       .add("-port_offset", conf.internalPortOffset)
       .add("-baseport", conf.nodeBasePort)
       .add("-timeout", conf.clusterStartTimeout)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/SharedBackendUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/SharedBackendUtils.scala
@@ -177,6 +177,7 @@ trait SharedBackendUtils extends Logging with Serializable {
       .add("-log_level", conf.logLevel)
       .add("-embedded")
       .add("-ice_root", conf.icedDir)
+      .add("-flow_dir", conf.flowDir)
       .buildArgs()
   }
 
@@ -187,7 +188,6 @@ trait SharedBackendUtils extends Logging with Serializable {
       .addIf("-quiet", !conf.clientVerboseOutput)
       .add("-log_dir", conf.h2oClientLogDir)
       .add("-baseport", conf.clientBasePort)
-      .add("-flow_dir", conf.flowDir)
       .add("-port", Some(conf.clientWebPort).filter(_ > 0))
       .addAsString(conf.clientExtraProperties)
       .buildArgs()

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -196,7 +196,7 @@ Configuration properties independent of selected backend
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
 | **H2O client parameters**                          |                |                                                 |                                        |
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
-| ``spark.ext.h2o.client.flow.dir``                  | ``None``       | ``setFlowDir(String)``                          | Directory where flows from H2O Flow    |
+| ``spark.ext.h2o.flow.dir``                         | ``None``       | ``setFlowDir(String)``                          | Directory where flows from H2O Flow    |
 |                                                    |                |                                                 | are saved.                             |
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
 | ``spark.ext.h2o.client.ip``                        | ``None``       | ``setClientIp(String)``                         | IP of H2O client node.                 |

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -15,6 +15,8 @@ From 3.32 to 3.34
   ``spark.ext.h2o.client.log.level`` and ``spark.ext.h2o.node.log.level`` are replaced by
   ``spark.ext.h2o.log.level``.
 
+- Spark option ``spark.ext.h2o.client.flow.dir`` is replaced by ``spark.ext.h2o.flow.dir``.
+
 From 3.30 to 3.32
 -----------------
 


### PR DESCRIPTION
I'm not moving out of the client section on the documentation as https://github.com/h2oai/sparkling-water/pull/2114 removes the section