### PR TITLE
[SW-2486] Upgrade MOJO runtime to 2.5.3

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -80,6 +80,7 @@ dependencies {
   api("ai.h2o:h2o-jetty-9:${h2oVersion}")
   api("ai.h2o:h2o-webserver-iface:${h2oVersion}")
   api("ai.h2o:h2o-automl:${h2oVersion}")
+  api("ai.h2o:h2o-ext-mojo-pipeline:${h2oVersion}")
 
   if (sparkMajorVersion >= "3.0") {
     api("io.fabric8:kubernetes-client:4.9.2") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ h2oMajorName=zermelo
 # H2O Build version, defined here to be overriden by -P option
 h2oBuild=2
 # Version of Mojo Pipeline library
-mojoPipelineVersion=2.4.8
+mojoPipelineVersion=2.5.3
 # Defines whether to run tests with Driverless AI mojo pipelines
 # These tests require the Driverless AI license
 testMojoPipeline=false


### PR DESCRIPTION
Upgrade is needed because of running DAI big data recipe on Sparkling Water.