### PR TITLE
[SW-2319] Replace 'External H2O Node' with just 'H2O Node' as the code is now used in both backends

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OContext.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OContext.scala
@@ -324,7 +324,7 @@ class H2OContext private[sparkling] (private val conf: H2OConf) extends H2OConte
             val swHeartBeatInfo = getSparklingWaterHeartbeatEvent()
             if (conf.runsInExternalClusterMode) {
               if (!swHeartBeatInfo.cloudHealthy) {
-                logError("External H2O cluster not healthy!")
+                logError("H2O cluster not healthy!")
                 if (conf.isKillOnUnhealthyClusterEnabled) {
                   logError("Stopping external H2O cluster as it is not healthy.")
                   if (H2OClientUtils.isH2OClientBased(conf)) {
@@ -343,10 +343,10 @@ class H2OContext private[sparkling] (private val conf: H2OConf) extends H2OConte
               }
               if (!Utils.inShutdown()) {
                 throw new H2OClusterNotReachableException(
-                  s"""External H2O cluster ${conf.h2oCluster.get + conf.contextPath
+                  s"""H2O cluster ${conf.h2oCluster.get + conf.contextPath
                        .getOrElse("")} - ${conf.cloudName.get} is not reachable,
                      |H2OContext has been closed! Please create a new H2OContext to a healthy and reachable (web enabled)
-                     |external H2O cluster.""".stripMargin,
+                     |H2O cluster.""".stripMargin,
                   cause)
               }
           }

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OContextExtensions.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OContextExtensions.scala
@@ -135,7 +135,7 @@ trait H2OContextExtensions extends RestCommunication with RestApiUtils with Shel
           stopExternalH2OCluster(conf)
         }
         throw new H2OClusterNotReachableException(
-          s"""External H2O cluster $h2oCluster - ${conf.cloudName.get} is not reachable.
+          s"""H2O cluster $h2oCluster - ${conf.cloudName.get} is not reachable.
              |H2OContext has not been created.""".stripMargin,
           cause)
     }

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
@@ -299,13 +299,13 @@ trait RestCommunication extends Logging with RestEncodingUtils {
       connection.getResponseCode()
     }
     statusCode match {
-      case HttpURLConnection.HTTP_OK => logInfo(s"External H2O node $url successfully responded for the $requestType.")
+      case HttpURLConnection.HTTP_OK => logInfo(s"H2O node $url successfully responded for the $requestType.")
       case HttpURLConnection.HTTP_UNAUTHORIZED =>
         throw new RestApiUnauthorisedException(
-          s"""External H2O node ${urlToString(url)} could not be reached because the client is not authorized.
+          s"""H2O node ${urlToString(url)} could not be reached because the client is not authorized.
            |Please make sure you have passed valid credentials to the client.
            |Status code $statusCode : ${connection.getResponseMessage()}.""".stripMargin)
-      case _ => throw new RestApiCommunicationException(s"""External H2O node ${urlToString(url)} responded with
+      case _ => throw new RestApiCommunicationException(s"""H2O node ${urlToString(url)} responded with
            |Status code: $statusCode : ${connection.getResponseMessage()}
            |Server error: ${getServerError(connection)}""".stripMargin)
     }
@@ -323,7 +323,7 @@ trait RestCommunication extends Logging with RestEncodingUtils {
 
   private def throwRestApiNotReachableException(url: URL, e: Exception) = {
     throw new RestApiNotReachableException(
-      s"""External H2O node ${urlToString(url)} is not reachable.
+      s"""H2O node ${urlToString(url)} is not reachable.
          |Please verify that you are passing ip and port of existing cluster node and the cluster
          |is running with web enabled.""".stripMargin,
       e)


### PR DESCRIPTION
We use the code for both backends so avoid wording which is specific just for external backend and might confuse some users