### PR TITLE
[SW-2427] Fix parameter generation in doc

### DIFF
--- a/doc/src/main/scala/ai/h2o/sparkling/doc/generation/ParametersTemplate.scala
+++ b/doc/src/main/scala/ai/h2o/sparkling/doc/generation/ParametersTemplate.scala
@@ -76,7 +76,11 @@ object ParametersTemplate {
     instance.params
       .filterNot(_.name == "withDetailedPredictionCol")
       .map { param =>
-        val defaultValue = instance.getDefault(param).get
+        val defaultValue = if (instance.getDefault(param).isDefined) {
+          instance.getDefault(param).get
+        } else {
+          "No default value"
+        }
 
         s"""${param.name}
            |  ${param.doc.replace("\n ", "\n\n  - ")}


### PR DESCRIPTION
H2OWord2VecTokenizer has no default value for input column and documentation generation fails.

H2OWord2VecTokenizer will be removed as part of the Word2Vec but before that, this commit ensures the CI is green