### PR TITLE
[SW-2453] Newly Introduced Parameter 'preprocessing' Broke SW API Generation

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/AutoMLIgnoredParameters.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/AutoMLIgnoredParameters.scala
@@ -28,6 +28,7 @@ object AutoMLIgnoredParameters {
       "blending_frame",
       "leaderboard_frame",
       "monotone_constraints",
+      "preprocessing",
       "stopping_criteria",
       "modeling_plan",
       "algo_parameters")


### PR DESCRIPTION
The parameter will be exposed in a different PR, just need to make SW build green again. Related PR: https://github.com/h2oai/h2o-3/pull/4927