### PR TITLE
[SW-2356] Fix timeout on long running Rest API commands through Proxy

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -171,7 +171,7 @@ trait SharedBackendConf {
 
   def icedDir: Option[String] = sparkConf.getOption(PROP_ICED_DIR._1)
 
-  def sessionTimeout: Int = sparkConf.getInt(PROP_SESSION_TIMEOUT._1, PROP_SESSION_TIMEOUT._2)
+  def restApiTimeout: Int = sparkConf.getInt(PROP_REST_API_TIMEOUT._1, PROP_REST_API_TIMEOUT._2)
 
   private[sparkling] def getClientLanguage: String = sparkConf.get(PROP_CLIENT_LANGUAGE._1, PROP_CLIENT_LANGUAGE._2)
 
@@ -356,7 +356,7 @@ trait SharedBackendConf {
 
   def setIcedDir(dir: String): H2OConf = set(PROP_ICED_DIR._1, dir)
 
-  def setSessionTimeout(timeout: Int): H2OConf = set(PROP_SESSION_TIMEOUT._1, timeout.toString)
+  def setRestApiTimeout(timeout: Int): H2OConf = set(PROP_REST_API_TIMEOUT._1, timeout.toString)
 
   private[backend] def getFileProperties: Seq[(String, _)] =
     Seq(PROP_JKS, PROP_LOGIN_CONF, PROP_SSL_CONF)
@@ -534,7 +534,7 @@ object SharedBackendConf {
   val PROP_ICED_DIR: (String, None.type) = ("spark.ext.h2o.iced.dir", None)
 
   /** Timeout for Rest API requests */
-  val PROP_SESSION_TIMEOUT: (String, Int) = ("spark.ext.h2o.session.timeout", 5 * 60 * 1000)
+  val PROP_REST_API_TIMEOUT: (String, Int) = ("spark.ext.h2o.rest.api.timeout", 5 * 60 * 1000)
 
   /** Language of the connected client. */
   private[sparkling] val PROP_CLIENT_LANGUAGE: (String, String) = ("spark.ext.h2o.client.language", "scala")

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -171,6 +171,8 @@ trait SharedBackendConf {
 
   def icedDir: Option[String] = sparkConf.getOption(PROP_ICED_DIR._1)
 
+  def sessionTimeout: Int = sparkConf.getInt(PROP_SESSION_TIMEOUT._1, PROP_SESSION_TIMEOUT._2)
+
   private[sparkling] def getClientLanguage: String = sparkConf.get(PROP_CLIENT_LANGUAGE._1, PROP_CLIENT_LANGUAGE._2)
 
   /** Setters */
@@ -354,6 +356,8 @@ trait SharedBackendConf {
 
   def setIcedDir(dir: String): H2OConf = set(PROP_ICED_DIR._1, dir)
 
+  def setSessionTimeout(timeout: Int): H2OConf = set(PROP_SESSION_TIMEOUT._1, timeout.toString)
+
   private[backend] def getFileProperties: Seq[(String, _)] =
     Seq(PROP_JKS, PROP_LOGIN_CONF, PROP_SSL_CONF)
 }
@@ -528,6 +532,9 @@ object SharedBackendConf {
 
   /** Location of iced directory for H2O nodes */
   val PROP_ICED_DIR: (String, None.type) = ("spark.ext.h2o.iced.dir", None)
+
+  /** Timeout for Rest API requests */
+  val PROP_SESSION_TIMEOUT: (String, Int) = ("spark.ext.h2o.session.timeout", 5 * 60 * 1000)
 
   /** Language of the connected client. */
   private[sparkling] val PROP_CLIENT_LANGUAGE: (String, String) = ("spark.ext.h2o.client.language", "scala")

--- a/core/src/main/scala/water/webserver/jetty9/SparklingWaterJettyHelper.scala
+++ b/core/src/main/scala/water/webserver/jetty9/SparklingWaterJettyHelper.scala
@@ -60,6 +60,8 @@ class SparklingWaterJettyHelper(hc: H2OContext, conf: H2OConf, h2oHttpView: H2OH
     handler.addServletMapping(m)
     val ipPort = conf.h2oCluster.get
     holder.setInitParameter("proxyTo", s"${conf.getScheme()}://$ipPort${conf.contextPath.getOrElse("")}")
+    holder.setInitParameter("idleTimeout", s"${conf.sessionTimeout}")
+    holder.setInitParameter("timeout", s"${conf.sessionTimeout}")
     handler
   }
 

--- a/core/src/main/scala/water/webserver/jetty9/SparklingWaterJettyHelper.scala
+++ b/core/src/main/scala/water/webserver/jetty9/SparklingWaterJettyHelper.scala
@@ -60,8 +60,8 @@ class SparklingWaterJettyHelper(hc: H2OContext, conf: H2OConf, h2oHttpView: H2OH
     handler.addServletMapping(m)
     val ipPort = conf.h2oCluster.get
     holder.setInitParameter("proxyTo", s"${conf.getScheme()}://$ipPort${conf.contextPath.getOrElse("")}")
-    holder.setInitParameter("idleTimeout", s"${conf.sessionTimeout}")
-    holder.setInitParameter("timeout", s"${conf.sessionTimeout}")
+    holder.setInitParameter("idleTimeout", s"${conf.restApiTimeout}")
+    holder.setInitParameter("timeout", s"${conf.restApiTimeout}")
     handler
   }
 

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -222,6 +222,9 @@ Configuration properties independent of selected backend
 | ``spark.ext.h2o.verify_ssl_certificates``          | ``True``       | ``setVerifySslCertificates(Boolean)``           | Whether certificates should be         |
 |                                                    |                |                                                 | verified before using in H2O or not.   |
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
+| ``spark.ext.h2o.session.timeout``                  | ``3*60*1000``  | ``setSessionTimeout(Boolean)``                  | Timeout in milliseconds for Rest API   |
+|                                                    |                |                                                 | requests.                              |
++----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
 
 --------------
 

--- a/doc/src/site/sphinx/configuration/configuration_properties.rst
+++ b/doc/src/site/sphinx/configuration/configuration_properties.rst
@@ -222,7 +222,7 @@ Configuration properties independent of selected backend
 | ``spark.ext.h2o.verify_ssl_certificates``          | ``True``       | ``setVerifySslCertificates(Boolean)``           | Whether certificates should be         |
 |                                                    |                |                                                 | verified before using in H2O or not.   |
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
-| ``spark.ext.h2o.session.timeout``                  | ``3*60*1000``  | ``setSessionTimeout(Boolean)``                  | Timeout in milliseconds for Rest API   |
+| ``spark.ext.h2o.rest.api.timeout``                 | ``3*60*1000``  | ``setSessionTimeout(Boolean)``                  | Timeout in milliseconds for Rest API   |
 |                                                    |                |                                                 | requests.                              |
 +----------------------------------------------------+----------------+-------------------------------------------------+----------------------------------------+
 

--- a/py/src/ai/h2o/sparkling/SharedBackendConf.py
+++ b/py/src/ai/h2o/sparkling/SharedBackendConf.py
@@ -213,8 +213,8 @@ class SharedBackendConf(SharedBackendConfUtils):
     def icedDir(self):
         return self._get_option(self._jconf.icedDir())
 
-    def sessionTimeout(self):
-        return self._jconf.sessionTimeout()
+    def restApiTimeout(self):
+        return self._jconf.restApiTimeout()
     #
     # Setters
     #
@@ -507,6 +507,6 @@ class SharedBackendConf(SharedBackendConfUtils):
         self._jconf.setIcedDir(dir)
         return self
 
-    def setSessionTimeout(self, timeout):
-        self._jconf.setSessionTimeout(timeout)
+    def setRestApiTimeout(self, timeout):
+        self._jconf.setRestApiTimeout(timeout)
         return self

--- a/py/src/ai/h2o/sparkling/SharedBackendConf.py
+++ b/py/src/ai/h2o/sparkling/SharedBackendConf.py
@@ -212,6 +212,9 @@ class SharedBackendConf(SharedBackendConfUtils):
 
     def icedDir(self):
         return self._get_option(self._jconf.icedDir())
+
+    def sessionTimeout(self):
+        return self._jconf.sessionTimeout()
     #
     # Setters
     #
@@ -502,4 +505,8 @@ class SharedBackendConf(SharedBackendConfUtils):
 
     def setIcedDir(self, dir):
         self._jconf.setIcedDir(dir)
+        return self
+
+    def setSessionTimeout(self, timeout):
+        self._jconf.setSessionTimeout(timeout)
         return self

--- a/r/src/R/ai/h2o/sparkling/SharedBackendConf.R
+++ b/r/src/R/ai/h2o/sparkling/SharedBackendConf.R
@@ -170,6 +170,8 @@ SharedBackendConf <- setRefClass("SharedBackendConf", methods = list(
 
     icedDir = function() { ConfUtils.getOption(invoke(jconf, "icedDir")) },
 
+    sessionTimeout = function() { invoke(jconf, "sessionTimeout") },
+
 #
 # Setters
 #
@@ -342,5 +344,7 @@ SharedBackendConf <- setRefClass("SharedBackendConf", methods = list(
 
     setHiveToken = function(token) { invoke(jconf, "setHiveToken", token); .self },
 
-    setIcedDir = function(dir) { invoke(jconf, "setIcedDir", dir); .self }
+    setIcedDir = function(dir) { invoke(jconf, "setIcedDir", dir); .self },
+
+    setSessionTimeout = function(timeout) { invoke(jconf, "setSessionTimeout", timeout); .self }
 ))

--- a/r/src/R/ai/h2o/sparkling/SharedBackendConf.R
+++ b/r/src/R/ai/h2o/sparkling/SharedBackendConf.R
@@ -170,7 +170,7 @@ SharedBackendConf <- setRefClass("SharedBackendConf", methods = list(
 
     icedDir = function() { ConfUtils.getOption(invoke(jconf, "icedDir")) },
 
-    sessionTimeout = function() { invoke(jconf, "sessionTimeout") },
+    resetApiTimeout = function() { invoke(jconf, "restApiTimeout") },
 
 #
 # Setters
@@ -346,5 +346,5 @@ SharedBackendConf <- setRefClass("SharedBackendConf", methods = list(
 
     setIcedDir = function(dir) { invoke(jconf, "setIcedDir", dir); .self },
 
-    setSessionTimeout = function(timeout) { invoke(jconf, "setSessionTimeout", timeout); .self }
+    setRestApiTimeout = function(timeout) { invoke(jconf, "setRestApiTimeout", timeout); .self }
 ))


### PR DESCRIPTION
Increase the default value to 5 minutes and make it configurable as well