### PR TITLE
[SW-2423] Remove Irrelevant Parameters from Kmeans API

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/IgnoredParameters.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/IgnoredParameters.scala
@@ -37,10 +37,25 @@ object IgnoredParameters {
 
   def common: Seq[String] = deprecated ++ implementedInParent ++ unimplemented
 
-  def all(algorithm: String): Seq[String] = algorithm match {
-    case "H2OKMeans" => common ++ Seq("response_column", "offset_column")
-    case "H2OGAM" => common ++ Seq("plug_values") // According to MK the parameter doesn't make much sense for GAM
-    case "H2ODeepLearning" => common ++ Seq("pretrained_autoencoder")
-    case _ => common
+  def all(algorithm: String): Seq[String] = common ++ {
+    algorithm match {
+      case "H2OKMeans" =>
+        Seq(
+          "response_column",
+          "offset_column",
+          "distribution",
+          "tweedie_power",
+          "quantile_alpha",
+          "huber_alpha",
+          "gainslift_bins",
+          "stopping_rounds",
+          "stopping_metric",
+          "stopping_tolerance",
+          "custom_metric_func",
+          "custom_distribution_func")
+      case "H2OGAM" => Seq("plug_values") // According to MK the parameter doesn't make much sense for GAM
+      case "H2ODeepLearning" => Seq("pretrained_autoencoder")
+      case _ => Seq.empty
+    }
   }
 }

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgorithm.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAlgorithm.scala
@@ -45,15 +45,11 @@ abstract class H2OAlgorithm[P <: Model.Parameters: ClassTag]
 
   def getWeightCol(): String
 
-  def getDistribution(): String
-
   def getModelId(): String
 
   def setFoldCol(value: String): this.type
 
   def setWeightCol(value: String): this.type
-
-  def setDistribution(value: String): this.type
 
   def setModelId(value: String): this.type
 

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OSupervisedAlgorithm.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OSupervisedAlgorithm.scala
@@ -33,9 +33,13 @@ abstract class H2OSupervisedAlgorithm[P <: Model.Parameters: ClassTag] extends H
 
   def getOffsetCol(): String
 
+  def getDistribution(): String
+
   def setLabelCol(value: String): this.type
 
   def setOffsetCol(value: String): this.type
+
+  def setDistribution(value: String): this.type
 
   @DeveloperApi
   override def transformSchema(schema: StructType): StructType = {


### PR DESCRIPTION
I have also a question about two parameters which are not included in the [MOJO json file](https://gist.github.com/mn-mikke/8177b9503bcffb124131c5b8e15b5b46#file-kmeans-model-json). The parameters are:
- `max_categorical_levels` - This parameter is mentioned in [H2O-3 documentation](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/k-means.html). So shouldn't be included in MOJO as well?
- `weights_column` - Is there any plan to implement this parameter on Kmeans. Or it doesn't make sence for KMeans at all?
