### PR TITLE
[SW-2062] Verify that training frame has all columns constants using Spark instead of H2O error

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
@@ -55,8 +55,8 @@ trait H2OAlgoCommonUtils extends EstimatorCommonUtils {
     val featureColumns = getFeaturesCols().map(sanitize).map(col)
 
     if (dataset.select(featureColumns: _*).distinct().count() == 1) {
-      throw new IllegalArgumentException(s"H2O could not use any of the specified feature" +
-        s" columns: '${getFeaturesCols().mkString(", ")}' because they are all constants. H2O ignores constant columns.")
+      throw new IllegalArgumentException(s"H2O could not use any of the specified features" +
+        s" columns: '${getFeaturesCols().mkString(", ")}' because they are all constants. H2O requires at least one non-constant column.")
     }
     val excludedColumns = excludedCols.map(sanitize).map(col)
     val columns = featureColumns ++ excludedColumns

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
@@ -56,7 +56,7 @@ trait H2OAlgoCommonUtils extends EstimatorCommonUtils {
 
     if (dataset.select(featureColumns: _*).distinct().count() == 1) {
       throw new IllegalArgumentException(s"H2O could not use any of the specified feature" +
-        s" columns: '${getFeaturesCols().mkString(", ")}'. H2O ignores constant columns, are all the columns constants?")
+        s" columns: '${getFeaturesCols().mkString(", ")}' because they are all constants. H2O ignores constant columns.")
     }
     val excludedColumns = excludedCols.map(sanitize).map(col)
     val columns = featureColumns ++ excludedColumns

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgoCommonUtils.scala
@@ -16,6 +16,7 @@
  */
 package ai.h2o.sparkling.ml.algos
 
+import ai.h2o.sparkling.backend.exceptions.RestApiCommunicationException
 import ai.h2o.sparkling.{H2OContext, H2OFrame}
 import ai.h2o.sparkling.ml.params.H2OCommonParams
 import ai.h2o.sparkling.ml.utils.{EstimatorCommonUtils, SchemaUtils}
@@ -52,6 +53,11 @@ trait H2OAlgoCommonUtils extends EstimatorCommonUtils {
     }
 
     val featureColumns = getFeaturesCols().map(sanitize).map(col)
+
+    if (dataset.select(featureColumns: _*).distinct().count() == 1) {
+      throw new IllegalArgumentException(s"H2O could not use any of the specified feature" +
+        s" columns: '${getFeaturesCols().mkString(", ")}'. H2O ignores constant columns, are all the columns constants?")
+    }
     val excludedColumns = excludedCols.map(sanitize).map(col)
     val columns = featureColumns ++ excludedColumns
     val h2oContext = H2OContext.ensure(

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgorithm.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgorithm.scala
@@ -75,13 +75,7 @@ abstract class H2OAlgorithm[P <: Model.Parameters: ClassTag]
           Map("validation_frame" -> fr.frameId)
         }
         .getOrElse(Map())
-    val modelId = try {
-      trainAndGetDestinationKey(s"/3/ModelBuilders/${parameters.algoName().toLowerCase}", params)
-    } catch {
-      case e: RestApiCommunicationException if e.getMessage.contains("There are no usable columns to generate model") =>
-        throw new IllegalArgumentException(s"H2O could not use any of the specified feature" +
-          s" columns: '${getFeaturesCols().mkString(", ")}'. H2O ignores constant columns, are all the columns constants?")
-    }
+    val modelId = trainAndGetDestinationKey(s"/3/ModelBuilders/${parameters.algoName().toLowerCase}", params)
     H2OModel(modelId).toMOJOModel(
       Identifiable.randomUID(parameters.algoName()),
       H2OMOJOSettings.createFromModelParams(this),

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/H2OKMeansTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/H2OKMeansTestSuite.scala
@@ -78,21 +78,4 @@ class H2OKMeansTestSuite extends FunSuite with Matchers with SharedH2OTestContex
       thrown.getMessage == "The following feature columns are not available on" +
         " the training dataset: 'not_exist_1, not_exist_2'")
   }
-
-  test("H2OKMeans with constant column") {
-    import org.apache.spark.sql.functions.lit
-    val datasetWithConst = dataset.withColumn("constant", lit(1))
-    val algo = new H2OKMeans()
-      .setSplitRatio(0.8)
-      .setSeed(1)
-      .setK(3)
-      .setFeaturesCols("constant")
-
-    val thrown = intercept[IllegalArgumentException] {
-      algo.fit(datasetWithConst)
-    }
-    assert(
-      thrown.getMessage.startsWith("H2O could not use any of the specified feature" +
-        " columns: 'constant'. H2O ignores constant columns, are all the columns constants?"))
-  }
 }


### PR DESCRIPTION
@mn-mikke promised this change a while ago. As you suggested, we can check the validity even before we start the training