### PR TITLE
[SW-2381] Deprecate removed XGBoost options

### DIFF
--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -3,8 +3,8 @@ Migration Guide
 
 Migration guide between Sparkling Water versions.
 
-From 3.30 to 3.32
------------------
+From 3.30.1 to 3.32
+-------------------
 
 - In PySparkling, the ``H2OConf`` no longer accepts any arguments. To create new ``H2OConf``, please just call ``conf = H2OConf()``.
   Also the ``H2OContext.getOrCreate`` method no longer accepts the spark argument. You can start H2OContext as
@@ -159,11 +159,13 @@ From 3.30 to 3.32
 | ``namedMojoOutputColumns``              | ``getNamedMojoOutputColumns``              | ``setNamedMojoOutputColumns``              |
 +-----------------------------------------+--------------------------------------------+--------------------------------------------+
 
+- On H2OXGBoost, the options ``minSumHessianInLeaf`` and ``minDataInLeaf`` have been removed as well as the corresponding
+  getters and setters. The methods are removed without replacement as these parameters weren't valid XGBoost parameters.
+
 From 3.30 to 3.30.1
 -------------------
 
-On H2OXGBoost, the options ``minSumHessianInLeaf`` and ``minDataInLeaf`` have been removed as well as the corresponding
-getters and setters. The methods are removed without replacement as these parameters weren't valid XGBoost parameters.
+No breaking changes.
 
 From 3.28.1 to 3.30
 -------------------

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -159,6 +159,12 @@ From 3.30 to 3.32
 | ``namedMojoOutputColumns``              | ``getNamedMojoOutputColumns``              | ``setNamedMojoOutputColumns``              |
 +-----------------------------------------+--------------------------------------------+--------------------------------------------+
 
+From 3.30 to 3.30.1
+-------------------
+
+On H2OXGBoost, the options ``minSumHessianInLeaf`` and ``minDataInLeaf`` have been removed as well as the corresponding
+getters and setters. The methods are removed without replacement as these parameters weren't valid XGBoost parameters.
+
 From 3.28.1 to 3.30
 -------------------
 

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OXGBoostParams.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OXGBoostParams.scala
@@ -16,6 +16,7 @@
  */
 package ai.h2o.sparkling.ml.params
 
+import ai.h2o.sparkling.macros.DeprecatedMethod
 import ai.h2o.sparkling.ml.params.H2OAlgoParamsHelper.getValidatedEnumValue
 import hex.schemas.XGBoostV3.XGBoostParametersV3
 import hex.tree.xgboost.XGBoostModel.XGBoostParameters
@@ -56,8 +57,6 @@ trait H2OXGBoostParams
   private val nthread = intParam("nthread")
   private val maxBins = intParam("maxBins")
   private val maxLeaves = intParam("maxLeaves")
-  private val minSumHessianInLeaf = floatParam("minSumHessianInLeaf")
-  private val minDataInLeaf = floatParam("minDataInLeaf")
   private val treeMethod = stringParam("treeMethod", "Tree Method")
   private val growPolicy = stringParam("growPolicy", "Grow Policy")
   private val booster = stringParam("booster", "Booster")
@@ -100,8 +99,6 @@ trait H2OXGBoostParams
     nthread -> -1,
     maxBins -> 256,
     maxLeaves -> 0,
-    minSumHessianInLeaf -> 100,
-    minDataInLeaf -> 0,
     treeMethod -> TreeMethod.auto.name(),
     growPolicy -> GrowPolicy.depthwise.name(),
     booster -> Booster.gbtree.name(),
@@ -160,9 +157,11 @@ trait H2OXGBoostParams
 
   def getMaxLeaves(): Int = $(maxLeaves)
 
-  def getMinSumHessianInLeaf(): Float = $(minSumHessianInLeaf)
+  @DeprecatedMethod(version = "3.32")
+  def getMinSumHessianInLeaf(): Float = 100
 
-  def getMinDataInLeaf(): Float = $(minDataInLeaf)
+  @DeprecatedMethod(version = "3.32")
+  def getMinDataInLeaf(): Float = 0
 
   def getTreeMethod(): String = $(treeMethod)
 
@@ -237,9 +236,11 @@ trait H2OXGBoostParams
 
   def setMaxLeaves(value: Int): this.type = set(maxLeaves, value)
 
-  def setMinSumHessianInLeaf(value: Float): this.type = set(minSumHessianInLeaf, value)
+  @DeprecatedMethod(version = "3.32")
+  def setMinSumHessianInLeaf(value: Float): this.type = this
 
