### PR TITLE
[SW-2283] Switch inner join implementation to use H2O

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OFrame.scala
@@ -138,10 +138,7 @@ class H2OFrame private (
     * @return new frame
     */
   def rightJoin(another: H2OFrame): H2OFrame = {
-    // Right join fails under "radix". The other variant is "hash" method
-    // but that method does not support strings in columns and does not work correctly if there are duplicate
-    // columns in the frame. Use Spark for now
-    joinUsingSpark(another, "right")
+    join(another, allFromCurrent = false, allFromAnother = true, "radix")
   }
 
   /**
@@ -160,6 +157,7 @@ class H2OFrame private (
     * @return new frame
     */
   def outerJoin(another: H2OFrame): H2OFrame = {
+    join(another, allFromCurrent = true, allFromAnother = true, "radix")
     // Outer join is broken in H2O, simulate H2O's join via Spark for now
     joinUsingSpark(another, "outer")
   }

--- a/core/src/main/scala/ai/h2o/sparkling/H2OFrame.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OFrame.scala
@@ -157,7 +157,6 @@ class H2OFrame private (
     * @return new frame
     */
   def outerJoin(another: H2OFrame): H2OFrame = {
-    join(another, allFromCurrent = true, allFromAnother = true, "radix")
     // Outer join is broken in H2O, simulate H2O's join via Spark for now
     joinUsingSpark(another, "outer")
   }


### PR DESCRIPTION
Right join has been fixed as part of https://0xdata.atlassian.net/browse/PUBDEV-7362 and we can use H2O implementation