### PR TITLE
[SW-2480] Fix Publishing of Nightly Build Images to DockerHub

### DIFF
--- a/ci/commons.groovy
+++ b/ci/commons.groovy
@@ -211,6 +211,7 @@ def gitCommit(files, msg) {
 }
 
 def installDocker() {
+    sh "sudo apt-get update"
     sh "sudo apt -y install docker.io"
     sh "sudo service docker start"
     sh "sudo chmod 666 /var/run/docker.sock"


### PR DESCRIPTION
The publishing of nightly images is failing on installing docker.io:
```

[2020-11-08T23:14:55.251Z] + sudo apt -y install docker.io

[2020-11-08T23:14:55.251Z] 

[2020-11-08T23:14:55.251Z] WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

[2020-11-08T23:14:55.251Z] 

[2020-11-08T23:14:56.615Z] Reading package lists...

[2020-11-08T23:14:56.615Z] Building dependency tree...

[2020-11-08T23:14:56.615Z] Reading state information...

[2020-11-08T23:14:56.615Z] The following additional packages will be installed:

[2020-11-08T23:14:56.615Z]   apparmor bridge-utils cgroupfs-mount containerd dns-root-data dnsmasq-base

[2020-11-08T23:14:56.615Z]   iptables libapparmor-perl libnetfilter-conntrack3 libnfnetlink0 pigz runc

[2020-11-08T23:14:56.615Z]   ubuntu-fan

[2020-11-08T23:14:56.615Z] Suggested packages:

[2020-11-08T23:14:56.615Z]   apparmor-profiles apparmor-profiles-extra apparmor-docs apparmor-utils

[2020-11-08T23:14:56.615Z]   mountall aufs-tools btrfs-tools debootstrap docker-doc rinse zfs-fuse

[2020-11-08T23:14:56.615Z]   | zfsutils

[2020-11-08T23:14:56.615Z] The following NEW packages will be installed:

[2020-11-08T23:14:56.615Z]   apparmor bridge-utils cgroupfs-mount containerd dns-root-data dnsmasq-base

[2020-11-08T23:14:56.615Z]   docker.io iptables libapparmor-perl libnetfilter-conntrack3 libnfnetlink0

[2020-11-08T23:14:56.615Z]   pigz runc ubuntu-fan

[2020-11-08T23:14:57.176Z] 0 upgraded, 14 newly installed, 0 to remove and 20 not upgraded.

[2020-11-08T23:14:57.176Z] Need to get 53.3 MB of archives.

[2020-11-08T23:14:57.176Z] After this operation, 262 MB of additional disk space will be used.

[2020-11-08T23:14:57.176Z] Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnfnetlink0 amd64 1.0.1-3 [13.3 kB]

[2020-11-08T23:14:57.176Z] Get:2 http://archive.ubuntu.com/ubuntu xenial/universe amd64 pigz amd64 2.3.1-2 [61.1 kB]

[2020-11-08T23:14:57.431Z] Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapparmor-perl amd64 2.10.95-0ubuntu2.11 [33.6 kB]

[2020-11-08T23:14:57.431Z] Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apparmor amd64 2.10.95-0ubuntu2.11 [451 kB]

[2020-11-08T23:14:57.992Z] Get:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 iptables amd64 1.6.0-2ubuntu3 [266 kB]

[2020-11-08T23:14:57.992Z] Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 bridge-utils amd64 1.5-9ubuntu1 [28.6 kB]

[2020-11-08T23:14:57.992Z] Get:7 http://archive.ubuntu.com/ubuntu xenial/universe amd64 cgroupfs-mount all 1.2 [4970 B]

[2020-11-08T23:14:57.992Z] Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 runc amd64 1.0.0~rc7+git20190403.029124da-0ubuntu1~16.04.4 [1890 kB]

[2020-11-08T23:14:58.248Z] Err:9 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 containerd amd64 1.2.6-0ubuntu1~16.04.3

[2020-11-08T23:14:58.248Z]   404  Not Found [IP: 91.189.88.142 80]

[2020-11-08T23:14:58.248Z] Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dns-root-data all 2018013001~16.04.1 [5424 B]

[2020-11-08T23:14:58.248Z] Get:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnetfilter-conntrack3 amd64 1.0.5-1 [36.6 kB]

[2020-11-08T23:14:58.248Z] Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 dnsmasq-base amd64 2.75-1ubuntu0.16.04.5 [295 kB]

[2020-11-08T23:14:58.248Z] Ign:13 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 docker.io amd64 18.09.7-0ubuntu1~16.04.5

[2020-11-08T23:14:58.248Z] Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ubuntu-fan all 0.12.8~16.04.3 [35.1 kB]

[2020-11-08T23:14:58.505Z] Err:9 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 containerd amd64 1.2.6-0ubuntu1~16.04.3

[2020-11-08T23:14:58.505Z]   404  Not Found [IP: 91.189.88.142 80]

[2020-11-08T23:14:58.505Z] Err:13 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 docker.io amd64 18.09.7-0ubuntu1~16.04.5

[2020-11-08T23:14:58.505Z]   404  Not Found [IP: 91.189.88.142 80]

[2020-11-08T23:14:58.505Z] Fetched 3120 kB in 1s (1639 kB/s)

[2020-11-08T23:14:58.505Z] E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/c/containerd/containerd_1.2.6-0ubuntu1~16.04.3_amd64.deb  404  Not Found [IP: 91.189.88.142 80]

[2020-11-08T23:14:58.505Z] 

[2020-11-08T23:14:58.505Z] E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/d/docker.io/docker.io_18.09.7-0ubuntu1~16.04.5_amd64.deb  404  Not Found [IP: 91.189.88.142 80]

[2020-11-08T23:14:58.505Z] 

[2020-11-08T23:14:58.505Z] E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```