### PR TITLE
[SW-2241] Remove Deprecated spark.ext.h2o.client.flow.dir Option

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -123,7 +123,6 @@ object H2OConf extends Logging {
   private val deprecatedOptions = Map[String, String](
     "spark.ext.h2o.node.iced.dir" -> "spark.ext.h2o.iced.dir",
     "spark.ext.h2o.client.iced.dir" -> "spark.ext.h2o.iced.dir",
-    "spark.ext.h2o.client.flow.dir" -> "spark.ext.h2o.flow.dir",
     "spark.ext.h2o.node.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.client.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.node.extra" -> "spark.ext.h2o.extra.properties",


### PR DESCRIPTION
Already replaced by `spark.ext.h2o.flow.dir`