### PR TITLE
[SW-1407][FOLLOWUP] Add missing mappings for family and distribution

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/ProblemType.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/ProblemType.scala
@@ -37,6 +37,7 @@ object ProblemType extends Enumeration {
       case Family.poisson => Regression
       case Family.gamma => Regression
       case Family.tweedie => Regression
+      case Family.negativebinomial => Regression
     }
   }
 
@@ -54,6 +55,8 @@ object ProblemType extends Enumeration {
       case DistributionFamily.quantile => Regression
       case DistributionFamily.huber => Regression
       case DistributionFamily.tweedie => Regression
+      case DistributionFamily.ordinal => Classification
+      case DistributionFamily.modified_huber => Classification
       case DistributionFamily.custom => Both
     }
   }


### PR DESCRIPTION
family
 - negativebinomial - https://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/glm.html#negative-binomial-models

distribution
- ordinal - assume it will the same as for family
- modified_huber- from h2o-code: https://github.com/h2oai/h2o-3/blob/ba26fe89fb81c50fd60d386017a33fc02a31f79e/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java#L196