### PR TITLE
[SW-2480][FOLLOWUP] Fix Publishing of R Nightly Images to DockerHub

### DIFF
--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -164,8 +164,7 @@ String getH2OBranchMajorVersion() {
 }
 
 String getH2OBranchMajorName() {
-    def versionLine = readFile("h2o-3/gradle.properties").split("\n").find() { line -> line.startsWith('codename') }
-    return versionLine.split("=")[1]
+    return "bleeding_edge"
 }
 
 String getH2OBranchBuildVersion() {

--- a/ci/Jenkinsfile-kubernetes
+++ b/ci/Jenkinsfile-kubernetes
@@ -56,8 +56,7 @@ String getH2OBranchMajorVersion() {
 }
 
 String getH2OBranchMajorName() {
-    def versionLine = readFile("h2o-3/gradle.properties").split("\n").find() { line -> line.startsWith('codename') }
-    return versionLine.split("=")[1]
+    return "bleeding_edge"
 }
 
 String getH2OBranchBuildVersion() {

--- a/ci/sparklingWaterPipeline.groovy
+++ b/ci/sparklingWaterPipeline.groovy
@@ -54,8 +54,7 @@ String getH2OBranchMajorVersion() {
 }
 
 String getH2OBranchMajorName() {
-    def versionLine = readFile("h2o-3/gradle.properties").split("\n").find() { line -> line.startsWith('codename') }
-    return versionLine.split("=")[1]
+    "bleeding_edge"
 }
 
 String getH2OBranchBuildVersion() {

--- a/ci/sparklingWaterPipeline.groovy
+++ b/ci/sparklingWaterPipeline.groovy
@@ -54,7 +54,7 @@ String getH2OBranchMajorVersion() {
 }
 
 String getH2OBranchMajorName() {
-    "bleeding_edge"
+    return "bleeding_edge"
 }
 
 String getH2OBranchBuildVersion() {


### PR DESCRIPTION
Error on rel-3.32:
```

[2020-11-16T16:55:55.487Z] Step 5/11 : COPY h2o.tar.gz /opt/spark/R/lib/h2o.tar.gz

[2020-11-16T16:56:21.978Z]  ---> 86804565af88

[2020-11-16T16:56:21.978Z] Step 6/11 : RUN cd /opt/spark/R/lib && R CMD INSTALL h2o.tar.gz

[2020-11-16T16:56:28.512Z]  ---> Running in 1f1be0eff554

[2020-11-16T16:56:38.449Z] Error in untar2(tarfile, files, list, exdir, restore_times) : 

[2020-11-16T16:56:38.449Z]   incomplete block on file

[2020-11-16T16:56:38.449Z] The command '/bin/sh -c cd /opt/spark/R/lib && R CMD INSTALL h2o.tar.gz' returned a non-zero code: 1

[2020-11-16T16:56:38.449Z] Done!
```

Building of R nightly images failed since curl downloaded R H2O package from non-existing location. Local build of H2O-3 build should be picked up instead. 

Decision logic: https://github.com/h2oai/sparkling-water/blob/master/bin/build-kubernetes-images.sh#L65