### PR TITLE
[SW-2360] R tests do not fail in gradle when there is failed test

### DIFF
--- a/r/build.gradle
+++ b/r/build.gradle
@@ -67,7 +67,7 @@ task test(type: Exec, dependsOn: distR) {
   environment['spark.ext.h2o.backend.cluster.mode'] = detectBackendClusterMode()
 
   workingDir "${project.buildDir}/src"
-  def testCmd = "library(sparklyr);library(devtools);devtools::test()"
+  def testCmd = "library(sparklyr);library(devtools);devtools::test(stop_on_failure = TRUE)"
   commandLine getOsSpecificCommandLine(["R", "-e", testCmd])
 }
 


### PR DESCRIPTION
I discovered that after fixing the intermittent issues with R tests, our tests suite does not fail when there is a failing test. Verified locally and should be ok with this change.