### PR TITLE
[SW-1668] Structure Contributions in the 'detailed_prediction' Colums as MapType

### DIFF
--- a/doc/src/site/sphinx/tutorials/shap_values.rst
+++ b/doc/src/site/sphinx/tutorials/shap_values.rst
@@ -46,12 +46,16 @@ To get SHAP values(=contributions) from H2OXGBoost model, please do:
         .. code:: scala
 
             import ai.h2o.sparkling.ml.algos.H2OXGBoost
-            val estimator = new H2OXGBoost().setLabelCol("CAPSULE").setWithDetailedPredictionCol(true)
+            val estimator = new H2OXGBoost()
+                .setLabelCol("CAPSULE")
+                .setWithDetailedPredictionCol(true)
+                .setWithContributions(true)
             val model = estimator.fit(trainingDF)
 
         The call ``setWithDetailedPredictionCol(true)`` tells Sparkling Water to create additional prediction column with
-        additional prediction details, such as the contributions. The name of this column is by default "detailed_prediction"
-        and can be modified via ``setDetailedPredictionCol`` setter.
+        additional prediction details and the call ``setWithContributions(true)`` tells to include contributions to
+        this column. The name of this column is by default "detailed_prediction" and can be modified via
+        ``setDetailedPredictionCol`` setter.
 
         Run Predictions
 
@@ -98,12 +102,12 @@ To get SHAP values(=contributions) from H2OXGBoost model, please do:
         .. code:: python
 
             from pysparkling.ml import H2OXGBoost
-            estimator = H2OXGBoost(labelCol = "CAPSULE", withDetailedPredictionCol = True)
+            estimator = H2OXGBoost(labelCol = "CAPSULE", withDetailedPredictionCol = True, withContributions = True)
             model = estimator.fit(trainingDF)
 
-        The parameter ``withDetailedPredictionCol = True`` tells Sparkling Water to create additional prediction column with
-        additional prediction details, such as the contributions. The name of this column is by default "detailed_prediction"
-        and can be modified via ``detailedPredictionCol`` parameter.
+        The parameter ``withDetailedPredictionCol = True`` tells Sparkling Water to create an additional prediction column with
+        additional prediction details and the parameter ``withContributions = True`` tells to include contributions to this column.
+        The name of this column is by default "detailed_prediction" and can be modified via ``detailedPredictionCol`` parameter.
 
         Run Predictions
 

--- a/doc/src/site/sphinx/tutorials/shap_values.rst
+++ b/doc/src/site/sphinx/tutorials/shap_values.rst
@@ -61,13 +61,13 @@ To get SHAP values(=contributions) from H2OXGBoost model, please do:
 
         .. code:: scala
 
-            val predictions = model.transform(testingDF).show(false)
+            val predictions = model.transform(testingDF)
 
         Show contributions
 
         .. code:: scala
 
-            predictions.select("detailed_prediction.contribution").show()
+            predictions.select("detailed_prediction.contributions").show(false)
 
 
 
@@ -113,13 +113,13 @@ To get SHAP values(=contributions) from H2OXGBoost model, please do:
 
         .. code:: python
 
-            model.transform(testingDF).show(truncate = False)
+            predictions = model.transform(testingDF)
 
         Show contributions
 
         .. code:: python
 
-            predictions.select("detailed_prediction.contributions").show()
+            predictions.select("detailed_prediction.contributions").show(truncate = False)
 
 Get Contributions from Raw MOJO
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -152,7 +152,7 @@ there is no need to start ``H2OContext``.
             import ai.h2o.sparkling.ml.models._
 
             val path = "/path/to/mojo.zip"
-            val settings = H2OMOJOSettings(withDetailedPredictionCol = true)
+            val settings = H2OMOJOSettings(withDetailedPredictionCol = true, withContributions = true)
             val model = H2OMOJOModel.createFromMojo(path, settings)
 
         Run Predictions
@@ -191,7 +191,7 @@ there is no need to start ``H2OContext``.
             from pysparkling.ml import *
 
             val path = '/path/to/mojo.zip'
