### PR TITLE
[SW-2289] Fix java.lang.IllegalArgumentException: requirement failed: The auto-closable resource can't be null

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
@@ -306,10 +306,10 @@ trait RestCommunication extends Logging with RestEncodingUtils {
   }
 
   private def getServerError(connection: HttpURLConnection): String = {
-    withResource(connection.getErrorStream) { errorStream =>
-      if (errorStream == null) {
-        "No error"
-      } else {
+    if (connection.getErrorStream == null) {
+      "No error"
+    } else {
+      withResource(connection.getErrorStream) { errorStream =>
         IOUtils.toString(errorStream)
       }
     }


### PR DESCRIPTION
Got this intermittent error on master nightly: https://sparkling-jenkins.h2o.ai/job/NIGHTLY_H2O_BRANCH/job/master/47/

```
ai.h2o.sparkling.backend.exceptions.RestApiNotReachableException: External H2O node 172.17.0.2:54321 is not reachable.
Please verify that you are passing ip and port of existing cluster node and the cluster
is running with web enabled.
	at ai.h2o.sparkling.backend.utils.RestCommunication$class.throwRestApiNotReachableException(RestCommunication.scala:319)
	at ai.h2o.sparkling.backend.utils.RestCommunication$class.readURLContent(RestCommunication.scala:277)
	at ai.h2o.sparkling.backend.utils.RestApiUtils$.readURLContent(RestApiUtils.scala:115)
	at ai.h2o.sparkling.backend.utils.RestCommunication$class.request(RestCommunication.scala:167)
	at ai.h2o.sparkling.backend.utils.RestApiUtils$.request(RestApiUtils.scala:115)
	at ai.h2o.sparkling.backend.utils.RestCommunication$class.query(RestCommunication.scala:54)
	at ai.h2o.sparkling.backend.utils.RestApiUtils$.query(RestApiUtils.scala:115)
	at ai.h2o.sparkling.backend.utils.RestApiUtils$class.getCloudInfoFromNode(RestApiUtils.scala:86)
	at ai.h2o.sparkling.backend.utils.RestApiUtils$.getCloudInfoFromNode(RestApiUtils.scala:115)
	at ai.h2o.sparkling.backend.utils.RestApiUtils$class.getClusterInfo(RestApiUtils.scala:51)
	at ai.h2o.sparkling.backend.utils.RestApiUtils$.getClusterInfo(RestApiUtils.scala:115)
	at ai.h2o.sparkling.H2OContext.updateUIAfterStart(H2OContext.scala:118)
	at ai.h2o.sparkling.H2OContext.<init>(H2OContext.scala:111)
	at ai.h2o.sparkling.H2OContext$.getOrCreate(H2OContext.scala:433)
	at ai.h2o.sparkling.SharedH2OTestContext$class.beforeAll(SharedH2OTestContext.scala:32)
	at ai.h2o.sparkling.backend.api.scalainterpreter.ScalaInterpreterServletTestSuite.beforeAll(ScalaInterpreterServletTestSuite.scala:28)
	at org.scalatest.BeforeAndAfterAll$class.beforeAll(BeforeAndAfterAll.scala:187)
	at ai.h2o.sparkling.backend.api.scalainterpreter.ScalaInterpreterServletTestSuite.beforeAll(ScalaInterpreterServletTestSuite.scala:28)
	at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:253)
	at ai.h2o.sparkling.backend.api.scalainterpreter.ScalaInterpreterServletTestSuite.run(ScalaInterpreterServletTestSuite.scala:28)
	at org.scalatest.junit.JUnitRunner.run(JUnitRunner.scala:99)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:413)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalArgumentException: requirement failed: The auto-closable resource can't be null!
	at scala.Predef$.require(Predef.scala:224)
	at ai.h2o.sparkling.utils.ScalaUtils$.withResource(ScalaUtils.scala:25)
	at ai.h2o.sparkling.backend.utils.RestCommunication$class.getServerError(RestCommunication.scala:309)
	at ai.h2o.sparkling.backend.utils.RestCommunication$class.checkResponseCode(RestCommunication.scala:304)
	at ai.h2o.sparkling.backend.utils.RestApiUtils$.checkResponseCode(RestApiUtils.scala:115)
	at ai.h2o.sparkling.backend.utils.RestCommunication$class.readURLContent(RestCommunication.scala:281)
	... 49 more
```

We need to check for null before we pass the stream to the `withResource` method