### PR TITLE
[SW-2479] Show Stack Trace of Exceptions in Failed Tests

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 description = "Sparkling Water Core"
 
 apply from: "$rootDir/gradle/utils.gradle"
@@ -146,6 +148,13 @@ test.dependsOn testJar
 integTest {
   if (detectBackendClusterMode() == "external") {
     exclude 'ai/h2o/sparkling/internal/**'
+  }
+
+  testLogging {
+    showCauses = true
+    showExceptions = true
+    showStackTraces = true
+    exceptionFormat = TestExceptionFormat.FULL
   }
 }
 

--- a/gradle/bench.gradle
+++ b/gradle/bench.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 sourceSets {
     bench {
         scala.srcDir file('src/bench/scala')
@@ -39,6 +41,13 @@ task bench(type: Test) {
 
     // Also setup expected Scala version for Spark launcher
     environment "SPARK_SCALA_VERSION", "$scalaBaseVersion"
+
+    testLogging {
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
+        exceptionFormat = TestExceptionFormat.FULL
+    }
 }
 
 // Create jar containing bench classes

--- a/gradle/itest.gradle
+++ b/gradle/itest.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 apply from: "$rootDir/gradle/utils.gradle"
 
 sourceSets {
@@ -45,6 +47,13 @@ task integTest(type: Test) {
 
     // Also setup expected Scala version for Spark launcher
     environment "SPARK_SCALA_VERSION", "$scalaBaseVersion"
+
+    testLogging {
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
+        exceptionFormat = TestExceptionFormat.FULL
+    }
 }
 
 

--- a/gradle/itest.gradle
+++ b/gradle/itest.gradle
@@ -42,9 +42,6 @@ task integTest(type: Test) {
     systemProperty "spark.testing", "true"
     systemProperty "spark.test.home", "${sparkHome}"
 
-    // Show standard out and standard error of the test JVM(s) on the console
-    testLogging.showStandardStreams = true
-
     // Also setup expected Scala version for Spark launcher
     environment "SPARK_SCALA_VERSION", "$scalaBaseVersion"
 
@@ -53,6 +50,9 @@ task integTest(type: Test) {
         showExceptions = true
         showStackTraces = true
         exceptionFormat = TestExceptionFormat.FULL
+
+        // Show standard out and standard error of the test JVM(s) on the console
+        showStandardStreams = true
     }
 }
 

--- a/gradle/scala.gradle
+++ b/gradle/scala.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 apply plugin: 'scala'
 apply plugin: 'java-library'
 apply from: "$rootDir/gradle/utils.gradle"
@@ -90,6 +92,13 @@ test {
     maxParallelForks = 1
     // Also setup expected Scala version for Spark launcher
     environment "SPARK_SCALA_VERSION", "$scalaBaseVersion"
+
+    testLogging {
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
+        exceptionFormat = TestExceptionFormat.FULL
+    }
 }
 
 def configurationsToResolve = [

--- a/gradle/sparkTest.gradle
+++ b/gradle/sparkTest.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 apply from: "$rootDir/gradle/utils.gradle"
 
 // Setup test environment for Spark
@@ -18,5 +20,11 @@ test {
 
     // Working dir will be root project
     workingDir = rootDir
-    // testLogging.showStandardStreams = true
+
+    testLogging {
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
+        exceptionFormat = TestExceptionFormat.FULL
+    }
 }


### PR DESCRIPTION
The current state:
```
ai.h2o.sparkling.DataSourceTestSuite > Reading H2OFrame using key option FAILED
    org.scalatest.exceptions.TestFailedException at DataSourceTestSuite.scala:41
```

After this change:
```
ai.h2o.sparkling.DataSourceTestSuite > Reading H2OFrame using key option FAILED
    org.scalatest.exceptions.TestFailedException: 1 equaled 1 Number of columns should match
        at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:530)
        at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:529)
        at org.scalatest.FunSuite.newAssertionFailedException(FunSuite.scala:1560)
        at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:503)
        at ai.h2o.sparkling.DataSourceTestSuite.$anonfun$new$1(DataSourceTestSuite.scala:41)
        at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
        at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
        at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
        at org.scalatest.Transformer.apply(Transformer.scala:22)
        at org.scalatest.Transformer.apply(Transformer.scala:20)
        at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:186)
        at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
        at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
        at org.scalatest.FunSuite.withFixture(FunSuite.scala:1560)
        at org.scalatest.FunSuiteLike.invokeWithFixture$1(FunSuiteLike.scala:184)
        at org.scalatest.FunSuiteLike.$anonfun$runTest$1(FunSuiteLike.scala:196)
        at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
        at org.scalatest.FunSuiteLike.runTest(FunSuiteLike.scala:196)
        at org.scalatest.FunSuiteLike.runTest$(FunSuiteLike.scala:178)
        at org.scalatest.FunSuite.runTest(FunSuite.scala:1560)
        at org.scalatest.FunSuiteLike.$anonfun$runTests$1(FunSuiteLike.scala:229)
        at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
        at scala.collection.immutable.List.foreach(List.scala:392)
        at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
        at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
        at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
        at org.scalatest.FunSuiteLike.runTests(FunSuiteLike.scala:229)
        at org.scalatest.FunSuiteLike.runTests$(FunSuiteLike.scala:228)
        at org.scalatest.FunSuite.runTests(FunSuite.scala:1560)
        at org.scalatest.Suite.run(Suite.scala:1124)
        at org.scalatest.Suite.run$(Suite.scala:1106)
        at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1560)
        at org.scalatest.FunSuiteLike.$anonfun$run$1(FunSuiteLike.scala:233)
        at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
        at org.scalatest.FunSuiteLike.run(FunSuiteLike.scala:233)
        at org.scalatest.FunSuiteLike.run$(FunSuiteLike.scala:232)
        at ai.h2o.sparkling.DataSourceTestSuite.org$scalatest$BeforeAndAfterAll$$super$run(DataSourceTestSuite.scala:29)
        at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
        at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
        at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
        at ai.h2o.sparkling.DataSourceTestSuite.run(DataSourceTestSuite.scala:29)
```

https://docs.gradle.org/6.5/dsl/org.gradle.api.tasks.testing.logging.TestLogging.html#org.gradle.api.tasks.testing.logging.TestLogging:showCauses