### PR TITLE
[SW-2469][FOLLOWUP] Unlocking of H2O Frame Could Throw NPE

### DIFF
--- a/extensions/src/main/scala/ai/h2o/sparkling/extensions/rest/api/ImportFrameHandler.scala
+++ b/extensions/src/main/scala/ai/h2o/sparkling/extensions/rest/api/ImportFrameHandler.scala
@@ -63,7 +63,7 @@ class ImportFrameHandler extends Handler {
 
     convertCategoricalColumnsToOtherTypesIfNeeded(frame, categoricalColumnIndices)
 
-    DKV.put(frame)
+    frame.update()
     frame.unlock()
 
     request


### PR DESCRIPTION
Possible error:
```
{
   "__meta":{
      "schema_version":3,
      "schema_name":"H2OErrorV3",
      "schema_type":"H2OError"
   },
   "timestamp":1604442830105,
   "error_url":"/3/FinalizeFrame",
   "msg":"\n\nERROR MESSAGE:\n\nDistributedException from 37b2c4d0bd01/172.17.0.2:54323: 'null'\n\n",
   "dev_msg":"\n\nERROR MESSAGE:\n\nDistributedException from 37b2c4d0bd01/172.17.0.2:54323: 'null'\n\n",
   "http_status":500,
   "values":{
      
   },
   "exception_type":"water.util.DistributedException",
   "exception_msg":"\n\nERROR MESSAGE:\n\nDistributedException from 37b2c4d0bd01/172.17.0.2:54323: 'null'\n\n",
   "stacktrace":[
      "DistributedException from 37b2c4d0bd01/172.17.0.2:54323: 'null', caused by java.lang.NullPointerException",
      "    water.RPC.result(RPC.java:240)",
      "    water.RPC.get(RPC.java:256)",
      "    water.Atomic.invoke(Atomic.java:32)",
      "    water.Lockable.unlock(Lockable.java:210)",
      "    water.Lockable.unlock(Lockable.java:204)",
      "    ai.h2o.sparkling.extensions.rest.api.ImportFrameHandler.finalize(ImportFrameHandler.scala:68)",
      "    sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)",
      "    sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)",
      "    sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)",
      "    java.lang.reflect.Method.invoke(Method.java:498)",
      "    water.api.Handler.handle(Handler.java:60)",
      "    water.api.RequestServer.serve(RequestServer.java:470)",
      "    water.api.RequestServer.doGeneric(RequestServer.java:301)",
      "    water.api.RequestServer.doPost(RequestServer.java:227)",
      "    javax.servlet.http.HttpServlet.service(HttpServlet.java:707)",
      "    javax.servlet.http.HttpServlet.service(HttpServlet.java:790)",
      "    org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:865)",
      "    org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:535)",
      "    org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)",
      "    org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1317)",
      "    org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)",
      "    org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)",
      "    org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)",
      "    org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1219)",
      "    org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)",
      "    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)",
      "    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)",
      "    water.webserver.jetty9.Jetty9ServerAdapter$LoginHandler.handle(Jetty9ServerAdapter.java:130)",
      "    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)",
      "    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)",
      "    org.eclipse.jetty.server.Server.handle(Server.java:531)",
      "    org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)",
      "    org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)",
      "    org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)",
      "    org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)",
      "    org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)",
      "    org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)",
      "    org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)",
      "    org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)",
      "    org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)",
      "    org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)",
      "    org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:762)",
      "    org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:680)",
      "    java.lang.Thread.run(Thread.java:748)",
      "Caused by:java.lang.NullPointerException",
      "    water.Lockable.set_unlocked(Lockable.java:262)",
      "    water.Lockable.access$400(Lockable.java:25)",
      "    water.Lockable$Unlock.atomic(Lockable.java:228)",
      "    water.Lockable$Unlock.atomic(Lockable.java:216)",
      "    water.TAtomic.atomic(TAtomic.java:17)",
      "    water.Atomic.compute2(Atomic.java:56)",
      "    water.H2O$H2OCountedCompleter.compute1(H2O.java:1580)",
      "    water.Lockable$Unlock$Icer.compute1(Lockable$Unlock$Icer.java)",
      "    water.H2O$H2OCountedCompleter.compute(H2O.java:1576)",
      "    jsr166y.CountedCompleter.exec(CountedCompleter.java:468)",
      "    jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)",
      "    jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)",
      "    jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)",
      "    jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)"
   ]
}
```