-            settings = H2OMOJOSettings(withDetailedPredictionCol=True)
+            settings = H2OMOJOSettings(withDetailedPredictionCol=True, withContributions=True)
             model = H2OMOJOModel.createFromMojo(path, settings)
 
         Run Predictions

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OCommonParams.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OCommonParams.scala
@@ -73,6 +73,8 @@ trait H2OCommonParams extends H2OBaseMOJOParams with H2OAlgoParamsBase {
 
   def setWithDetailedPredictionCol(enabled: Boolean): this.type = set(withDetailedPredictionCol, enabled)
 
+  def setWithContributions(enabled: Boolean): this.type = set(withContributions, enabled)
+
   def setFeaturesCol(first: String): this.type = setFeaturesCols(first)
 
   def setFeaturesCols(first: String, others: String*): this.type = set(featuresCols, Array(first) ++ others)

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/ParameterSetters.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/ParameterSetters.scala
@@ -1,0 +1,23 @@
+package ai.h2o.sparkling.ml
+
+import ai.h2o.sparkling.ml.algos.H2OSupervisedAlgorithm
+import hex.Model
+import org.apache.spark.ml.param.{IntParam, LongParam, Param}
+
+object ParameterSetters {
+  implicit class AlgorithmWrapper(val algo: H2OSupervisedAlgorithm[_ <: Model.Parameters]) {
+
+    def setSeed(value: Long): algo.type = setParam[Long, LongParam]("seed", value)
+
+    def setNfolds(value: Int): algo.type = setParam[Int, IntParam]("nfolds", value)
+
+    private def setParam[ValueType, ParamType <: Param[ValueType]](paramName: String, value: ValueType): algo.type = {
+      val field = algo.getClass.getDeclaredFields.find(_.getName().endsWith("$$" + paramName)).head
+      field.setAccessible(true)
+      val parameter = field.get(algo).asInstanceOf[ParamType]
+      algo.set(parameter, value)
+      field.setAccessible(false)
+      algo
+    }
+  }
+}

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/BinomialPredictionTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/BinomialPredictionTestSuite.scala
@@ -145,10 +145,8 @@ class BinomialPredictionTestSuite extends FunSuite with Matchers with SharedH2OT
     val probabilitiesField =
       StructField("probabilities", MapType(StringType, DoubleType, valueContainsNull = false), nullable = true)
     val predictionColField = StructField("prediction", StringType, nullable = true)
-    val detailedPredictionColField = StructField(
-      "detailed_prediction",
-      StructType(labelField :: probabilitiesField :: Nil),
-      nullable = true)
+    val detailedPredictionColField =
+      StructField("detailed_prediction", StructType(labelField :: probabilitiesField :: Nil), nullable = true)
 
     val expectedSchema = StructType(datasetFields ++ (detailedPredictionColField :: predictionColField :: Nil))
     val expectedSchemaByTransform = model.transform(dataset).schema

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/H2ODRFTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/H2ODRFTestSuite.scala
@@ -57,6 +57,7 @@ class H2ODRFTestSuite extends FunSuite with Matchers with SharedH2OTestContext {
       .setSplitRatio(0.8)
       .setSeed(1)
       .setWithDetailedPredictionCol(true)
+      .setWithContributions(true)
       .setFeaturesCols("CAPSULE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON")
       .setLabelCol("AGE")
 
@@ -65,7 +66,7 @@ class H2ODRFTestSuite extends FunSuite with Matchers with SharedH2OTestContext {
 
     val expectedCols = Seq("value", "contributions")
     assert(predictions.select("detailed_prediction.*").schema.fields.map(_.name).sameElements(expectedCols))
-    val contributions = predictions.select("detailed_prediction.contributions").head().getAs[Seq[Double]](0)
+    val contributions = predictions.select("detailed_prediction.contributions").head().getAs[Map[String, Double]](0)
     assert(contributions != null)
     assert(contributions.size == 8)
   }

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/RegressionPredictionTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/RegressionPredictionTestSuite.scala
@@ -89,7 +89,7 @@ class RegressionPredictionTestSuite extends FunSuite with Matchers with SharedH2
     assert(contributions == null)
   }
 
-  for(algo <- Seq(new H2OGBM(), new H2OGLM())) {
+  for (algo <- Seq(new H2OGBM(), new H2OGLM())) {
     test(s"transformSchema with detailed prediction col - ${algo.getClass.getSimpleName}") {
       import ai.h2o.sparkling.ml.ParameterSetters._
       algo

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/RegressionPredictionTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/RegressionPredictionTestSuite.scala
@@ -55,6 +55,7 @@ class RegressionPredictionTestSuite extends FunSuite with Matchers with SharedH2
       .setSplitRatio(0.8)
       .setSeed(1)
       .setWithDetailedPredictionCol(true)
+      .setWithContributions(true)
       .setFeaturesCols("CAPSULE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON")
       .setLabelCol("AGE")
 
@@ -64,33 +65,57 @@ class RegressionPredictionTestSuite extends FunSuite with Matchers with SharedH2
 
     val expectedCols = Seq("value", "contributions")
     assert(predictions.select("detailed_prediction.*").schema.fields.map(_.name).sameElements(expectedCols))
-    val contributions = predictions.select("detailed_prediction.contributions").head().getAs[Seq[Double]](0)
+    val contributions = predictions.select("detailed_prediction.contributions").head().getMap[String, Double](0)
     assert(contributions != null)
     assert(contributions.size == 8)
   }
 
-  test("transformSchema with detailed prediction col") {
-    val algo = new H2OGBM()
+  test("contributions on unsupported algorithm") {
+    val algo = new H2OGLM()
       .setSplitRatio(0.8)
       .setSeed(1)
       .setWithDetailedPredictionCol(true)
+      .setWithContributions(true)
       .setFeaturesCols("CAPSULE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON")
       .setLabelCol("AGE")
+
     val model = algo.fit(dataset)
 
-    val datasetFields = dataset.schema.fields
-    val valueField = StructField("value", DoubleType, nullable = false)
-    val predictionColField = StructField("prediction", DoubleType, nullable = true)
-    val contributionsField = StructField("contributions", ArrayType(FloatType, containsNull = false), nullable = true)
-    val detailedPredictionColField =
-      StructField("detailed_prediction", StructType(valueField :: contributionsField :: Nil), nullable = true)
+    val predictions = model.transform(dataset)
 
-    val expectedSchema = StructType(datasetFields ++ (detailedPredictionColField :: predictionColField :: Nil))
-    val expectedSchemaByTransform = model.transform(dataset).schema
-    val schema = model.transformSchema(dataset.schema)
+    val expectedCols = Seq("value", "contributions")
+    assert(predictions.select("detailed_prediction.*").schema.fields.map(_.name).sameElements(expectedCols))
+    val contributions = predictions.select("detailed_prediction.contributions").head().getMap[String, Double](0)
+    assert(contributions == null)
+  }
 
-    assert(schema == expectedSchema)
-    assert(schema == expectedSchemaByTransform)
+  for(algo <- Seq(new H2OGBM(), new H2OGLM())) {
+    test(s"transformSchema with detailed prediction col - ${algo.getClass.getSimpleName}") {
+      import ai.h2o.sparkling.ml.ParameterSetters._
+      algo
+        .setSplitRatio(0.8)
+        .setWithDetailedPredictionCol(true)
+        .setSeed(1)
+        .setWithContributions(true)
+        .setFeaturesCols("CAPSULE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON")
+        .setLabelCol("AGE")
+      val model = algo.fit(dataset)
+
+      val datasetFields = dataset.schema.fields
+      val valueField = StructField("value", DoubleType, nullable = false)
+      val predictionColField = StructField("prediction", DoubleType, nullable = true)
+      val contributionsType = MapType(StringType, FloatType, valueContainsNull = false)
+      val contributionsField = StructField("contributions", contributionsType, nullable = true)
+      val detailedPredictionColField =
+        StructField("detailed_prediction", StructType(valueField :: contributionsField :: Nil), nullable = true)
+
+      val expectedSchema = StructType(datasetFields ++ (detailedPredictionColField :: predictionColField :: Nil))
+      val expectedSchemaByTransform = model.transform(dataset).schema
+      val schema = model.transformSchema(dataset.schema)
+
+      assert(schema == expectedSchema)
+      assert(schema == expectedSchemaByTransform)
+    }
   }
 
   test("transformSchema without detailed prediction col") {

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/H2OSupervisedMOJOModelTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/H2OSupervisedMOJOModelTestSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FunSuite, Matchers}
-import ParameterSetters._
+import ai.h2o.sparkling.ml.ParameterSetters._
 
 @RunWith(classOf[JUnitRunner])
 class H2OSupervisedMOJOModelTestSuite extends FunSuite with Matchers with SharedH2OTestContext {

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/H2OTreeBasedSupervisedMOJOModelTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/H2OTreeBasedSupervisedMOJOModelTestSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.SparkSession
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
-import ParameterSetters._
+import ai.h2o.sparkling.ml.ParameterSetters._
 
 @RunWith(classOf[JUnitRunner])
 class H2OTreeBasedSupervisedMOJOModelTestSuite extends FunSuite with SharedH2OTestContext {

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OAutoML.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OAutoML.py
@@ -62,7 +62,8 @@ class H2OAutoML(H2OAutoMLParams, H2OSupervisedAlgoBase):
                  maxRuntimeSecsPerModel=0.0,
                  exportCheckpointsDir=None,
                  exploitationRatio=0.0,
-                 monotoneConstraints={}):
+                 monotoneConstraints={},
+                 withContributions=False):
         Initializer.load_sparkling_jar()
         super(H2OAutoML, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2OAutoML", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2ODRF.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2ODRF.py
@@ -83,7 +83,8 @@ class H2ODRF(H2ODRFParams, H2OTreeBasedSupervisedAlgoBase):
                  checkConstantResponse=True,
                  foldAssignment="AUTO",
                  categoricalEncoding="AUTO",
-                 keepCrossValidationModels=True):
+                 keepCrossValidationModels=True,
+                 withContributions=False):
         Initializer.load_sparkling_jar()
         super(H2ODRF, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2ODRF", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2ODeepLearning.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2ODeepLearning.py
@@ -121,7 +121,8 @@ class H2ODeepLearning(H2ODeepLearningParams, H2OSupervisedAlgoBase):
                  replicateTrainingData=True,
                  miniBatchSize=1,
                  scoreValidationSamples=0,
-                 maxCategoricalLevels=10):
+                 maxCategoricalLevels=10,
+                 withContributions=False):
         Initializer.load_sparkling_jar()
         super(H2ODeepLearning, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2ODeepLearning", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OGBM.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OGBM.py
@@ -87,7 +87,8 @@ class H2OGBM(H2OGBMParams, H2OTreeBasedSupervisedAlgoBase):
                  scoreEachIteration=False,
                  categoricalEncoding="AUTO",
                  maxCategoricalLevels=10,
-                 balanceClasses=False):
+                 balanceClasses=False,
+                 withContributions=False):
         Initializer.load_sparkling_jar()
         super(H2OGBM, self).__init__()
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.algos.H2OGBM", self.uid)

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OGLM.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OGLM.py
@@ -97,6 +97,7 @@ class H2OGLM(H2OGLMParams, H2OSupervisedAlgoBase):
                  foldAssignment="AUTO",
                  calcLike=False,
                  maxRuntimeSecs=0.0,
+                 withContributions=False,
                  **DeprecatedParams):
         Initializer.load_sparkling_jar()
         super(H2OGLM, self).__init__()

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OKMeans.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OKMeans.py
@@ -68,6 +68,7 @@ class H2OKMeans(H2OKMeansParams, H2OUnsupervisedAlgoBase):
                  stoppingTolerance=0.001,
                  foldAssignment="AUTO",
                  categoricalEncoding="AUTO",
