### PR TITLE
[SW-2304] Avoid putting scala-lib to shadowJar

### DIFF
--- a/api-generation/build.gradle
+++ b/api-generation/build.gradle
@@ -4,7 +4,7 @@ apply from: "$rootDir/gradle/utils.gradle"
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
-  implementation("org.scala-lang:scala-library:${scalaVersion}")
+  compileOnly("org.scala-lang:scala-library:${scalaVersion}")
   implementation("ai.h2o:h2o-algos:${h2oVersion}")
   implementation("ai.h2o:h2o-automl:${h2oVersion}")
   implementation("ai.h2o:h2o-ext-xgboost:${h2oVersion}")

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -47,10 +47,13 @@ python {
 
 configurations {
   sparklingWaterAssemblyJar
+  apiGeneration
 }
 
 dependencies {
   sparklingWaterAssemblyJar project(path: ':sparkling-water-assembly', configuration: 'shadow')
+  apiGeneration "org.scala-lang:scala-library:${scalaVersion}"
+  apiGeneration project(path: ':sparkling-water-api-generation', configuration: 'shadow')
 }
 
 //
@@ -355,7 +358,7 @@ task cleanGeneratedApi(type: Delete) {
 
 task generateApi(type: JavaExec, dependsOn: [cleanGeneratedApi, ':sparkling-water-api-generation:build']) {
   group = "Execution"
-  classpath = files("../api-generation/build/libs/sparkling-water-api-generation_${scalaBaseVersion}-${version}-all.jar")
+  classpath = files(* (configurations.apiGeneration.files as List))
   main = "ai.h2o.sparkling.api.generation.Runner"
   args = ["py", "$projectDir/src-gen"]
   standardOutput = System.out


### PR DESCRIPTION
Diff before master and rel before fix:
```
516,522c516
< |    +--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
< |    \--- project :sparkling-water-api-generation
< |         +--- org.scala-lang:scala-library:2.11.12
< |         +--- ai.h2o:h2o-algos:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-automl:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-ext-xgboost:3.30.0.4 (*)
< |         \--- project :sparkling-water-utils (*)
---
> |    \--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
742,747c736
< |    +--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
< |    \--- project :sparkling-water-api-generation
< |         +--- ai.h2o:h2o-algos:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-automl:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-ext-xgboost:3.30.0.4 (*)
< |         \--- project :sparkling-water-utils (*)
---
> |    \--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
1243,1249c1232
< |    +--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
< |    \--- project :sparkling-water-api-generation
< |         +--- org.scala-lang:scala-library:2.11.12
< |         +--- ai.h2o:h2o-algos:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-automl:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-ext-xgboost:3.30.0.4 (*)
< |         \--- project :sparkling-water-utils (*)
---
```

and after fix:

```
< |    +--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
< |    \--- project :sparkling-water-api-generation
< |         +--- ai.h2o:h2o-algos:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-automl:3.30.0.4 (*)
[SW-2304] Avoid putting scala-lib to shadowJar
< |         +--- ai.h2o:h2o-ext-xgboost:3.30.0.4 (*)
< |         \--- project :sparkling-water-utils (*)
---
> |    \--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
741,746c736
< |    +--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
< |    \--- project :sparkling-water-api-generation
< |         +--- ai.h2o:h2o-algos:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-automl:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-ext-xgboost:3.30.0.4 (*)
< |         \--- project :sparkling-water-utils (*)
---
> |    \--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
1242,1247c1232
< |    +--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
< |    \--- project :sparkling-water-api-generation
< |         +--- ai.h2o:h2o-algos:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-automl:3.30.0.4 (*)
< |         +--- ai.h2o:h2o-ext-xgboost:3.30.0.4 (*)
< |         \--- project :sparkling-water-utils (*)
---
> |    \--- ai.h2o:mojo2-runtime-impl:2.3.0 (*)
```

[SW-2304]: https://0xdata.atlassian.net/browse/SW-2304