### PR TITLE
[SW-2243] Remove deprecated setClientBasePort, setNodeBasePort, clientBasePort, nodeBasePort

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -126,8 +126,6 @@ object H2OConf extends Logging {
     "spark.ext.h2o.client.log.level" -> "spark.ext.h2o.log.level",
     "spark.ext.h2o.node.log.level" -> "spark.ext.h2o.log.level",
     "spark.ext.h2o.client.flow.dir" -> "spark.ext.h2o.flow.dir",
-    "spark.ext.h2o.client.port.base" -> "spark.ext.h2o.base.port",
-    "spark.ext.h2o.node.port.base" -> "spark.ext.h2o.base.port",
     "spark.ext.h2o.node.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.client.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.node.extra" -> "spark.ext.h2o.extra.properties",

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -102,9 +102,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def internalPortOffset: Int = sparkConf.getInt(PROP_INTERNAL_PORT_OFFSET._1, PROP_INTERNAL_PORT_OFFSET._2)
 
-  @DeprecatedMethod("basePort", "3.34")
-  def nodeBasePort: Int = basePort
-
   def basePort: Int = sparkConf.getInt(PROP_BASE_PORT._1, PROP_BASE_PORT._2)
 
   def mojoDestroyTimeout: Int = sparkConf.getInt(PROP_MOJO_DESTROY_TIMEOUT._1, PROP_MOJO_DESTROY_TIMEOUT._2)
@@ -134,9 +131,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   @DeprecatedMethod("logDir", "3.34")
   def h2oClientLogDir: Option[String] = logDir
-
-  @DeprecatedMethod("basePort", "3.34")
-  def clientBasePort: Int = basePort
 
   def clientWebPort: Int = sparkConf.getInt(PROP_CLIENT_WEB_PORT._1, PROP_CLIENT_WEB_PORT._2)
 
@@ -270,9 +264,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def setInternalPortOffset(offset: Int): H2OConf = set(PROP_INTERNAL_PORT_OFFSET._1, offset.toString)
 
-  @DeprecatedMethod("setBasePort", "3.34")
-  def setNodeBasePort(port: Int): H2OConf = setBasePort(port)
-
   def setBasePort(port: Int): H2OConf = set(PROP_BASE_PORT._1, port.toString)
 
   def setMojoDestroyTimeout(timeoutInMilliseconds: Int): H2OConf =
@@ -316,9 +307,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   @DeprecatedMethod("setLogDir", "3.34")
   def setH2OClientLogDir(dir: String): H2OConf = setLogDir(dir)
-
-  @DeprecatedMethod("setBasePort", "3.34")
-  def setClientBasePort(basePort: Int): H2OConf = setBasePort(basePort)
 
   def setClientWebPort(port: Int): H2OConf = set(PROP_CLIENT_WEB_PORT._1, port.toString)
 


### PR DESCRIPTION
Already replaced by `basePort`, `setBasePort` 