### PR TITLE
[SW-2442] Remove "max_hit_ratio_k" from the List of Deprecated Parameters

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/IgnoredParameters.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/IgnoredParameters.scala
@@ -19,12 +19,9 @@ package ai.h2o.sparkling.api.generation.common
 
 object IgnoredParameters {
   def deprecated(algorithm: String): Seq[String] = algorithm match {
-    case "H2OGAM" => Seq("r2_stopping", "lambda_min_ratio", "max_hit_ratio_k")
-    case "H2OGBM" => Seq("r2_stopping", "max_hit_ratio_k")
-    case "H2OGLM" => Seq("r2_stopping", "max_hit_ratio_k")
-    case "H2ODRF" => Seq("r2_stopping", "max_hit_ratio_k")
+    case "H2OGAM" => Seq("r2_stopping", "lambda_min_ratio")
     case "H2OGLRM" => Seq("r2_stopping", "loading_name")
-    case "H2ODeepLearning" => Seq("r2_stopping", "max_hit_ratio_k", "col_major", "max_confusion_matrix_size")
+    case "H2ODeepLearning" => Seq("r2_stopping", "col_major", "max_confusion_matrix_size")
     case _ => Seq("r2_stopping")
   }
 

--- a/py/tests/unit/with_runtime_sparkling/test_mojo.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo.py
@@ -52,7 +52,7 @@ def testTrainingParams(gbmModel):
     assert params["seed"] == "42"
     assert params["distribution"] == "bernoulli"
     assert params["ntrees"] == "2"
-    assert len(params) == 44
+    assert len(params) == 43
 
 
 def testModelCategory(gbmModel):


### PR DESCRIPTION
There is no need to ignore the `max_hit_ratio_k` parameter during API generation since it has been removed from H2O-3 codebase by https://github.com/h2oai/h2o-3/pull/4926.