### PR TITLE
[SW-2399] Missing mappings for 'negativebinomial' and 'fractionalbinomial' in ProblemType.distributionToProblemType

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/ProblemType.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/ProblemType.scala
@@ -57,6 +57,8 @@ object ProblemType extends Enumeration {
       case DistributionFamily.tweedie => Regression
       case DistributionFamily.ordinal => Classification
       case DistributionFamily.modified_huber => Classification
+      case DistributionFamily.negativebinomial => Regression
+      case DistributionFamily.fractionalbinomial => Regression
       case DistributionFamily.custom => Both
     }
   }


### PR DESCRIPTION
[This commit](https://github.com/h2oai/h2o-3/commit/848e9d5d97df897a405130ed391d99a20b9ff68f) to H2O-3 codebase added these two options.