### PR TITLE
[SW-2294] Base non-nightly external-backend k8s image on h2o image

### DIFF
--- a/bin/build-kubernetes-images.sh
+++ b/bin/build-kubernetes-images.sh
@@ -30,9 +30,6 @@ if [ "$1" = "external-backend" ]; then
   # case, the name of H2O is always bleeding_edge
   if [ "${H2O_NAME}" = "bleeding_edge" ]; then
       cp "$H2O_HOME/build/h2o.jar" "$WORKDIR/h2o.jar"
-  else
-    path=$($TOPDIR/bin/get-h2o-driver.sh standalone)
-    cp "$path" "$WORKDIR/h2o.jar"
   fi
   docker build -t "sparkling-water-external-backend:$VERSION" -f "$WORKDIR/Dockerfile-External-backend" "$WORKDIR"
   echo "Done!"

--- a/kubernetes/build.gradle
+++ b/kubernetes/build.gradle
@@ -22,12 +22,14 @@ ext {
 }
 
 task createExternalBackendDockerfile(type: Dockerfile) {
-  // Based on h2o-3/docker/public/Dockerfile-h2o-release
-  // After official H2O image is out, remove duplication as mentioned in https://0xdata.atlassian.net/browse/SW-2294
   destFile = outputFileExternalBackend
-  from "openjdk:11"
-  runCommand "mkdir -p /opt/h2oai/h2o-3/"
-  copyFile("h2o.jar", "/opt/h2oai/h2o-3/")
+  if (h2oMajorName == "bleeding_edge") {
+    from "openjdk:11"
+    runCommand "mkdir -p /opt/h2oai/h2o-3/"
+    copyFile("h2o.jar", "/opt/h2oai/h2o-3/")
+  } else {
+    from "h2oai/h2o-open-source-k8s:${h2oMajorVersion}.${h2oBuild}"
+  }
   copyFile("sparkling-water-assembly-extensions_${scalaBaseVersion}-${version}-all.jar", "/opt/h2oai/h2o-3/")
   defaultCommand(
     "java",


### PR DESCRIPTION
Last from K8S related PRs.

For official releases we depend on H2O images, but since we build our own h2o in nightly tests, we also need to create such docker image from scratch