+                 withContributions=False,
                  huberAlpha=0.9):
         Initializer.load_sparkling_jar()
         super(H2OKMeans, self).__init__()

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
@@ -106,6 +106,7 @@ class H2OXGBoost(H2OXGBoostParams, H2OTreeBasedSupervisedAlgoBase):
                  maxCategoricalLevels=10,
                  exportCheckpointsDir=None,
                  quantileAlpha=0.5,
+                 withContributions=False,
                  **DeprecatedParams):
         Initializer.load_sparkling_jar()
         super(H2OXGBoost, self).__init__()

--- a/py/src/ai/h2o/sparkling/ml/models/H2OMOJOModelBase.py
+++ b/py/src/ai/h2o/sparkling/ml/models/H2OMOJOModelBase.py
@@ -49,3 +49,6 @@ class H2OMOJOModelBase(JavaModel, JavaMLWritable, JavaMLReadable):
 
     def getNamedMojoOutputColumns(self):
         return self._java_obj.getNamedMojoOutputColumns()
+
+    def getWithContributions(self):
+        return self._java_obj.getWithContributions()

--- a/py/src/ai/h2o/sparkling/ml/models/H2OMOJOSettings.py
+++ b/py/src/ai/h2o/sparkling/ml/models/H2OMOJOSettings.py
@@ -28,7 +28,8 @@ class H2OMOJOSettings(JavaWrapper):
                  withDetailedPredictionCol=False,
                  convertUnknownCategoricalLevelsToNa=False,
                  convertInvalidNumbersToNa=False,
