### PR TITLE
[SW-2467] Fix Publishing of SW Booklet

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -178,7 +178,7 @@ task copyFilesForZipDistribution {
     copyRecursive("kubernetes/build/dist", "$zipDir/kubernetes")
     copyRecursive("bin/", "$zipDir/bin")
     if (makeBooklet.toBoolean()) {
-      copySingle("booklet/build", "SparklingWaterBooklet.pdf", "$zipDir/booklet")
+      copySingle("booklet/build/src", "SparklingWaterBooklet.pdf", "$zipDir/booklet")
     }
     copyRecursive("doc/build/site/", "$zipDir/doc/build/site")
   }
@@ -208,7 +208,7 @@ task dist(dependsOn: zipDistribution) {
     copyRecursive("r/build/repo/", "$distDir/R")
     copyRecursive("core/build/docs/scaladoc/", "$distDir/scaladoc")
     if (makeBooklet.toBoolean()) {
-      copySingle("booklet/build", "SparklingWaterBooklet.pdf", "$distDir/booklet")
+      copySingle("booklet/build/src", "SparklingWaterBooklet.pdf", "$distDir/booklet")
     }
     copyRecursive("doc/build/site/", "$distDir/doc")
     copyRecursive("templates/build/", "$distDir/templates")


### PR DESCRIPTION
The PR https://github.com/h2oai/sparkling-water/pull/2277 moved compiled pdf from `booklet/build` to `booklet/build/src` which broke publishing of the pdf.