### PR TITLE
[SW-2264] Warn user of upcomming change in grid search in 3.32

### DIFF
--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -150,6 +150,14 @@ From 3.30 to 3.32
   ``val df = spark.read.format("h2o").load(key)`` instead. The same holds for ``spark.write.h2o(key)``. Please use
   ``df.write.format("h2o").save("new_key")`` instead.
 
+- Starting from version 3.32, ``H2OGridSearch`` hyper-parameters now correspond to parameter names in Sparkling Water.
+  Previously, the hyper-parameters were specified using internal H2O names such as ``_ntrees`` or ``_max_depth``.
+  At this version, the parameter names follow the naming convention of getters and setters of the corresponding
+  parameter, such as ``ntrees`` or ``maxDepth``.
+
+  Also the output of ``getGridModelsParams`` now contains column names which correspond to Sparkling Water parameter names
+  instead of H2O internal ones. When updating to version 3.32, please make sure to update your hyper parameter names.
+
 From 3.28.1 to 3.30
 -------------------
 

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -150,7 +150,7 @@ From 3.30 to 3.32
   ``val df = spark.read.format("h2o").load(key)`` instead. The same holds for ``spark.write.h2o(key)``. Please use
   ``df.write.format("h2o").save("new_key")`` instead.
 
-- Starting from version 3.32, ``H2OGridSearch`` hyper-parameters now correspond to parameter names in Sparkling Water.
+- Starting from version the 3.32, ``H2OGridSearch`` hyper-parameters now correspond to parameter names in Sparkling Water.
   Previously, the hyper-parameters were specified using internal H2O names such as ``_ntrees`` or ``_max_depth``.
   At this version, the parameter names follow the naming convention of getters and setters of the corresponding
   parameter, such as ``ntrees`` or ``maxDepth``.

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
@@ -90,7 +90,7 @@ class H2OGridSearch(override val uid: String)
 
   private def prepareHyperParameters(): String = {
     logWarning(
-      "Starting from version 3.32, hyper-parameter names will use the names correspodning to Sparkling Water parameters" +
+      "Starting from the version 3.32, hyper-parameter names will use the names corresponding to Sparkling Water parameters" +
         " instead of H2O internal ones.")
     val it = getHyperParameters().entrySet().iterator()
     val checkedHyperParams = new java.util.HashMap[String, Array[AnyRef]]()

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
@@ -89,6 +89,9 @@ class H2OGridSearch(override val uid: String)
   }
 
   private def prepareHyperParameters(): String = {
+    logWarning(
+      "Starting from version 3.32, hyper-parameter names will use the names correspodning to Sparkling Water parameters" +
+        " instead of H2O internal ones.")
     val it = getHyperParameters().entrySet().iterator()
     val checkedHyperParams = new java.util.HashMap[String, Array[AnyRef]]()
     while (it.hasNext) {


### PR DESCRIPTION
@mn-mikke I decided for different approach, deprecate in 3.32 and change in 3.34 instead of supporting two paths in the code.