-                 namedMojoOutputColumns=True):
+                 namedMojoOutputColumns=True,
+                 withContributions=False):
         self._java_obj = None
 
         assert_is_type(predictionCol, str)
@@ -37,12 +38,14 @@ class H2OMOJOSettings(JavaWrapper):
         assert_is_type(convertUnknownCategoricalLevelsToNa, bool)
         assert_is_type(convertInvalidNumbersToNa, bool)
         assert_is_type(namedMojoOutputColumns, bool)
+        assert_is_type(withContributions, bool)
         self.predictionCol = predictionCol
         self.detailedPredictionCol = detailedPredictionCol
         self.withDetailedPredictionCol = withDetailedPredictionCol
         self.convertUnknownCategoricalLevelsToNa = convertUnknownCategoricalLevelsToNa
         self.convertInvalidNumbersToNa = convertInvalidNumbersToNa
         self.namedMojoOutputColumns = namedMojoOutputColumns
+        self.withContributions = withContributions
 
     def toJavaObject(self):
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.models.H2OMOJOSettings",
@@ -51,7 +54,8 @@ class H2OMOJOSettings(JavaWrapper):
                                             self.withDetailedPredictionCol,
                                             self.convertUnknownCategoricalLevelsToNa,
                                             self.convertInvalidNumbersToNa,
