### PR TITLE
[SW-2483] Fix Deployment of Sparkling Water Testing Infrastructure

### DIFF
--- a/ci/aws/terraform/modules/jenkins/scripts/init.sh
+++ b/ci/aws/terraform/modules/jenkins/scripts/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-wget -q -O - https://pkg.jenkins.io/debian/jenkins-ci.org.key | apt-key add -
+wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | apt-key add -
 sh -c 'echo deb http://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list'
 add-apt-repository ppa:certbot/certbot --yes
 apt update -y


### PR DESCRIPTION
The repository key has changed: https://www.jenkins.io/doc/book/installing/linux/#long-term-support-release