### PR TITLE
[SW-2445] Add logic of FrameUtils.guessParserSetup to Sparkling Water

### DIFF
--- a/extensions/src/main/scala/water/fvec/H2OFrame.scala
+++ b/extensions/src/main/scala/water/fvec/H2OFrame.scala
@@ -24,7 +24,7 @@ import water._
 import water.parser.DefaultParserProviders.GUESS_INFO
 import water.parser.ParseSetup
 import water.parser.ParseSetup._
-import water.util.FrameUtils
+import water.H2O
 
 /**
   * Wrapper around Java H2O Frame
@@ -179,6 +179,8 @@ object H2OFrame {
     * @param uris      URIs of files to parse
     * @return guessed parser setup
     */
-  def parserSetup(userSetup: ParseSetup, uris: URI*): ParseSetup =
-    FrameUtils.guessParserSetup(defaultParserSetup(), uris: _*)
+  def parserSetup(userSetup: ParseSetup, uris: URI*): ParseSetup = {
+    val inKeys = uris.map(H2O.getPM.anyURIToKey(_)).toArray
+    return ParseSetup.guessSetup(inKeys, userSetup)
+  }
 }

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
@@ -84,6 +84,7 @@ class MOJOParameterTestSuite extends FunSuite with SharedH2OTestContext with Mat
     val algorithm = new H2OGAM()
       .setLabelCol("CAPSULE")
       .setSeed(1)
+      .setLambdaValue(Array(0.5))
       .setGamCols(Array("PSA", "AGE"))
       .setNumKnots(Array(5, 5))
       .setBs(Array(5, 5))

--- a/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
@@ -49,7 +49,8 @@ def testGLMParameters(prostateDataset):
 
 def testGAMParameters(prostateDataset):
     features = ['AGE', 'RACE', 'DPROS', 'DCAPS', 'PSA']
-    algorithm = H2OGAM(seed=1, labelCol="CAPSULE", gamCols=["PSA", "AGE"], numKnots=[5, 5], featuresCols=features)
+    algorithm = H2OGAM(seed=1, labelCol="CAPSULE", gamCols=["PSA", "AGE"], numKnots=[5, 5], lambdaValue=[0.5],
+                       featuresCols=features)
     model = algorithm.fit(prostateDataset)
     compareParameterValues(algorithm, model, ["getFeaturesCols"])
 


### PR DESCRIPTION
The method was removed by this commit https://github.com/h2oai/h2o-3/commit/96ac0bfcd5c6fa4150b39089add644c03c8de90d#diff-d63531c6c93a765957616530e4121ef1 in H2O-3.