### PR TITLE
[SW-2344] Fix mojo test -> H2O added a new parameter and therefore number of parameters does not match now

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_mojo.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo.py
@@ -42,7 +42,7 @@ def testTrainingParams(gbmModel):
     assert params["seed"] == "42"
     assert params["distribution"] == "bernoulli"
     assert params["ntrees"] == "2"
-    assert len(params) == 45
+    assert len(params) == 46
 
 def testModelCategory(gbmModel):
     category = gbmModel.getModelCategory()


### PR DESCRIPTION
H2O exposed a new parameter h2o-core/src/main/java/hex/Model.java which leads to failure of this test