### PR TITLE
[SW-2482][FOLLOWUP] Test Propagation of Interactions Constraints to MOJO Model

### DIFF
--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
@@ -62,7 +62,7 @@ class MOJOParameterTestSuite extends FunSuite with SharedH2OTestContext with Mat
       .setLabelCol("CAPSULE")
       .setSeed(1)
       .setMonotoneConstraints(Map("AGE" -> 1.0, "RACE" -> -1.0))
-      .setInteractionConstraints(Array(Array("DPROS", "DCAPS"), Array("PSA", "VOL" , "GLEASON")))
+      .setInteractionConstraints(Array(Array("DPROS", "DCAPS"), Array("PSA", "VOL", "GLEASON")))
     val mojo = algorithm.fit(dataset)
 
     compareParameterValues(algorithm, mojo)

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
@@ -62,6 +62,7 @@ class MOJOParameterTestSuite extends FunSuite with SharedH2OTestContext with Mat
       .setLabelCol("CAPSULE")
       .setSeed(1)
       .setMonotoneConstraints(Map("AGE" -> 1.0, "RACE" -> -1.0))
+      .setInteractionConstraints(Array(Array("DPROS", "DCAPS"), Array("PSA", "VOL" , "GLEASON")))
     val mojo = algorithm.fit(dataset)
 
     compareParameterValues(algorithm, mojo)
@@ -146,6 +147,7 @@ class MOJOParameterTestSuite extends FunSuite with SharedH2OTestContext with Mat
     case (_, "auto") => true
     case (_, "family_default") => true
     case (null, map: Map[_, _]) if map.isEmpty => true
+    case (array1: Array[Array[_]], array2: Array[Array[_]]) => array1.map(_.toSeq).toSeq == array2.map(_.toSeq).toSeq
     case (array1: Array[_], array2: Array[_]) => array1.toSeq == array2.toSeq
     case (val1, val2) => val1 == val2
   }

--- a/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
@@ -33,7 +33,9 @@ def testDRFParameters(prostateDataset):
 
 def testXGBoostParameters(prostateDataset):
     features = ['AGE', 'RACE', 'DPROS', 'DCAPS', 'PSA']
-    algorithm = H2OXGBoost(seed=1, labelCol="CAPSULE", featuresCols=features, monotoneConstraints={'AGE': 1, 'RACE': -1})
+    algorithm = H2OXGBoost(seed=1, labelCol="CAPSULE", featuresCols=features,
+                           monotoneConstraints={'AGE': 1, 'RACE': -1},
+                           interactionConstraints=[['AGE', 'RACE', 'DPROS'], ['DCAPS', 'PSA']])
     model = algorithm.fit(prostateDataset)
     compareParameterValues(algorithm, model)
 


### PR DESCRIPTION
Thanks to the fix in  https://github.com/h2oai/h2o-3/pull/5136 SW can test `getInteractionConstraints()` on `H2OXGboostMOJOModel`.