### PR TITLE
[SW-2245] Remove deprecated setClientExtraProperties, setNodeExtraProperties, clientExtraProperties, nodeExtraProperties

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -120,9 +120,7 @@ object H2OConf extends Logging {
 
   def apply(sparkConf: SparkConf): H2OConf = new H2OConf(sparkConf)
 
-  private val deprecatedOptions = Map[String, String](
-    "spark.ext.h2o.node.extra" -> "spark.ext.h2o.extra.properties",
-    "spark.ext.h2o.client.extra" -> "spark.ext.h2o.extra.properties")
+  private val deprecatedOptions = Map[String, String]()
 
   private def checkDeprecatedOptions(sparkConf: SparkConf): Unit = {
     deprecatedOptions.foreach {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -100,9 +100,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def mojoDestroyTimeout: Int = sparkConf.getInt(PROP_MOJO_DESTROY_TIMEOUT._1, PROP_MOJO_DESTROY_TIMEOUT._2)
 
-  @DeprecatedMethod("extraProperties", "3.34")
-  def nodeExtraProperties: Option[String] = extraProperties
-
   def extraProperties: Option[String] = sparkConf.getOption(PROP_EXTRA_PROPERTIES._1)
 
   def flowExtraHttpHeaders: Option[String] = sparkConf.getOption(PROP_FLOW_EXTRA_HTTP_HEADERS._1)
@@ -124,9 +121,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def clientNetworkMask: Option[String] = sparkConf.getOption(PROP_CLIENT_NETWORK_MASK._1)
 
   def clientFlowBaseurlOverride: Option[String] = sparkConf.getOption(PROP_CLIENT_FLOW_BASEURL_OVERRIDE._1)
-
-  @DeprecatedMethod("extraProperties", "3.34")
-  def clientExtraProperties: Option[String] = extraProperties
 
   def runsInExternalClusterMode: Boolean = backendClusterMode.toLowerCase() == BACKEND_MODE_EXTERNAL
 
@@ -248,9 +242,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def setMojoDestroyTimeout(timeoutInMilliseconds: Int): H2OConf =
     set(PROP_MOJO_DESTROY_TIMEOUT._1, timeoutInMilliseconds.toString)
 
-  @DeprecatedMethod("setExtraProperties", "3.34")
-  def setNodeExtraProperties(extraProperties: String): H2OConf = setExtraProperties(extraProperties)
-
   def setExtraProperties(extraProperties: String): H2OConf = set(PROP_EXTRA_PROPERTIES._1, extraProperties)
 
   def setFlowExtraHttpHeaders(headers: String): H2OConf = { // R mapping
@@ -289,9 +280,6 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def setClientFlowBaseurlOverride(baseUrl: String): H2OConf = set(PROP_CLIENT_FLOW_BASEURL_OVERRIDE._1, baseUrl)
 
   def setClientCheckRetryTimeout(timeout: Int): H2OConf = set(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, timeout.toString)
-
-  @DeprecatedMethod("setExtraProperties", "3.34")
-  def setClientExtraProperties(extraProperties: String): H2OConf = setExtraProperties(extraProperties)
 
   def setVerifySslCertificates(verify: Boolean): H2OConf = set(PROP_VERIFY_SSL_CERTIFICATES._1, verify)
 


### PR DESCRIPTION
Already replaced by `extraProperties` and `setExtraProperties`