### PR TITLE
[SW-2251] Remove usage of deprecated properties in Python integration tests

### DIFF
--- a/py/tests/integration/integ_test_utils.py
+++ b/py/tests/integration/integ_test_utils.py
@@ -32,9 +32,9 @@ def get_default_spark_conf(additional_conf=None):
         "spark.ext.h2o.port.base": "63331",
         "spark.executor.memory": "2g",
         "spark.driver.memory": "2g",
-        "spark.ext.h2o.node.log.dir": "build/h2ologs-pyIntegTest",
+        "spark.ext.h2o.log.dir": "build/h2ologs-pyIntegTest",
         "spark.ext.h2o.external.cluster.size": "1",
-        "spark.ext.h2o.node.log.level": "WARN"
+        "spark.ext.h2o.log.level": "WARN"
     }
 
     for key in additional_conf:


### PR DESCRIPTION
Leftovers after the parameter deprecations