-                                            self.namedMojoOutputColumns)
+                                            self.namedMojoOutputColumns,
+                                            self.withContributions)
         return self._java_obj
 
     @staticmethod

--- a/py/src/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.py
@@ -39,6 +39,12 @@ class H2OBaseMOJOParams(Params):
         "Enables or disables generating additional prediction column, but with more details",
         H2OTypeConverters.toBoolean())
 
+    withContributions = Param(
+        Params._dummy(),
+        "withContributions ",
+        "Enables or disables generating a sub-column of detailedPredictionCol containing Shapley values.",
+        H2OTypeConverters.toBoolean())
+
     featuresCols = Param(
         Params._dummy(),
         "featuresCols",
@@ -74,6 +80,9 @@ class H2OBaseMOJOParams(Params):
 
     def getWithDetailedPredictionCol(self):
         return self.getOrDefault(self.withDetailedPredictionCol)
+
+    def getWithContributions(self):
+        return self.getOrDefault(self.withContributions)
 
     def getFeaturesCols(self):
         return self.getOrDefault(self.featuresCols)

--- a/py/src/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.py
@@ -41,7 +41,7 @@ class H2OBaseMOJOParams(Params):
 
     withContributions = Param(
         Params._dummy(),
-        "withContributions ",
+        "withContributions",
         "Enables or disables generating a sub-column of detailedPredictionCol containing Shapley values.",
         H2OTypeConverters.toBoolean())
 

--- a/py/src/ai/h2o/sparkling/ml/params/H2OCommonParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OCommonParams.py
@@ -131,3 +131,6 @@ class H2OCommonParams(H2OBaseMOJOParams):
 
     def setNamedMojoOutputColumns(self, value):
         return self._set(namedMojoOutputColumns=value)
+
+    def setWithContributions(self, value):
+        return self._set(withContributions=value)

--- a/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOModelBase.R
+++ b/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOModelBase.R
@@ -29,6 +29,9 @@ H2OMOJOModelBase <- setRefClass("H2OMOJOModelBase", fields = list(jmojo = "ANY")
   getWithDetailedPredictionCol = function() {
     invoke(.self$jmojo, "getWithDetailedPredictionCol")
   },
+  getWithContributions = function() {
+    invoke(.self$jmojo, "getWithContributions")
+  },
   getFeaturesCols = function() {
     invoke(.self$jmojo, "getFeaturesCols")
   },

--- a/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOSettings.R
+++ b/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOSettings.R
@@ -26,20 +26,23 @@ H2OMOJOSettings <- setRefClass("H2OMOJOSettings",
                                              withDetailedPredictionCol = "logical",
                                              convertUnknownCategoricalLevelsToNa = "logical",
                                              convertInvalidNumbersToNa = "logical",
-                                             namedMojoOutputColumns = "logical"),
+                                             namedMojoOutputColumns = "logical",
+                                             withContributions = "logical"),
                                methods = list(
                                  initialize = function(predictionCol = "prediction",
                                                        detailedPredictionCol = "detailed_prediction",
                                                        withDetailedPredictionCol = FALSE,
                                                        convertUnknownCategoricalLevelsToNa = FALSE,
                                                        convertInvalidNumbersToNa = FALSE,
-                                                       namedMojoOutputColumns = TRUE) {
+                                                       namedMojoOutputColumns = TRUE,
+                                                       withContributions = FALSE) {
                                    .self$predictionCol <- predictionCol
                                    .self$detailedPredictionCol <- detailedPredictionCol
                                    .self$withDetailedPredictionCol <- withDetailedPredictionCol
                                    .self$convertUnknownCategoricalLevelsToNa <- convertUnknownCategoricalLevelsToNa
                                    .self$convertInvalidNumbersToNa <- convertInvalidNumbersToNa
                                    .self$namedMojoOutputColumns <- namedMojoOutputColumns
+                                   .self$withContributions <- withContributions
                                  },
                                  toJavaObject = function() {
                                    sc <- spark_connection_find()[[1]]
@@ -49,6 +52,7 @@ H2OMOJOSettings <- setRefClass("H2OMOJOSettings",
                                               .self$withDetailedPredictionCol,
                                               .self$convertUnknownCategoricalLevelsToNa,
                                               .self$convertInvalidNumbersToNa,
-                                              .self$namedMojoOutputColumns)
+                                              .self$namedMojoOutputColumns,
+                                              .self$withContributions)
                                  }
                                ))

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOModel.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOModel.scala
@@ -266,6 +266,7 @@ object H2OMOJOModel extends H2OMOJOReadable[H2OMOJOModel] with H2OMOJOLoader[H2O
     model.set(model.modelCategory -> modelCategory.toString)
     model.set(model.detailedPredictionCol -> settings.detailedPredictionCol)
     model.set(model.withDetailedPredictionCol -> settings.withDetailedPredictionCol)
+    model.set(model.withContributions -> settings.withContributions)
     model
   }
 

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionBinomial.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionBinomial.scala
@@ -56,7 +56,7 @@ trait H2OMOJOPredictionBinomial extends PredictionWithContributions {
         }
       } else {
         if (getWithContributions()) {
-           udf[DetailedWithContributions, Row, Double] { (r: Row, offset: Double) =>
+          udf[DetailedWithContributions, Row, Double] { (r: Row, offset: Double) =>
             val model = H2OMOJOCache.getMojoBackend(uid, getMojo, this)
             val pred = model.predictBinomial(RowConverter.toH2ORowData(r), offset)
             val probabilities = model.getResponseDomainValues.zip(pred.classProbabilities).toMap

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionBinomial.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOPredictionBinomial.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, Row}
 
-trait H2OMOJOPredictionBinomial {
+trait H2OMOJOPredictionBinomial extends PredictionWithContributions {
   self: H2OMOJOModel =>
 
   private def supportsCalibratedProbabilities(predictWrapper: EasyPredictModelWrapper): Boolean = {
@@ -36,19 +36,40 @@ trait H2OMOJOPredictionBinomial {
   def getBinomialPredictionUDF(): UserDefinedFunction = {
     if (getWithDetailedPredictionCol()) {
       if (supportsCalibratedProbabilities(H2OMOJOCache.getMojoBackend(uid, getMojo, this))) {
-        udf[DetailedWithCalibration, Row, Double] { (r: Row, offset: Double) =>
-          val model = H2OMOJOCache.getMojoBackend(uid, getMojo, this)
-          val pred = model.predictBinomial(RowConverter.toH2ORowData(r), offset)
-          val probabilities = model.getResponseDomainValues.zip(pred.classProbabilities).toMap
-          val calibratedProbabilities = model.getResponseDomainValues.zip(pred.calibratedClassProbabilities).toMap
-          DetailedWithCalibration(pred.label, probabilities, pred.contributions, calibratedProbabilities)
+        if (getWithContributions()) {
+          udf[DetailedWithContributionsAndCalibration, Row, Double] { (r: Row, offset: Double) =>
+            val model = H2OMOJOCache.getMojoBackend(uid, getMojo, this)
+            val pred = model.predictBinomial(RowConverter.toH2ORowData(r), offset)
+            val probabilities = model.getResponseDomainValues.zip(pred.classProbabilities).toMap
+            val calibratedProbabilities = model.getResponseDomainValues.zip(pred.calibratedClassProbabilities).toMap
+            val contributions = convertContributionsToMap(model, pred.contributions)
+            DetailedWithContributionsAndCalibration(pred.label, probabilities, contributions, calibratedProbabilities)
+          }
+        } else {
+          udf[DetailedWithCalibration, Row, Double] { (r: Row, offset: Double) =>
+            val model = H2OMOJOCache.getMojoBackend(uid, getMojo, this)
+            val pred = model.predictBinomial(RowConverter.toH2ORowData(r), offset)
+            val probabilities = model.getResponseDomainValues.zip(pred.classProbabilities).toMap
+            val calibratedProbabilities = model.getResponseDomainValues.zip(pred.calibratedClassProbabilities).toMap
+            DetailedWithCalibration(pred.label, probabilities, calibratedProbabilities)
+          }
         }
       } else {
-        udf[Detailed, Row, Double] { (r: Row, offset: Double) =>
-          val model = H2OMOJOCache.getMojoBackend(uid, getMojo, this)
-          val pred = model.predictBinomial(RowConverter.toH2ORowData(r), offset)
-          val probabilities = model.getResponseDomainValues.zip(pred.classProbabilities).toMap
-          Detailed(pred.label, probabilities, pred.contributions)
+        if (getWithContributions()) {
+           udf[DetailedWithContributions, Row, Double] { (r: Row, offset: Double) =>
+            val model = H2OMOJOCache.getMojoBackend(uid, getMojo, this)
+            val pred = model.predictBinomial(RowConverter.toH2ORowData(r), offset)
+            val probabilities = model.getResponseDomainValues.zip(pred.classProbabilities).toMap
+            val contributions = convertContributionsToMap(model, pred.contributions)
+            DetailedWithContributions(pred.label, probabilities, contributions)
+          }
+        } else {
+          udf[Detailed, Row, Double] { (r: Row, offset: Double) =>
+            val model = H2OMOJOCache.getMojoBackend(uid, getMojo, this)
+            val pred = model.predictBinomial(RowConverter.toH2ORowData(r), offset)
+            val probabilities = model.getResponseDomainValues.zip(pred.classProbabilities).toMap
+            Detailed(pred.label, probabilities)
+          }
         }
       }
     } else {
@@ -70,22 +91,31 @@ trait H2OMOJOPredictionBinomial {
 
   def getBinomialDetailedPredictionColSchema(): Seq[StructField] = {
     val labelField = StructField("label", predictionColType, nullable = predictionColNullable)
+    val baseFields = labelField :: Nil
 
     val fields = if (getWithDetailedPredictionCol()) {
       val probabilitiesField =
         StructField("probabilities", MapType(StringType, DoubleType, valueContainsNull = false), nullable = true)
-      val contributionsField = StructField("contributions", ArrayType(FloatType, containsNull = false), nullable = true)
+      val detailedPredictionFields = baseFields :+ probabilitiesField
+
+      val contributionsFields = if (getWithContributions()) {
+        val contributionsField = StructField("contributions", getContributionsSchema(), nullable = true)
+        detailedPredictionFields :+ contributionsField
+      } else {
+        detailedPredictionFields
+      }
+
       if (supportsCalibratedProbabilities(H2OMOJOCache.getMojoBackend(uid, getMojo, this))) {
         val calibratedProbabilitiesField = StructField(
           "calibratedProbabilities",
           MapType(StringType, DoubleType, valueContainsNull = false),
           nullable = false)
-        labelField :: probabilitiesField :: contributionsField :: calibratedProbabilitiesField :: Nil
+        contributionsFields :+ calibratedProbabilitiesField
       } else {
-        labelField :: probabilitiesField :: contributionsField :: Nil
+        contributionsFields
       }
     } else {
-      labelField :: Nil
+      baseFields
     }
 
     Seq(StructField(getDetailedPredictionCol(), StructType(fields), nullable = true))
@@ -100,12 +130,22 @@ object H2OMOJOPredictionBinomial {
 
   case class Base(label: String)
 
-  case class Detailed(label: String, probabilities: Map[String, Double], contributions: Array[Float])
+  case class Detailed(label: String, probabilities: Map[String, Double])
+
+  case class DetailedWithContributions(
+      label: String,
+      probabilities: Map[String, Double],
+      contributions: Map[String, Float])
 
   case class DetailedWithCalibration(
       label: String,
       probabilities: Map[String, Double],
-      contributions: Array[Float],
+      calibratedProbabilities: Map[String, Double])
+
+  case class DetailedWithContributionsAndCalibration(
+      label: String,
+      probabilities: Map[String, Double],
+      contributions: Map[String, Float],
       calibratedProbabilities: Map[String, Double])
 
 }

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOSettings.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOSettings.scala
@@ -25,7 +25,8 @@ case class H2OMOJOSettings(
     withDetailedPredictionCol: Boolean = false,
     convertUnknownCategoricalLevelsToNa: Boolean = false,
     convertInvalidNumbersToNa: Boolean = false,
-    namedMojoOutputColumns: Boolean = true)
+    namedMojoOutputColumns: Boolean = true,
+    withContributions: Boolean = false)
 
 object H2OMOJOSettings {
   def default = H2OMOJOSettings()
@@ -35,6 +36,7 @@ object H2OMOJOSettings {
       predictionCol = params.getPredictionCol(),
       detailedPredictionCol = params.getDetailedPredictionCol(),
       withDetailedPredictionCol = params.getWithDetailedPredictionCol(),
+      withContributions = params.getWithContributions(),
       convertUnknownCategoricalLevelsToNa = params.getConvertUnknownCategoricalLevelsToNa(),
       convertInvalidNumbersToNa = params.getConvertInvalidNumbersToNa())
   }

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/PredictionWithContributions.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/PredictionWithContributions.scala
@@ -26,7 +26,7 @@ trait PredictionWithContributions {
   protected def convertContributionsToMap(
       wrapper: EasyPredictModelWrapper,
       contributions: Array[Float]): Map[String, Float] = {
-    if(contributions == null) {
+    if (contributions == null) {
       null
     } else {
       val contributionNames = wrapper.getContributionNames()

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.scala
@@ -29,14 +29,21 @@ trait H2OBaseMOJOParams extends Params with Logging {
   // Param definitions
   //
   protected final val predictionCol: Param[String] = new Param[String](this, "predictionCol", "Prediction column name")
+
   protected final val detailedPredictionCol = new Param[String](
     this,
     "detailedPredictionCol",
     "Column containing additional prediction details, its content depends on the model type.")
+
   protected final val withDetailedPredictionCol = new BooleanParam(
     this,
     "withDetailedPredictionCol",
     "Enables or disables generating additional prediction column, but with more details")
+
+  protected final val withContributions = new BooleanParam(
+    this,
+    "withContributionsCol",
+    "Enables or disables generating a sub-column of detailedPredictionCol containing Shapley values.")
 
   protected final val featuresCols: StringArrayParam =
     new StringArrayParam(this, "featuresCols", "Name of feature columns")
@@ -65,6 +72,7 @@ trait H2OBaseMOJOParams extends Params with Logging {
     predictionCol -> H2OMOJOSettings.default.predictionCol,
     detailedPredictionCol -> H2OMOJOSettings.default.detailedPredictionCol,
     withDetailedPredictionCol -> H2OMOJOSettings.default.withDetailedPredictionCol,
+    withContributions -> H2OMOJOSettings.default.withContributions,
     featuresCols -> Array.empty[String],
     convertUnknownCategoricalLevelsToNa -> H2OMOJOSettings.default.convertUnknownCategoricalLevelsToNa,
     convertInvalidNumbersToNa -> H2OMOJOSettings.default.convertInvalidNumbersToNa,
@@ -78,6 +86,8 @@ trait H2OBaseMOJOParams extends Params with Logging {
   def getDetailedPredictionCol(): String = $(detailedPredictionCol)
 
   def getWithDetailedPredictionCol(): Boolean = $(withDetailedPredictionCol)
+
+  def getWithContributions(): Boolean = $(withContributions)
 
   def getFeaturesCols(): Array[String] = $(featuresCols)
 

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.scala
@@ -42,7 +42,7 @@ trait H2OBaseMOJOParams extends Params with Logging {
 
   protected final val withContributions = new BooleanParam(
     this,
-    "withContributionsCol",
+    "withContributions",
     "Enables or disables generating a sub-column of detailedPredictionCol containing Shapley values.")
 
   protected final val featuresCols: StringArrayParam =


### PR DESCRIPTION
I've tried to expose contributions as `StructType`. To achieve that, we would have to change the whole concept  using udfs during scoring and to use case classes in prediction traits. IMHO, it's not good approach to do such a change in fix release. I think there is opportunity to do it for one of the major release and also reconsider existence of the current map types (probabilities, etc.)