### PR TITLE
[SW-2489] Downgrade Sparklyr to 1.3.1 due to Problems with K8s Deployment

### DIFF
--- a/booklet/src/sections/kubernetes.tex
+++ b/booklet/src/sections/kubernetes.tex
@@ -420,7 +420,9 @@ local:///opt/sparkling-water/tests/initTest.py
 
 \subsubsection{R}
 
-First, make sure that RSparkling is installed on the node we want to run RSparkling from.
+First, make sure that RSparkling is installed on the node we want to run RSparkling from. Also check that the version
+of your Sparklyr is older or equal to ``1.3.1``. There is a problem with the deployment on Kubernetes since Sparklyr ``1.4``.
+
 You can install RSparkling as:
 
 \begin{lstlisting}[style=R]
@@ -659,7 +661,8 @@ local:///opt/sparkling-water/tests/initTest.py
 
 \subsubsection{R}
 
-First, make sure that RSparkling is installed on the node we want to run RSparkling from.
+First, make sure that RSparkling is installed on the node we want to run RSparkling from.  Also check that the version
+of your Sparklyr is older or equal to ``1.3.1``. There is a problem with the deployment on Kubernetes since Sparklyr ``1.4``.
 You can install RSparkling as:
 
 \begin{lstlisting}[style=R]

--- a/doc/src/site/sphinx/deployment/kubernetes.rst
+++ b/doc/src/site/sphinx/deployment/kubernetes.rst
@@ -207,7 +207,9 @@ Dynamic allocation must be disabled in Spark.
     .. tab-container:: R
         :title: R
 
-        First, make sure that RSparkling is installed on the node we want to run RSparkling from.
+        First, make sure that RSparkling is installed on the node we want to run RSparkling from. Also check that the version
+        of your Sparklyr is older or equal to ``1.3.1``. There is a problem with the deployment on Kubernetes since Sparklyr ``1.4``.
+
         You can install RSparkling as:
 
         .. code:: r
@@ -462,7 +464,9 @@ After we created the external H2O backend, we can connect to it from Sparkling W
     .. tab-container:: R
         :title: R
 
-        First, make sure that RSparkling is installed on the node we want to run RSparkling from.
+        First, make sure that RSparkling is installed on the node we want to run RSparkling from. Also check that the version
+        of your Sparklyr is older or equal to ``1.3.1``. There is a problem with the deployment on Kubernetes since Sparklyr ``1.4``.
+
         You can install RSparkling as:
 
         .. code:: r

--- a/kubernetes/build.gradle
+++ b/kubernetes/build.gradle
@@ -68,21 +68,8 @@ task createRDockerfile(type: Dockerfile) {
                 R -e 'install.packages("RCurl", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("jsonlite", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("testthat", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("base64enc’", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("config", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("DBI", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("dplyr", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("dbplyr", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("forge", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("generics", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("globals", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("purrr", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("r2d3", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("rappdirs", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("rjson", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("tidyr", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("uuid", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/sparklyr/sparklyr_1.3.1.tar.gz", repos=NULL, type="source")'
+                R -e 'install.packages("devtools", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'library(devtools); install_version("sparklyr", repos = "http://cran.us.r-project.org", version = "1.3.1")'
                 """
   copyFile("h2o.tar.gz", "/opt/spark/R/lib/h2o.tar.gz")
   runCommand "cd /opt/spark/R/lib && R CMD INSTALL h2o.tar.gz"

--- a/kubernetes/build.gradle
+++ b/kubernetes/build.gradle
@@ -68,7 +68,21 @@ task createRDockerfile(type: Dockerfile) {
                 R -e 'install.packages("RCurl", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("jsonlite", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("testthat", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("sparklyr", repos = "http://cran.us.r-project.org")'
+                R -e 'install.packages("base64enc’", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("config", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("DBI", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("dplyr", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("dbplyr", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("forge", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("generics", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("globals", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("purrr", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("r2d3", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("rappdirs", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("rjson", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("tidyr", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("uuid", repos = "http://cran.us.r-project.org")' && \\
+                R -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/sparklyr/sparklyr_1.3.1.tar.gz", repos=NULL, type="source")'
                 """
   copyFile("h2o.tar.gz", "/opt/spark/R/lib/h2o.tar.gz")
   runCommand "cd /opt/spark/R/lib && R CMD INSTALL h2o.tar.gz"

--- a/kubernetes/src/r/initTest.R
+++ b/kubernetes/src/r/initTest.R
@@ -48,6 +48,7 @@ config <- spark_config_kubernetes(master = master,
                                  version = sparkVersion,
                                  executors = numExecutors,
                                  conf = extraOptionsParsed,
+                                 timeout = 300,
                                  ports = c(8880, 8881, 4040, 54321))
 config["spark.home"] <- sparkHome
 sc <- spark_connect(config = config, spark_home = sparkHome)

--- a/kubernetes/src/r/initTest.R
+++ b/kubernetes/src/r/initTest.R
@@ -17,6 +17,7 @@
 library(sparklyr)
 library(rsparkling)
 library(testthat)
+options(sparklyr.console.log = TRUE)
 master <- Sys.getenv("KUBERNETES_MASTER")
 registryId <- Sys.getenv("REGISTRY_ID")
 version <- Sys.getenv("SW_VERSION")


### PR DESCRIPTION
This PR should fix R tests on K8s.

More details in https://github.com/sparklyr/sparklyr/issues/2832