### PR TITLE
[SW-2275] Ensure pytest cache is generated into build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ rsparkling.Rproj
 py/build
 py/__pycache__/
 *.py[cod]
-py/.pytest_cache
 
 # Terraform
 

--- a/py/tests/pytest.ini
+++ b/py/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+cache_dir = ../build/.pytest_cache


### PR DESCRIPTION
Doing some small improvements whilst testing kubernetes