### PR TITLE
[SW-2463] Move Ping Messages to Debug Logging Level

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestApiUtils.scala
@@ -29,7 +29,7 @@ trait RestApiUtils extends RestCommunication {
 
   def getPingInfo(conf: H2OConf): PingV3 = {
     val endpoint = getClusterEndpoint(conf)
-    query[PingV3](endpoint, "/3/Ping", conf)
+    query[PingV3](endpoint, "/3/Ping", conf, confirmationLoggingLevel = LoggingLevel.Debug)
   }
 
   def shutdownCluster(conf: H2OConf): Unit = {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
@@ -34,6 +34,13 @@ import scala.reflect.{ClassTag, classTag}
 
 trait RestCommunication extends Logging with RestEncodingUtils {
 
+  object LoggingLevel extends Enumeration {
+    type LoggingLevel = Value
+    val Info, Debug = Value
+  }
+
+  import LoggingLevel._
+
   /**
     *
     * @param endpoint      An address of H2O node with exposed REST endpoint
@@ -50,8 +57,10 @@ trait RestCommunication extends Logging with RestEncodingUtils {
       suffix: String,
       conf: H2OConf,
       params: Map[String, Any] = Map.empty,
-      skippedFields: Seq[(Class[_], String)] = Seq.empty): ResultType = {
-    request(endpoint, "GET", suffix, conf, params, skippedFields)
+      skippedFields: Seq[(Class[_], String)] = Seq.empty,
+      confirmationLoggingLevel: LoggingLevel = Info): ResultType = {
+    val encodeParamsAsJson = false
+    request(endpoint, "GET", suffix, conf, params, skippedFields, encodeParamsAsJson, confirmationLoggingLevel)
   }
 
   /**
@@ -163,7 +172,8 @@ trait RestCommunication extends Logging with RestEncodingUtils {
       conf: H2OConf,
       params: Map[String, Any] = Map.empty,
       skippedFields: Seq[(Class[_], String)] = Seq.empty,
-      encodeParamsAsJson: Boolean = false): ResultType = {
+      encodeParamsAsJson: Boolean = false,
+      confirmationLoggingLevel: LoggingLevel = Info): ResultType = {
     withResource(readURLContent(endpoint, requestType, suffix, conf, params, encodeParamsAsJson, None)) { response =>
       val content = IOUtils.toString(response)
       deserialize[ResultType](content, skippedFields)
@@ -276,7 +286,8 @@ trait RestCommunication extends Logging with RestEncodingUtils {
       conf: H2OConf,
       params: Map[String, Any] = Map.empty,
       encodeParamsAsJson: Boolean = false,
-      file: Option[String]): InputStream = {
+      file: Option[String],
+      confirmationLoggingLevel: LoggingLevel = Info): InputStream = {
     val suffixWithParams =
       if (params.nonEmpty && (requestType == "GET")) s"$suffix?${stringifyParams(params)}" else suffix
     val url = resolveUrl(endpoint, suffixWithParams)
@@ -284,7 +295,7 @@ trait RestCommunication extends Logging with RestEncodingUtils {
       val connection = url.openConnection().asInstanceOf[HttpURLConnection]
       connection.setRequestMethod(requestType)
       setHeaders(connection, conf, requestType, params, encodeParamsAsJson, file)
-      checkResponseCode(connection)
+      checkResponseCode(connection, confirmationLoggingLevel)
       connection.getInputStream()
     } catch {
       case e: RestApiException => throw e
@@ -292,14 +303,19 @@ trait RestCommunication extends Logging with RestEncodingUtils {
     }
   }
 
-  def checkResponseCode(connection: HttpURLConnection): Unit = {
+  def checkResponseCode(connection: HttpURLConnection, confirmationLoggingLevel: LoggingLevel = Info): Unit = {
     val url = connection.getURL
     val requestType = connection.getRequestMethod
     val statusCode = retry(3) {
       connection.getResponseCode()
     }
     statusCode match {
-      case HttpURLConnection.HTTP_OK => logInfo(s"H2O node $url successfully responded for the $requestType.")
+      case HttpURLConnection.HTTP_OK =>
+        val message = s"H2O node $url successfully responded for the $requestType."
+        confirmationLoggingLevel match {
+          case Info => logInfo(message)
+          case Debug => logDebug(message)
+        }
       case HttpURLConnection.HTTP_UNAUTHORIZED =>
         throw new RestApiUnauthorisedException(
           s"""H2O node ${urlToString(url)} could not be reached because the client is not authorized.

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
@@ -174,9 +174,11 @@ trait RestCommunication extends Logging with RestEncodingUtils {
       skippedFields: Seq[(Class[_], String)] = Seq.empty,
       encodeParamsAsJson: Boolean = false,
       confirmationLoggingLevel: LoggingLevel = Info): ResultType = {
-    withResource(readURLContent(endpoint, requestType, suffix, conf, params, encodeParamsAsJson, None)) { response =>
-      val content = IOUtils.toString(response)
-      deserialize[ResultType](content, skippedFields)
+    withResource(
+      readURLContent(endpoint, requestType, suffix, conf, params, encodeParamsAsJson, None, confirmationLoggingLevel)) {
+      response =>
+        val content = IOUtils.toString(response)
+        deserialize[ResultType](content, skippedFields)
     }
   }
 


### PR DESCRIPTION
The goal of this PR is to remove ping messages in spark-shell by default:
```
10-08 07:32:27.385 10.159.129.72:54321   #2488   Thread-62  INFO ai.h2o.sparkling.backend.utils.RestApiUtils: H2O node http://10.159.129.70:54321/3/Ping successfully responded for the GET.
10-08 07:32:37.389 10.159.129.72:54321   #2488   Thread-62  INFO ai.h2o.sparkling.backend.utils.RestApiUtils: H2O node http://10.159.129.70:54321/3/Ping successfully responded for the GET.
10-08 07:32:47.393 10.159.129.72:54321   #2488   Thread-62  INFO ai.h2o.sparkling.backend.utils.RestApiUtils: H2O node http://10.159.129.70:54321/3/Ping successfully responded for the GET.
10-08 07:32:57.397 10.159.129.72:54321   #2488   Thread-62  INFO ai.h2o.sparkling.backend.utils.RestApiUtils: H2O node http://10.159.129.70:54321/3/Ping successfully responded for the GET.
10-08 07:33:07.401 10.159.129.72:54321   #2488   Thread-62  INFO ai.h2o.sparkling.backend.utils.RestApiUtils: H2O node http://10.159.129.70:54321/3/Ping successfully responded for the GET.
10-08 07:33:17.405 10.159.129.72:54321   #2488   Thread-62  INFO ai.h2o.sparkling.backend.utils.RestApiUtils: H2O node http://10.159.129.70:54321/3/Ping successfully responded for the GET.
```

A user could disable the messages by adding `log4j.logger.ai.h2o.sparkling.backend.utils.RestApiUtils=WARN` to `$SPARK_HOME/conf/log4j.properties`, but this will disable all info messages from `RestApiUtils`.