### PR TITLE
[SW-2259] Replace old H2OFrame api mentions in docs

### DIFF
--- a/doc/src/site/sphinx/devel/integ_tests.rst
+++ b/doc/src/site/sphinx/devel/integ_tests.rst
@@ -68,7 +68,7 @@ The following code reflects the use cases listed above. The code is executed in 
         val h2oContext = H2OContext.getOrCreate()
 
         import java.io.File
-        val df: H2OFrame = new H2OFrame(new File("examples/smalldata/airlines/allyears2k_headers.csv"))
+        val df: H2OFrame = H2OFrame(new File("examples/smalldata/airlines/allyears2k_headers.csv"))
 
     **Note**: The file must be present on all nodes. Specifically in the case of the Sparkling Water internal backend, this must be present on all nodes with Spark. In the case of the Sparkling Water external backend, this must be present on all nodes with H2O.
      
@@ -84,7 +84,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
         val path = "hdfs://mr-0xd6.0xdata.loc/datasets/airlines_all.csv"
         val uri = new java.net.URI(path)
-        val airlinesHF = new H2OFrame(uri)
+        val airlinesHF = H2OFrame(uri)
 
  - From S3N:
 
@@ -97,7 +97,7 @@ The following code reflects the use cases listed above. The code is executed in 
 
         val path = "s3n://h2o-airlines-unpacked/allyears2k.csv"
         val uri = new java.net.URI(path)
-        val airlinesHF = new H2OFrame(uri)
+        val airlinesHF = H2OFrame(uri)
 
     **Note**: Spark/H2O needs to know the AWS credentials specified in ``core-site.xml``. The credentials are passed via ``HADOOP_CONF_DIR``, which points to a configuration directory with ``core-site.xml``.
 

--- a/doc/src/site/sphinx/tutorials/import_export_s3.rst
+++ b/doc/src/site/sphinx/tutorials/import_export_s3.rst
@@ -80,7 +80,7 @@ Finally, read the data:
  .. code:: scala
 
     import java.net.URI
-    val fr = new H2OFrame(new URI("s3n://data.h2o.ai/h2o-open-tour/2016-nyc/weather.csv"))
+    val fr = H2OFrame(new URI("s3n://data.h2o.ai/h2o-open-tour/2016-nyc/weather.csv"))
 
 PySparkling Example Code
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/src/site/sphinx/tutorials/shap_values.rst
+++ b/doc/src/site/sphinx/tutorials/shap_values.rst
@@ -35,7 +35,7 @@ To get SHAP values(=contributions) from H2OXGBoost model, please do:
 
         .. code:: scala
 
-            val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
+            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
             val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 

--- a/doc/src/site/sphinx/tutorials/sw_automl.rst
+++ b/doc/src/site/sphinx/tutorials/sw_automl.rst
@@ -27,7 +27,7 @@ The following sections describe how to train an AutoML model in Sparkling Water 
 
         .. code:: scala
 
-            val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
+            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
             val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 

--- a/doc/src/site/sphinx/tutorials/sw_drf.rst
+++ b/doc/src/site/sphinx/tutorials/sw_drf.rst
@@ -29,7 +29,7 @@ The following sections describe how to train DRF model in Sparkling Water in bot
 
         .. code:: scala
 
-            val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
+            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
             val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 

--- a/doc/src/site/sphinx/tutorials/sw_kmeans.rst
+++ b/doc/src/site/sphinx/tutorials/sw_kmeans.rst
@@ -29,7 +29,7 @@ The following sections describe how to train KMeans model in Sparkling Water in 
 
         .. code:: scala
 
-            val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/iris/iris_wheader.csv"))
+            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/iris/iris_wheader.csv"))
             val sparkDF = hc.asSparkFrame(frame)
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 

--- a/doc/src/site/sphinx/tutorials/sw_target_encoder.rst
+++ b/doc/src/site/sphinx/tutorials/sw_target_encoder.rst
@@ -109,7 +109,7 @@ and prepare the environment:
 
         .. code:: scala
 
-            val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
+            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
             val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 

--- a/doc/src/site/sphinx/tutorials/sw_xgboost.rst
+++ b/doc/src/site/sphinx/tutorials/sw_xgboost.rst
@@ -27,7 +27,7 @@ The following sections describe how to train XGBoost model in Sparkling Water in
 
         .. code:: scala
 
-            val frame = new H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
+            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
             val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 


### PR DESCRIPTION
Missing updates after updating to ai.h2o.sparkling.H2OContext. Need to switch to ai.h2o.sparkling.H2OFrame api.