### PR TITLE
[SW-2280] Fix Reading of Spark DataFrames in SW Tutorials

### DIFF
--- a/doc/src/site/sphinx/tutorials/shap_values.rst
+++ b/doc/src/site/sphinx/tutorials/shap_values.rst
@@ -35,8 +35,10 @@ To get SHAP values(=contributions) from H2OXGBoost model, please do:
 
         .. code:: scala
 
-            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+	        import org.apache.spark.SparkFiles
+            spark.sparkContext.addFile("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv")
+	        val rawSparkDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("prostate.csv"))
+            val sparkDF = rawSparkDF.withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Train the model. You can configure all the available XGBoost arguments using provided setters, such as the label column.

--- a/doc/src/site/sphinx/tutorials/sw_automl.rst
+++ b/doc/src/site/sphinx/tutorials/sw_automl.rst
@@ -27,8 +27,10 @@ The following sections describe how to train an AutoML model in Sparkling Water 
 
         .. code:: scala
 
-            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+	        import org.apache.spark.SparkFiles
+            spark.sparkContext.addFile("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv")
+	        val rawSparkDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("prostate.csv"))
+            val sparkDF = rawSparkDF.withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Create a H2OAutoML instance and configure it according your use case via provided setters. If feature columns are not specified explicitly,

--- a/doc/src/site/sphinx/tutorials/sw_drf.rst
+++ b/doc/src/site/sphinx/tutorials/sw_drf.rst
@@ -29,8 +29,10 @@ The following sections describe how to train DRF model in Sparkling Water in bot
 
         .. code:: scala
 
-            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+	        import org.apache.spark.SparkFiles
+            spark.sparkContext.addFile("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv")
+	        val rawSparkDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("prostate.csv"))
+            val sparkDF = rawSparkDF.withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Train the model. You can configure all the available DRF arguments using provided setters, such as the label column.

--- a/doc/src/site/sphinx/tutorials/sw_kmeans.rst
+++ b/doc/src/site/sphinx/tutorials/sw_kmeans.rst
@@ -29,8 +29,9 @@ The following sections describe how to train KMeans model in Sparkling Water in 
 
         .. code:: scala
 
-            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/iris/iris_wheader.csv"))
-            val sparkDF = hc.asSparkFrame(frame)
+	        import org.apache.spark.SparkFiles
+            spark.sparkContext.addFile("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/iris/iris_wheader.csv")
+	        val sparkDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("iris_wheader.csv"))
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Train the model. You can configure all the available KMeans arguments using provided setters.

--- a/doc/src/site/sphinx/tutorials/sw_target_encoder.rst
+++ b/doc/src/site/sphinx/tutorials/sw_target_encoder.rst
@@ -109,8 +109,10 @@ and prepare the environment:
 
         .. code:: scala
 
-            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+	        import org.apache.spark.SparkFiles
+            spark.sparkContext.addFile("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv")
+	        val rawSparkDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("prostate.csv"))
+            val sparkDF = rawSparkDF.withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
     .. tab-container:: Python

--- a/doc/src/site/sphinx/tutorials/sw_xgboost.rst
+++ b/doc/src/site/sphinx/tutorials/sw_xgboost.rst
@@ -27,8 +27,10 @@ The following sections describe how to train XGBoost model in Sparkling Water in
 
         .. code:: scala
 
-            val frame = H2OFrame(new URI("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv"))
-            val sparkDF = hc.asSparkFrame(frame).withColumn("CAPSULE", $"CAPSULE" cast "string")
+	        import org.apache.spark.SparkFiles
+            spark.sparkContext.addFile("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/prostate/prostate.csv")
+	        val rawSparkDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("prostate.csv"))
+            val sparkDF = rawSparkDF.withColumn("CAPSULE", $"CAPSULE" cast "string")
             val Array(trainingDF, testingDF) = sparkDF.randomSplit(Array(0.8, 0.2))
 
         Train the model. You can configure all the available XGBoost arguments using provided setters, such as the label column.


### PR DESCRIPTION
Reading data via `H2OFrame(new Uri(...))` seems to doesn't work on master anymore.