### PR TITLE
[SW-2470] Fails to Convert Categorical Columns on Big Dataset and Identity Column

### DIFF
--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterCategoricalTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterCategoricalTestSuite.scala
@@ -87,14 +87,17 @@ class DataFrameConverterCategoricalTestSuite extends FunSuite with SharedH2OTest
 
     def testDataFrameConversionWithHighNumberOfCategoricalLevels(numPartitions: Int) {
       val uniqueValues = 1 to (Categorical.MAX_CATEGORICAL_COUNT * 1.1).toInt
-      val values = uniqueValues.map(i => (i % (Categorical.MAX_CATEGORICAL_COUNT + 1)).toHexString)
+      val values = uniqueValues
+        .map(i => ((i % 10).toString, (i % (Categorical.MAX_CATEGORICAL_COUNT + 1)).toHexString, (i % 100).toHexString))
       val rdd = sc.parallelize(values, numPartitions)
 
-      val df = rdd.toDF("strings")
+      val df = rdd.toDF("cat10", "strings", "cat100")
       val h2oFrame = hc.asH2OFrame(df)
 
       assertH2OFrameInvariants(df, h2oFrame)
-      assert(h2oFrame.columns(0).isString())
+      assert(h2oFrame.columns(0).isCategorical())
+      assert(h2oFrame.columns(1).isString())
+      assert(h2oFrame.columns(2).isCategorical())
 
       val resultDF = hc.asSparkFrame(h2oFrame)
       TestUtils.assertDataFramesAreIdentical(df, resultDF)
@@ -111,14 +114,17 @@ class DataFrameConverterCategoricalTestSuite extends FunSuite with SharedH2OTest
   }
 
   def testDataFrameConversionWithOnlyUniqueValues(numPartitions: Int) {
-    val uniqueValues = (1 to (Categorical.MAX_CATEGORICAL_COUNT / 10)).map(_.toHexString)
-    val rdd = sc.parallelize(uniqueValues, numPartitions)
+    val uniqueValues = (1 to (Categorical.MAX_CATEGORICAL_COUNT / 10))
+    val values = uniqueValues.map(i => ((i % 10).toString, i.toHexString, (i % 100).toHexString))
+    val rdd = sc.parallelize(values, numPartitions)
 
-    val df = rdd.toDF("strings")
+    val df = rdd.toDF("cat10", "strings", "cat100")
     val h2oFrame = hc.asH2OFrame(df)
 
     assertH2OFrameInvariants(df, h2oFrame)
-    assert(h2oFrame.columns(0).isString())
+    assert(h2oFrame.columns(0).isCategorical())
+    assert(h2oFrame.columns(1).isString())
+    assert(h2oFrame.columns(2).isCategorical())
 
     val resultDF = hc.asSparkFrame(h2oFrame)
     TestUtils.assertDataFramesAreIdentical(df, resultDF)

--- a/extensions/src/main/scala/ai/h2o/sparkling/extensions/internals/ConvertCategoricalToStringColumnsTask.java
+++ b/extensions/src/main/scala/ai/h2o/sparkling/extensions/internals/ConvertCategoricalToStringColumnsTask.java
@@ -60,4 +60,10 @@ public class ConvertCategoricalToStringColumnsTask
       }
     }
   }
+
+  @Override
+  public void closeLocal() {
+    super.closeLocal();
+    LocalNodeDomains.remove(frameKey, domainIndices);
+  }
 }

--- a/extensions/src/main/scala/ai/h2o/sparkling/extensions/internals/LocalNodeDomains.java
+++ b/extensions/src/main/scala/ai/h2o/sparkling/extensions/internals/LocalNodeDomains.java
@@ -111,7 +111,8 @@ public final class LocalNodeDomains {
     String[][] result = new String[newSize][];
     int removedDomainIndex = 0;
     for (int originalIndex = 0; originalIndex < originalDomains.length; originalIndex++) {
-      if (removedDomainIndex >= domainsToRemove.length || originalIndex != domainsToRemove[removedDomainIndex]) {
+      if (removedDomainIndex >= domainsToRemove.length
+          || originalIndex != domainsToRemove[removedDomainIndex]) {
         result[originalIndex - removedDomainIndex] = originalDomains[originalIndex];
       } else {
         removedDomainIndex++;

--- a/extensions/src/main/scala/ai/h2o/sparkling/extensions/internals/UpdateCategoricalIndicesTask.java
+++ b/extensions/src/main/scala/ai/h2o/sparkling/extensions/internals/UpdateCategoricalIndicesTask.java
@@ -72,7 +72,8 @@ public class UpdateCategoricalIndicesTask extends MRTask<UpdateCategoricalIndice
   }
 
   @Override
-  public void postGlobal() {
+  public void closeLocal() {
+    super.closeLocal();
     LocalNodeDomains.remove(frameKey);
   }
 }


### PR DESCRIPTION
[`UpdateCategoricalIndicesTask`](https://github.com/h2oai/sparkling-water/blob/68a8a90d4e3c9242fb5109d58be3585da2da89ea/extensions/src/main/scala/ai/h2o/sparkling/extensions/rest/api/ImportFrameHandler.scala#L62) used to work with the original local domains even if the column was converted to a string column due to too exceeding the maximum of categorical levels.