### PR TITLE
[SW-2433] Deprecate 'distribution' Parameter on H2OGLM

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/AlgorithmConfigurations.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/AlgorithmConfigurations.scala
@@ -71,6 +71,7 @@ trait AlgorithmConfigurations {
     val interactionPairs = ExplicitField("interaction_pairs", "HasInteractionPairs", null)
 
     val deprecatedWeightCol = DeprecatedField("weights_col", "DeprecatedWeightCol", "weightCol", "3.34")
+    val deprecatedDistribution = DeprecatedField("distribution", "DeprecatedDistribution", "distribution", "3.34")
 
     val xgboostFields = Seq(monotonicity, calibrationDataFrame, ignoredCols)
     val glmFields = Seq(randomCols, ignoredCols, plugValues, betaConstraints, interactionPairs)
@@ -83,6 +84,7 @@ trait AlgorithmConfigurations {
     val ifFields = Seq(calibrationDataFrame, validationLabelCol)
 
     val kmeansDeprecations = Seq(deprecatedWeightCol)
+    val glmDeprecations = Seq(deprecatedDistribution)
 
     val dlFields = Seq(
       ExplicitField("initial_biases", "HasInitialBiases", null),
@@ -106,7 +108,7 @@ trait AlgorithmConfigurations {
       ("H2OXGBoostParams", classOf[XGBParamsV3], classOf[XGBoostParameters], xgboostFields, noDeprecation),
       ("H2OGBMParams", classOf[GBMV3.GBMParametersV3], classOf[GBMParameters], gbmFields, noDeprecation),
       ("H2ODRFParams", classOf[DRFV3.DRFParametersV3], classOf[DRFParameters], drfFields, noDeprecation),
-      ("H2OGLMParams", classOf[GLMV3.GLMParametersV3], classOf[GLMParameters], glmFields, noDeprecation),
+      ("H2OGLMParams", classOf[GLMV3.GLMParametersV3], classOf[GLMParameters], glmFields, glmDeprecations),
       ("H2OGAMParams", classOf[GAMV3.GAMParametersV3], classOf[GAMParameters], gamFields, noDeprecation),
       ("H2ODeepLearningParams", classOf[DLParamsV3], classOf[DeepLearningParameters], dlFields, noDeprecation),
       ("H2OKMeansParams", classOf[KMeansParamsV3], classOf[KMeansParameters], kmeansFields, kmeansDeprecations),

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -43,6 +43,8 @@ From 3.32 to 3.34
 - The ``getTrainingParams`` method on ``H2OMOJOModel`` and inherited classes has been removed in Python and Scala API.
   Use a specific getter method for a given training parameter.
 
+- The ``distribution`` parameter on ``H2OGLM`` was removed without a replacement.
+
 From 3.30.1 to 3.32
 -------------------
 

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/DeprecatedDistribution.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/DeprecatedDistribution.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.h2o.sparkling.ml.params
+
+import ai.h2o.sparkling.macros.DeprecatedMethod
+import org.apache.spark.expose.Logging
+
+trait DeprecatedDistribution extends Logging {
+
+  @DeprecatedMethod(version = "3.34")
+  def getDistribution(): String = "AUTO"
+
+  @DeprecatedMethod(version = "3.34")
+  def setDistribution(value: String): this.type = this
+}

--- a/py/src/ai/h2o/sparkling/ml/params/DeprecatedDistribution.py
+++ b/py/src/ai/h2o/sparkling/ml/params/DeprecatedDistribution.py
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import warnings
+
+class DeprecatedDistribution:
+
+    def getDistribution(self):
+        warnings.warn("The method 'getDistribution' is deprecated and will be removed in the version 3.34.")
+        return "AUTO"
+
+    def setDistribution(self, value):
+        warnings.warn("The method 'setDistribution' is deprecated and will be removed in the version 3.34.")
+        return self


### PR DESCRIPTION
The `distribution` parameter was exposed in past, but there is no equivalent for the parameter in H2O-3 API.