### PR TITLE
[SW-2318] Expose rand_link and rand_family on GLM

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/IgnoredParameters.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/IgnoredParameters.scala
@@ -33,8 +33,6 @@ object IgnoredParameters {
     "plug_values", // GLM
     "interaction_pairs", // GLM
     "beta_constraints", // GLM
-    "rand_link", // GLM
-    "rand_family", // GLM
     "random_columns", // GLM
     "initial_biases", // DeepLearning
     "initial_weights", // DeepLearning

--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/ParameterNameConverter.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/ParameterNameConverter.scala
@@ -25,7 +25,9 @@ object ParameterNameConverter {
     "alpha" -> "alphaValue",
     "colsample_bylevel" -> "colSampleByLevel",
     "colsample_bytree" -> "colSampleByTree",
-    "colsample_bynode" -> "colSampleByNode")
+    "colsample_bynode" -> "colSampleByNode",
+    "rand_family" -> "randomFamily",
+    "rand_link" -> "randomLink")
 
   val conversionRules: Map[String, String] = Map("Column" -> "Col")
 


### PR DESCRIPTION
The output parameter are `randLink` and `randFamily`. I'm just wondering whether we shouldn't rename them to `randomLink` and `randomFamily`