### PR TITLE
[SW-2406][FOLLOWUP] Remove detailed_predictions from DataFrame comparision

### DIFF
--- a/doc/src/site/sphinx/ml/sw_drf.rst
+++ b/doc/src/site/sphinx/ml/sw_drf.rst
@@ -85,7 +85,7 @@ The following sections describe how to train the DRF model in Sparkling Water in
         .. code:: python
 
             from pysparkling.ml import H2ODRF
-            estimator = H2ODRF(labelCol = "CAPSULE")
+            estimator = H2ODRF(labelCol = "CAPSULE", withDetailedPredictionCol = False)
             model = estimator.fit(trainingDF)
 
         You can also get raw model details by calling the *getModelDetails()* method available on the model as:

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/PipelinePredictionTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/PipelinePredictionTestSuite.scala
@@ -57,6 +57,8 @@ class PipelinePredictionTestSuite extends PipelinePredictionTestBase {
     // Run predictions on the trained model right now in Scala
     val predictions2 = trainedPipelineModel(spark).transform(inputDataStream)
 
-    TestUtils.assertDataFramesAreIdentical(predictions1, predictions2)
+    TestUtils.assertDataFramesAreIdentical(
+      predictions1.drop("detailed_prediction"),
+      predictions2.drop("detailed_prediction"))
   }
 }

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/StreamingPipelinePredictionTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/StreamingPipelinePredictionTestSuite.scala
@@ -79,7 +79,9 @@ class StreamingPipelinePredictionTestSuite extends PipelinePredictionTestBase {
     // Run predictions on the trained model right now in Scala
     val predictions2 = trainedPipelineModel(spark).transform(data).drop("label")
 
-    TestUtils.assertDataFramesAreIdentical(predictions1, predictions2)
+    TestUtils.assertDataFramesAreIdentical(
+      predictions1.drop("detailed_prediction"),
+      predictions2.drop("detailed_prediction"))
   }
 
 }

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/H2OMOJOModelTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/H2OMOJOModelTestSuite.scala
@@ -240,14 +240,18 @@ class H2OMOJOModelTestSuite extends FunSuite with SharedH2OTestContext with Matc
     val reloadedModel = H2OMOJOModel.load(modelFolder)
     val predAfterReload = reloadedModel.transform(df)
 
-    TestUtils.assertDataFramesAreIdentical(predBeforeSave, predAfterReload)
+    TestUtils.assertDataFramesAreIdentical(
+      predBeforeSave.drop("detailed_prediction"),
+      predAfterReload.drop("detailed_prediction"))
   }
 
   private def assertEqual(m1: H2OMOJOModel, m2: H2OMOJOModel, df: DataFrame): Unit = {
     val predMojo = m1.transform(df)
     val predModel = m2.transform(df)
 
-    TestUtils.assertDataFramesAreIdentical(predMojo, predModel)
+    TestUtils.assertDataFramesAreIdentical(
+      predMojo.drop("detailed_prediction"),
+      predModel.drop("detailed_prediction"))
   }
 
   private def tempFolder(prefix: String) = {

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/H2OMOJOModelTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/H2OMOJOModelTestSuite.scala
@@ -249,9 +249,7 @@ class H2OMOJOModelTestSuite extends FunSuite with SharedH2OTestContext with Matc
     val predMojo = m1.transform(df)
     val predModel = m2.transform(df)
 
-    TestUtils.assertDataFramesAreIdentical(
-      predMojo.drop("detailed_prediction"),
-      predModel.drop("detailed_prediction"))
+    TestUtils.assertDataFramesAreIdentical(predMojo.drop("detailed_prediction"), predModel.drop("detailed_prediction"))
   }
 
   private def tempFolder(prefix: String) = {

--- a/py/tests/unit/with_runtime_sparkling/test_H2O_GBM_estimator.py
+++ b/py/tests/unit/with_runtime_sparkling/test_H2O_GBM_estimator.py
@@ -34,8 +34,8 @@ def testLoadAndTrainMojo(hc, spark, prostateDataset):
     mojoFile = gbm.download_mojo(path=os.path.abspath("build/"), get_genmodel_jar=False)
     trainedMojo = H2OMOJOModel.createFromMojo("file://" + mojoFile)
 
-    expect = referenceMojo.transform(prostateDataset)
-    result = trainedMojo.transform(prostateDataset)
+    expect = referenceMojo.transform(prostateDataset).drop("detailed_prediction")
+    result = trainedMojo.transform(prostateDataset).drop("detailed_prediction")
 
     unit_test_utils.assert_data_frames_are_identical(expect, result)
 


### PR DESCRIPTION
The `detailed_predictions` column needs to be removed in release branch since `Map` type can't be used except operations.