### PR TITLE
[SW-2317] Use leader node from the beginning of Rest API communication

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OContextExtensions.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OContextExtensions.scala
@@ -120,13 +120,6 @@ trait H2OContextExtensions extends RestCommunication with RestApiUtils with Shel
       if (!conf.isBackendVersionCheckDisabled) {
         verifyVersion(conf)
       }
-      val leaderIpPort = RestApiUtils.getLeaderNode(conf).ipPort()
-      if (conf.h2oCluster.get != leaderIpPort) {
-        logInfo(
-          s"Updating %s to H2O's leader node %s"
-            .format(ExternalBackendConf.PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, leaderIpPort))
-        conf.setH2OCluster(leaderIpPort)
-      }
       RestApiUtils.getNodes(conf)
     } catch {
       case cause: RestApiException =>

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
@@ -51,16 +51,6 @@ trait RestApiUtils extends RestCommunication {
     getNodes(cloudV3)
   }
 
-  def getLeaderNode(conf: H2OConf): NodeDesc = {
-    val cloudV3 = getClusterInfo(conf)
-    val nodes = getNodes(cloudV3)
-    if (cloudV3.leader_idx < 0 || cloudV3.leader_idx >= nodes.length) {
-      throw new RuntimeException(
-        s"The leader index '${cloudV3.leader_idx}' doesn't correspond to the size of the H2O cluster ${nodes.length}.")
-    }
-    nodes(cloudV3.leader_idx)
-  }
-
   def getClusterEndpoint(conf: H2OConf): URI = {
     val uriBuilder = new URIBuilder(s"${conf.getScheme()}://${conf.h2oCluster.get}")
     uriBuilder.setPath(conf.contextPath.orNull)

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/H2ORpcEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/H2ORpcEndpoint.scala
@@ -59,7 +59,7 @@ class H2ORpcEndpoint(override val rpcEnv: RpcEnv) extends ThreadSafeRpcEndpoint 
       context.reply(nodeDesc)
     case CheckClusterSizeMsg =>
       context.reply(H2O.CLOUD.size())
-    case IsLeaderNodeMsg =>
+    case GetLeaderNodeMsg =>
       val reply = if (H2O.SELF.isLeaderNode) {
         Some(NodeDesc(SparkEnv.get.executorId, H2O.SELF_ADDRESS.getHostAddress, H2O.API_PORT))
       } else {
@@ -79,4 +79,4 @@ case object CheckClusterSizeMsg
 
 case object LockClusterMsg
 
-case object IsLeaderNodeMsg
+case object GetLeaderNodeMsg

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -65,7 +65,7 @@ object InternalH2OBackend extends InternalBackendUtils {
   private def getLeaderNode(endpoints: Array[RpcEndpointRef], conf: H2OConf): NodeDesc = {
     val askTimeout = RpcUtils.askRpcTimeout(conf.sparkConf)
     endpoints.flatMap { ref =>
-      val future = ref.ask[Option[NodeDesc]](IsLeaderNodeMsg)
+      val future = ref.ask[Option[NodeDesc]](GetLeaderNodeMsg)
       askTimeout.awaitResult(future)
     }.head
   }

--- a/core/src/test/scala/ai/h2o/sparkling/H2OContextTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/H2OContextTestSuite.scala
@@ -16,6 +16,7 @@
  */
 package ai.h2o.sparkling
 
+import ai.h2o.sparkling.backend.utils.RestApiUtils
 import org.apache.spark.sql.SparkSession
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -32,5 +33,11 @@ class H2OContextTestSuite extends FunSuite with SharedH2OTestContext {
   test("setH2OLogLevel") {
     hc.setH2OLogLevel("DEBUG")
     assert(hc.getH2OLogLevel() == "DEBUG")
+  }
+
+  test("Sparkling Water communicates with leader node") {
+    val clusterInfo = RestApiUtils.getClusterInfo(hc.getConf)
+    val leaderIdx = clusterInfo.leader_idx
+    assert(hc.getConf.h2oCluster.get == clusterInfo.nodes(leaderIdx).ip_port)
   }
 }


### PR DESCRIPTION
This change ensures that the REST API communicates with the leader node from the beginning.

In Internal backend, we can first report IP & port of some node which might not be a leader and we reassign it later. However, calls for the cloud lock and verification calls such for version and web open are done before this and therefore communicate with the non-leader node.

This is relevant only to the internal backend as in the external cluster, in the auto cluster start we provide automatically leader IP and port and in manual cluster start the users need to provide leader node IP.
