### PR TITLE
[SW-2230] Remove deprecated setClientIcedDir, setNodeIcedDir, clientIcedDir and nodeIcedDir

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -121,8 +121,6 @@ object H2OConf extends Logging {
   def apply(sparkConf: SparkConf): H2OConf = new H2OConf(sparkConf)
 
   private val deprecatedOptions = Map[String, String](
-    "spark.ext.h2o.node.iced.dir" -> "spark.ext.h2o.iced.dir",
-    "spark.ext.h2o.client.iced.dir" -> "spark.ext.h2o.iced.dir",
     "spark.ext.h2o.node.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.client.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.node.extra" -> "spark.ext.h2o.extra.properties",

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -120,9 +120,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def clientIp: Option[String] = sparkConf.getOption(PROP_CLIENT_IP._1)
 
-  @DeprecatedMethod("icedDir", "3.34")
-  def clientIcedDir: Option[String] = icedDir
-
   @DeprecatedMethod("logDir", "3.34")
   def h2oClientLogDir: Option[String] = logDir
 
@@ -289,9 +286,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def setFlowDir(dir: String): H2OConf = set(PROP_FLOW_DIR._1, dir)
 
   def setClientIp(ip: String): H2OConf = set(PROP_CLIENT_IP._1, ip)
-
-  @DeprecatedMethod("setIcedDir", "3.34")
-  def setClientIcedDir(icedDir: String): H2OConf = setIcedDir(icedDir)
 
   @DeprecatedMethod("setLogDir", "3.34")
   def setH2OClientLogDir(dir: String): H2OConf = setLogDir(dir)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
@@ -47,9 +47,6 @@ trait InternalBackendConf extends SharedBackendConf with InternalBackendConfExte
 
   def subseqTries: Int = sparkConf.getInt(PROP_SUBSEQ_TRIES._1, PROP_SUBSEQ_TRIES._2)
 
-  @DeprecatedMethod("icedDir", "3.34")
-  def nodeIcedDir: Option[String] = sparkConf.getOption(SharedBackendConf.PROP_ICED_DIR._1)
-
   def hdfsConf: Option[String] = sparkConf.getOption(PROP_HDFS_CONF._1)
 
   def spreadRddRetriesTimeout: Int =
@@ -66,9 +63,6 @@ trait InternalBackendConf extends SharedBackendConf with InternalBackendConfExte
     set(PROP_DEFAULT_CLUSTER_SIZE._1, defaultClusterSize.toString)
 
   def setSubseqTries(subseqTriesNum: Int): H2OConf = set(PROP_SUBSEQ_TRIES._1, subseqTriesNum.toString)
-
-  @DeprecatedMethod("setIcedDir", "3.34")
-  def setNodeIcedDir(dir: String): H2OConf = set(SharedBackendConf.PROP_ICED_DIR._1, dir)
 
   def setHdfsConf(path: String): H2OConf = set(PROP_HDFS_CONF._1, path)
 


### PR DESCRIPTION
Already replaced by `icedDir` and `setIcedDir`