### PR TITLE
[SW-2255] Deprecate H2OConf and H2OContext in package org.apache.spark

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -28,8 +28,9 @@ import org.apache.spark.internal.Logging
   */
 class H2OConf(sparkConf: SparkConf) extends ai.h2o.sparkling.H2OConf(sparkConf) {
   this.set("spark.ext.h2o.rest.api.based.client", value = false)
-  logWarning("The class org.apache.spark.h2o.H2OConf is deprecated and will be removed in release 3.34." +
-    " Please use ai.h2o.sparkling.H2OConf instead.")
+  logWarning(
+    "The class org.apache.spark.h2o.H2OConf is deprecated and will be removed in release 3.34." +
+      " Please use ai.h2o.sparkling.H2OConf instead.")
   def this() = this(SparkSessionUtils.active.sparkContext.getConf)
 }
 

--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 class H2OConf(sparkConf: SparkConf) extends ai.h2o.sparkling.H2OConf(sparkConf) {
   this.set("spark.ext.h2o.rest.api.based.client", value = false)
   logWarning(
-    "The class org.apache.spark.h2o.H2OConf is deprecated and will be removed in release 3.34." +
+    "The class org.apache.spark.h2o.H2OConf is deprecated and will be removed in the version 3.34." +
       " Please use ai.h2o.sparkling.H2OConf instead.")
   def this() = this(SparkSessionUtils.active.sparkContext.getConf)
 }

--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.h2o
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
@@ -27,12 +28,16 @@ import org.apache.spark.internal.Logging
   */
 class H2OConf(sparkConf: SparkConf) extends ai.h2o.sparkling.H2OConf(sparkConf) {
   this.set("spark.ext.h2o.rest.api.based.client", value = false)
+  logWarning("The class org.apache.spark.h2o.H2OConf is deprecated and will be removed in release 3.34." +
+    " Please use ai.h2o.sparkling.H2OConf instead.")
   def this() = this(SparkSessionUtils.active.sparkContext.getConf)
 }
 
 object H2OConf extends Logging {
+  @DeprecatedMethod("ai.h2o.sparkling.H2OConf", "3.34")
   def apply(): H2OConf = new H2OConf()
 
+  @DeprecatedMethod("ai.h2o.sparkling.H2OConf", "3.34")
   def apply(sparkConf: SparkConf): H2OConf = new H2OConf(sparkConf)
 
   private var _sparkConfChecked = false

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import ai.h2o.sparkling.backend.NodeDesc
 import ai.h2o.sparkling.backend.converters._
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.utils.SparkSessionUtils
 import org.apache.spark.expose.Logging
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -178,20 +179,24 @@ object H2OContext extends Logging {
 
   private val instantiatedContext = new AtomicReference[H2OContext]()
 
+  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.getOrCreate", "3.34")
   def getOrCreate(): H2OContext = {
     val hc = ai.h2o.sparkling.H2OContext.getOrCreate()
     instantiatedContext.set(new H2OContext(hc))
     instantiatedContext.get()
   }
 
+  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.getOrCreate", "3.34")
   def getOrCreate(conf: H2OConf): H2OContext = synchronized {
     val hc = ai.h2o.sparkling.H2OContext.getOrCreate(conf)
     instantiatedContext.set(new H2OContext(hc))
     instantiatedContext.get()
   }
 
+  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.get", "3.34")
   def get(): Option[H2OContext] = Option(instantiatedContext.get())
 
+  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.ensure", "3.34")
   def ensure(onError: => String = "H2OContext has to be running."): H2OContext = {
     Option(instantiatedContext.get()) getOrElse {
       throw new RuntimeException(onError)


### PR DESCRIPTION
The migration guide already contains the information, I just forgot to the the deprecation as part of that change