### PR TITLE
[SW-2297] Exclude Content of site/.doctrees from SW Distribution Archive

### DIFF
--- a/doc/build.gradle
+++ b/doc/build.gradle
@@ -47,6 +47,10 @@ task substitute() {
   }
 }
 
+task deleteDocTrees(type: Delete) {
+  delete "${buildDir}/site/.doctrees"
+}
+
 sphinx {
   environments = ["PYTHONWARNINGS" : ""]
   if (VersionNumber.parse(sparkVersion) >= VersionNumber.parse(kubernetesSupportSinceSpark)) {
@@ -95,7 +99,8 @@ createVersionFile.dependsOn cleanDoc
 sphinx.dependsOn createVersionFile
 clean.dependsOn cleanDoc
 substitute.dependsOn sphinx
-sourcesDocJar.dependsOn substitute
+deleteDocTrees.dependsOn substitute
+sourcesDocJar.dependsOn deleteDocTrees
 docJar.dependsOn sourcesDocJar
 site.dependsOn docJar
 

--- a/doc/build.gradle
+++ b/doc/build.gradle
@@ -100,8 +100,7 @@ sphinx.dependsOn createVersionFile
 clean.dependsOn cleanDoc
 substitute.dependsOn sphinx
 deleteDocTrees.dependsOn substitute
-sourcesDocJar.dependsOn deleteDocTrees
-docJar.dependsOn sourcesDocJar
+docJar.dependsOn sourcesDocJar, deleteDocTrees
 site.dependsOn docJar
 
 defineStandardPublication().call()


### PR DESCRIPTION
The options `useDoctreeCache` and `doctreeCacheDirectory ` of  [`sphinx-gradle-plugin`](https://trustin.github.io/sphinx-gradle-plugin/configuration.html) seem to not have any effect.