-  def setMinDataInLeaf(value: Float): this.type = set(minDataInLeaf, value)
+  @DeprecatedMethod(version = "3.32")
+  def setMinDataInLeaf(value: Float): this.type = this
 
   def setTreeMethod(value: String): this.type = {
     val validated = getValidatedEnumValue[TreeMethod](value)
@@ -316,8 +317,6 @@ trait H2OXGBoostParams
         "nthread" -> getNthread(),
         "max_bins" -> getMaxBins(),
         "max_leaves" -> getMaxLeaves(),
-        "min_sum_hessian_in_leaf" -> getMinSumHessianInLeaf(),
-        "min_data_in_leaf" -> getMinDataInLeaf(),
         "tree_method" -> getTreeMethod(),
         "grow_policy" -> getGrowPolicy(),
         "booster" -> getBooster(),

--- a/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
+++ b/py/src/ai/h2o/sparkling/ml/algos/H2OXGBoost.py
@@ -48,8 +48,6 @@ class H2OXGBoost(H2OXGBoostParams, H2OTreeBasedSupervisedAlgoBase):
                  nthread=-1,
                  maxBins=256,
                  maxLeaves=0,
-                 minSumHessianInLeaf=100.0,
-                 minDataInLeaf=0.0,
                  treeMethod="auto",
                  growPolicy="depthwise",
                  booster="gbtree",

--- a/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
@@ -15,14 +15,13 @@
 # limitations under the License.
 #
 
-from pyspark.ml.param import *
-
 from ai.h2o.sparkling.ml.params.H2OAlgoSupervisedParams import H2OAlgoSupervisedParams
 from ai.h2o.sparkling.ml.params.H2OTreeBasedSupervisedMOJOParams import H2OTreeBasedSupervisedMOJOParams
 from ai.h2o.sparkling.ml.params.H2OTypeConverters import H2OTypeConverters
 from ai.h2o.sparkling.ml.params.HasMonotoneConstraints import HasMonotoneConstraints
 from ai.h2o.sparkling.ml.params.HasStoppingCriteria import HasStoppingCriteria
-from ai.h2o.sparkling.ml.Utils import Utils
+from pyspark.ml.param import *
+import warnings
 
 class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams, HasMonotoneConstraints,
                        HasStoppingCriteria):
@@ -148,18 +147,6 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         "maxLeaves",
         "max leaves",
         H2OTypeConverters.toInt())
-
-    minSumHessianInLeaf = Param(
-        Params._dummy(),
-        "minSumHessianInLeaf",
-        "min sum hessian in leaf",
-        H2OTypeConverters.toFloat())
-
-    minDataInLeaf = Param(
-        Params._dummy(),
-        "minDataInLeaf",
-        "min data in leaf",
-        H2OTypeConverters.toFloat())
 
     treeMethod = Param(
         Params._dummy(),
@@ -309,10 +296,12 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         return self.getOrDefault(self.maxLeaves)
 
     def getMinSumHessianInLeaf(self):
-        return self.getOrDefault(self.minSumHessianInLeaf)
+        warnings.warn("The method 'getMinSumHessianInLeaf' is deprecated without replacement and will be removed in 3.32.")
+        return 100
 
     def getMinDataInLeaf(self):
-        return self.getOrDefault(self.minDataInLeaf)
+        warnings.warn("The method 'getMinDataInLeaf' is deprecated without replacement and will be removed in 3.32.")
+        return 0
 
     def getTreeMethod(self):
         return self.getOrDefault(self.treeMethod)
@@ -423,10 +412,12 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
         return self._set(maxLeaves=value)
 
     def setMinSumHessianInLeaf(self, value):
-        return self._set(minSumHessianInLeaf=value)
+        warnings.warn("The method 'setMinSumHessianInLeaf' is deprecated without replacement and will be removed in 3.32.")
+        return self
 
     def setMinDataInLeaf(self, value):
-        return self._set(minDataInLeaf=value)
+        warnings.warn("The method 'setMinDataInLeaf' is deprecated without replacement and will be removed in 3.32.")
+        return self
 
     def setTreeMethod(self, value):
         return self._set(treeMethod=value)

--- a/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
+++ b/py/src/ai/h2o/sparkling/ml/params/H2OXGBoostParams.py
@@ -297,11 +297,11 @@ class H2OXGBoostParams(H2OAlgoSupervisedParams, H2OTreeBasedSupervisedMOJOParams
 
     def getMinSumHessianInLeaf(self):
         warnings.warn("The method 'getMinSumHessianInLeaf' is deprecated without replacement and will be removed in 3.32.")
-        return 100
+        return 100.0
 
     def getMinDataInLeaf(self):
         warnings.warn("The method 'getMinDataInLeaf' is deprecated without replacement and will be removed in 3.32.")
-        return 0
+        return 0.0
 
     def getTreeMethod(self):
         return self.getOrDefault(self.treeMethod)


### PR DESCRIPTION
H2O has removed ``minSumHessianInLeaf`` and ``minDataInLeaf`` and our build on rel-3.30.1 started to fail as the we still refer to them