### PR TITLE
[SW-2490] Rename Driver Pods to Fix K8s Tests in Client Mode

### DIFF
--- a/ci/Jenkinsfile-kubernetes
+++ b/ci/Jenkinsfile-kubernetes
@@ -23,6 +23,18 @@ def readPropertiesFile(file) {
     return properties
 }
 
+def runCommandWithK8sDebugInfo(GString script) {
+    def result = sh(script: script, returnStatus: true)
+    if (result > 0) {
+        sh """
+            kubectl describe service sparkling-water-app
+            kubectl get pods --all-namespaces 
+            kubectl describe pods
+            kubectl logs sparkling-water-app
+        """
+    }
+}
+
 static def getKubernetesSparkVersions(props) {
     def sparkVersions = props["supportedSparkVersions"].split(" ").toList()
     def boundaryVersion = props["kubernetesSupportSinceSpark"]
@@ -157,11 +169,12 @@ def withTestEnv(commons, image, code) {
 }
 
 def testScalaInternalBackendClusterMode(registryId, master, version) {
-    sh "kubectl delete pod driver-scala --ignore-not-found"
-    sh """
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo """
         \$SPARK_HOME/bin/spark-submit \
          --conf spark.kubernetes.container.image=${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:scala-${version} \
-         --conf spark.kubernetes.driver.pod.name=driver-scala \
+         --conf spark.driver.host=sparkling-water-app \
+         --conf spark.kubernetes.driver.pod.name=sparkling-water-app \
          --conf spark.scheduler.minRegisteredResourcesRatio=1 \
          --master $master \
          --deploy-mode cluster \
@@ -170,15 +183,16 @@ def testScalaInternalBackendClusterMode(registryId, master, version) {
          --conf spark.executor.instances=3 \
          local:///opt/sparkling-water/tests/initTest.jar
         """
-    sh "kubectl get pod driver-scala | grep -q Completed && echo \"OK\" || exit 1"
+    sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
 }
 
 def testPythonInternalBackendClusterMode(registryId, master, version) {
-    sh "kubectl delete pod driver-python --ignore-not-found"
-    sh """
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo """
         \$SPARK_HOME/bin/spark-submit \
          --conf spark.kubernetes.container.image=${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:python-${version} \
-         --conf spark.kubernetes.driver.pod.name=driver-python \
+         --conf spark.kubernetes.driver.pod.name=sparkling-water-app \
+         --conf spark.driver.host=sparkling-water-app \
          --conf spark.scheduler.minRegisteredResourcesRatio=1 \
          --master $master \
          --deploy-mode cluster \
@@ -186,12 +200,12 @@ def testPythonInternalBackendClusterMode(registryId, master, version) {
          --conf spark.executor.instances=3 \
          local:///opt/sparkling-water/tests/initTest.py
         """
-    sh "kubectl get pod driver-python | grep -q Completed && echo \"OK\" || exit 1"
+    sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
 }
 
 def testRInternalBackend(registryId, master, version, sparkVersion) {
-    sh "kubectl delete pod driver-r --ignore-not-found"
-    sh """
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo """
             export KUBERNETES_MASTER=$master
             export REGISTRY_ID=$registryId
             export SW_VERSION=$version
@@ -199,8 +213,8 @@ def testRInternalBackend(registryId, master, version, sparkVersion) {
             Rscript --default-packages=methods,utils /opt/sparkling-water/tests/initTest.R
             """
     sh 'sleep 60'
-    sh "kubectl logs driver-r | grep -q \"Open H2O Flow in browser\" && echo \"OK\" || exit 1"
-    sh "kubectl logs driver-r | grep -qv \"ASSERTION ERROR\" && echo \"OK\" || exit 1"
+    sh "kubectl logs sparkling-water-app | grep -q \"Open H2O Flow in browser\" && echo \"OK\" || exit 1"
+    sh "kubectl logs sparkling-water-app | grep -qv \"ASSERTION ERROR\" && echo \"OK\" || exit 1"
 }
 
 def installSparkHeadlessService() {
@@ -223,15 +237,17 @@ def testScalaInternalBackendClientMode(registryId, master, version) {
     sh "kubectl delete pod sparkling-water-app --ignore-not-found"
     installSparkHeadlessService()
     def image = "${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:scala-${version}"
-    sh """
+    runCommandWithK8sDebugInfo"""
         kubectl run -n default -i --tty sparkling-water-app --restart=Never --labels spark-driver-selector=sparkling-water-app \
         --image=${image} -- \
         \$SPARK_HOME/bin/spark-submit \
          --conf spark.scheduler.minRegisteredResourcesRatio=1 \
          --conf spark.kubernetes.container.image=${image}  \
          --master $master \
+         --name test \
          --class ai.h2o.sparkling.InitTest \
          --conf spark.driver.host=sparkling-water-app \
+         --conf spark.kubernetes.driver.pod.name=sparkling-water-app \
          --deploy-mode client \
          --conf spark.executor.instances=3 \
          local:///opt/sparkling-water/tests/initTest.jar
@@ -243,18 +259,21 @@ def testPythonInternalBackendClientMode(registryId, master, version) {
     sh "kubectl delete pod sparkling-water-app --ignore-not-found"
     installSparkHeadlessService()
     def image = "${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:python-${version}"
-    sh """
+    runCommandWithK8sDebugInfo """
         kubectl run -n default -i --tty sparkling-water-app --restart=Never --labels spark-driver-selector=sparkling-water-app \
         --image=${image} -- \
         \$SPARK_HOME/bin/spark-submit \
-         --conf spark.scheduler.minRegisteredResourcesRatio=1 \
-         --conf spark.kubernetes.container.image=${image}  \
-         --master $master \
-         --conf spark.driver.host=sparkling-water-app \
-         --deploy-mode client \
-         --conf spark.executor.instances=3 \
-         local:///opt/sparkling-water/tests/initTest.py
+        --conf spark.scheduler.minRegisteredResourcesRatio=1 \
+        --conf spark.kubernetes.container.image=${image}  \
+        --master $master \
+        --name test \
+        --conf spark.driver.host=sparkling-water-app \
+        --conf spark.kubernetes.driver.pod.name=sparkling-water-app \
+        --deploy-mode client \
+        --conf spark.executor.instances=3 \
+        local:///opt/sparkling-water/tests/initTest.py
         """
+
     sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
 }
 
@@ -332,12 +351,13 @@ EOF
 
 def stopExternalH2OBackend() {
     sh "kubectl delete statefulsets h2o-stateful-set --ignore-not-found"
+    sh "kubectl delete service h2o-service --ignore-not-found"
 }
 
 def testRExternalBackendManual(registryId, master, version, sparkVersion) {
     startExternalH2OBackend(registryId, version)
-    sh "kubectl delete pod driver-r --ignore-not-found"
-    sh """
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo """
         export KUBERNETES_MASTER=$master
         export REGISTRY_ID=$registryId
         export SW_VERSION=$version
@@ -346,8 +366,8 @@ def testRExternalBackendManual(registryId, master, version, sparkVersion) {
         Rscript --default-packages=methods,utils /opt/sparkling-water/tests/initTest.R
         """
     sh 'sleep 60'
-    sh "kubectl logs driver-r | grep -q \"Open H2O Flow in browser\" && echo \"OK\" || exit 1"
-    sh "kubectl logs driver-r | grep -qv \"ASSERTION ERROR\" && echo \"OK\" || exit 1"
+    sh "kubectl logs sparkling-water-app | grep -q \"Open H2O Flow in browser\" && echo \"OK\" || exit 1"
+    sh "kubectl logs sparkling-water-app | grep -qv \"ASSERTION ERROR\" && echo \"OK\" || exit 1"
     stopExternalH2OBackend()
 }
 
@@ -356,8 +376,8 @@ def testRExternalBackendAuto(registryId, master, version, sparkVersion) {
         kubectl delete namespace h2o --ignore-not-found
         kubectl create namespace h2o
         """
-    sh "kubectl delete pod driver-r --ignore-not-found"
-    sh """
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo """
         export KUBERNETES_MASTER=$master
         export REGISTRY_ID=$registryId
         export SW_VERSION=$version
@@ -366,15 +386,16 @@ def testRExternalBackendAuto(registryId, master, version, sparkVersion) {
         Rscript --default-packages=methods,utils /opt/sparkling-water/tests/initTest.R
         """
     sh 'sleep 60'
-    sh "kubectl logs driver-r | grep -q \"Open H2O Flow in browser\" && echo \"OK\" || exit 1"
-    sh "kubectl logs driver-r | grep -qv \"ASSERTION ERROR\" && echo \"OK\" || exit 1"
+    sh "kubectl logs sparkling-water-app | grep -q \"Open H2O Flow in browser\" && echo \"OK\" || exit 1"
+    sh "kubectl logs sparkling-water-app | grep -qv \"ASSERTION ERROR\" && echo \"OK\" || exit 1"
     stopExternalH2OBackend()
 }
 
 static String externalBackendManualSharedSubmitCmd(registryId, master, version, mode, language) {
     return """\$SPARK_HOME/bin/spark-submit \
              --conf spark.kubernetes.container.image=${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:${language}-${version} \
-             --conf spark.kubernetes.driver.pod.name=driver-${language} \
+             --conf spark.driver.host=sparkling-water-app \
+             --conf spark.kubernetes.driver.pod.name=sparkling-water-app \
              --conf spark.scheduler.minRegisteredResourcesRatio=1 \
              --master $master \
              --deploy-mode $mode \
@@ -391,7 +412,8 @@ static String externalBackendManualSharedSubmitCmd(registryId, master, version, 
 static String externalBackendAutoSharedSubmitCmd(registryId, master, version, mode, language) {
     return """\$SPARK_HOME/bin/spark-submit \
              --conf spark.kubernetes.container.image=${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:${language}-${version} \
-             --conf spark.kubernetes.driver.pod.name=driver-${language} \
+             --conf spark.driver.host=sparkling-water-app \
+             --conf spark.kubernetes.driver.pod.name=sparkling-water-app \
              --conf spark.scheduler.minRegisteredResourcesRatio=1 \
              --master $master \
              --deploy-mode $mode \
@@ -417,14 +439,14 @@ static String scalaExternalBackendSubmitCmd(registryId, master, version, mode, s
     return """${prefix} \
               --class ai.h2o.sparkling.InitTest \
               local:///opt/sparkling-water/tests/initTest.jar
-            """
+           """
 }
 
 def testScalaExternalBackendManualClusterMode(registryId, master, version) {
     startExternalH2OBackend(registryId, version)
-    sh "kubectl delete pod driver-scala --ignore-not-found"
-    sh "${scalaExternalBackendSubmitCmd(registryId, master, version, "cluster", "manual")}"
-    sh "kubectl get pod driver-scala | grep -q Completed && echo \"OK\" || exit 1"
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo "${scalaExternalBackendSubmitCmd(registryId, master, version, "cluster", "manual")}"
+    sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
     stopExternalH2OBackend()
 }
 
@@ -433,7 +455,7 @@ def testScalaExternalBackendManualClientMode(registryId, master, version) {
     sh "kubectl delete pod sparkling-water-app --ignore-not-found"
     installSparkHeadlessService()
     def image = "${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:scala-${version}"
-    sh """
+    runCommandWithK8sDebugInfo"""
         kubectl run -n default -i --tty sparkling-water-app --restart=Never --labels spark-driver-selector=sparkling-water-app \
         --image=${image} -- ${scalaExternalBackendSubmitCmd(registryId, master, version, "client", "manual")}
         """
@@ -446,9 +468,9 @@ def testScalaExternalBackendAutoClusterMode(registryId, master, version) {
         kubectl delete namespace h2o --ignore-not-found
         kubectl create namespace h2o
         """
-    sh "kubectl delete pod driver-scala --ignore-not-found"
-    sh "${scalaExternalBackendSubmitCmd(registryId, master, version, "cluster", "auto")}"
-    sh "kubectl get pod driver-scala | grep -q Completed && echo \"OK\" || exit 1"
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo"${scalaExternalBackendSubmitCmd(registryId, master, version, "cluster", "auto")}"
+    sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
 }
 
 def testScalaExternalBackendAutoClientMode(registryId, master, version) {
@@ -459,10 +481,11 @@ def testScalaExternalBackendAutoClientMode(registryId, master, version) {
     sh "kubectl delete pod sparkling-water-app --ignore-not-found"
     installSparkHeadlessService()
     def image = "${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:scala-${version}"
-    sh """
+    runCommandWithK8sDebugInfo"""
         kubectl run -n default -i --tty sparkling-water-app --restart=Never --labels spark-driver-selector=sparkling-water-app \
         --image=${image} -- ${scalaExternalBackendSubmitCmd(registryId, master, version, "client", "auto")}
         """
+    sh "sleep 330"
     sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
 }
 
@@ -481,9 +504,9 @@ static String pythonExternalBackendSubmitCmd(registryId, master, version, mode, 
 
 def testPythonExternalBackendManualClusterMode(registryId, master, version) {
     startExternalH2OBackend(registryId, version)
-    sh "kubectl delete pod driver-python --ignore-not-found"
-    sh "${pythonExternalBackendSubmitCmd(registryId, master, version, "cluster", "manual")}"
-    sh "kubectl get pod driver-python | grep -q Completed && echo \"OK\" || exit 1"
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo "${pythonExternalBackendSubmitCmd(registryId, master, version, "cluster", "manual")}"
+    sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
     stopExternalH2OBackend()
 }
 
@@ -492,7 +515,7 @@ def testPythonExternalBackendManualClientMode(registryId, master, version) {
     sh "kubectl delete pod sparkling-water-app --ignore-not-found"
     installSparkHeadlessService()
     def image = "${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:python-${version}"
-    sh """
+    runCommandWithK8sDebugInfo """
         kubectl run -n default -i --tty sparkling-water-app --restart=Never --labels spark-driver-selector=sparkling-water-app \
         --image=${image} -- ${pythonExternalBackendSubmitCmd(registryId, master, version, "client", "manual")}
         """
@@ -505,9 +528,9 @@ def testPythonExternalBackendAutoClusterMode(registryId, master, version) {
         kubectl delete namespace h2o --ignore-not-found
         kubectl create namespace h2o
         """
-    sh "kubectl delete pod driver-python --ignore-not-found"
-    sh "${pythonExternalBackendSubmitCmd(registryId, master, version, "cluster", "auto")}"
-    sh "kubectl get pod driver-python | grep -q Completed && echo \"OK\" || exit 1"
+    sh "kubectl delete pod sparkling-water-app --ignore-not-found"
+    runCommandWithK8sDebugInfo "${pythonExternalBackendSubmitCmd(registryId, master, version, "cluster", "auto")}"
+    sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
 }
 
 def testPythonExternalBackendAutoClientMode(registryId, master, version) {
@@ -518,10 +541,11 @@ def testPythonExternalBackendAutoClientMode(registryId, master, version) {
     sh "kubectl delete pod sparkling-water-app --ignore-not-found"
     installSparkHeadlessService()
     def image = "${registryId}.dkr.ecr.${awsRegion()}.amazonaws.com/sw_kubernetes_repo/sparkling-water:python-${version}"
-    sh """
+    runCommandWithK8sDebugInfo """
         kubectl run -n default -i --tty sparkling-water-app --restart=Never --labels spark-driver-selector=sparkling-water-app \
         --image=${image} -- ${pythonExternalBackendSubmitCmd(registryId, master, version, "client", "auto")}
         """
+    sh "sleep 330"
     sh "kubectl get pod sparkling-water-app | grep -q Completed && echo \"OK\" || exit 1"
 }
 

--- a/kubernetes/src/r/initTest.R
+++ b/kubernetes/src/r/initTest.R
@@ -44,7 +44,7 @@ if (optionName %in% names(extraOptionsParsed) && extraOptionsParsed[optionName] 
 config <- spark_config_kubernetes(master = master,
                                  image = paste0(registryId, ".dkr.ecr.us-east-2.amazonaws.com/sw_kubernetes_repo/sparkling-water:r-", version),
                                  account = "default",
-                                 driver = "driver-r",
+                                 driver = "sparkling-water-app",
                                  version = sparkVersion,
                                  executors = numExecutors,
                                  conf = extraOptionsParsed,


### PR DESCRIPTION
Some K8s test are failing due to referencing wrong pod names:
```
+ kubectl run -n default -i --tty sparkling-water-app --restart=Never --labels spark-driver-selector=sparkling-water-app --image=524466471676.dkr.ecr.us-east-2.amazonaws.com/sw_kubernetes_repo/sparkling-water:scala-3.32.0.3-1-2.4 -- /opt/spark/bin/spark-submit --conf spark.kubernetes.container.image=524466471676.dkr.ecr.us-east-2.amazonaws.com/sw_kubernetes_repo/sparkling-water:scala-3.32.0.3-1-2.4 --conf spark.kubernetes.driver.pod.name=driver-scala --conf spark.scheduler.minRegisteredResourcesRatio=1 --master k8s://https://A6560DFE7DC91C583A6AA479DB047E03.yl4.us-east-2.eks.amazonaws.com --deploy-mode client --name test --conf spark.ext.h2o.backend.cluster.mode=external --conf spark.ext.h2o.external.start.mode=auto --conf spark.ext.h2o.external.auto.start.backend=kubernetes --conf spark.ext.h2o.external.memory=2G --conf spark.ext.h2o.external.k8s.namespace=h2o --conf spark.ext.h2o.external.k8s.docker.image=524466471676.dkr.ecr.us-east-2.amazonaws.com/sw_kubernetes_repo/sparkling-water:external-backend-3.32.0.3-1-2.4 --conf spark.executor.instances=2 --conf spark.ext.h2o.external.cluster.size=2 --class ai.h2o.sparkling.InitTest local:///opt/sparkling-water/tests/initTest.jar

Unable to use a TTY - input is not a terminal or the right kind of file

If you don't see a command prompt, try pressing enter.

Error attaching, falling back to logs: 

++ id -u

+ myuid=0

++ id -g

+ mygid=0

+ set +e

++ getent passwd 0

+ uidentry=root:x:0:0:root:/root:/bin/bash

+ set -e

+ '[' -z root:x:0:0:root:/root:/bin/bash ']'

+ SPARK_K8S_CMD=/opt/spark/bin/spark-submit

+ case "$SPARK_K8S_CMD" in

+ echo 'Non-spark-on-k8s command provided, proceeding in pass-through mode...'

Non-spark-on-k8s command provided, proceeding in pass-through mode...

+ exec /usr/bin/tini -s -- /opt/spark/bin/spark-submit --conf spark.kubernetes.container.image=524466471676.dkr.ecr.us-east-2.amazonaws.com/sw_kubernetes_repo/sparkling-water:scala-3.32.0.3-1-2.4 --conf spark.kubernetes.driver.pod.name=driver-scala --conf spark.scheduler.minRegisteredResourcesRatio=1 --master k8s://https://A6560DFE7DC91C583A6AA479DB047E03.yl4.us-east-2.eks.amazonaws.com --deploy-mode client --name test --conf spark.ext.h2o.backend.cluster.mode=external --conf spark.ext.h2o.external.start.mode=auto --conf spark.ext.h2o.external.auto.start.backend=kubernetes --conf spark.ext.h2o.external.memory=2G --conf spark.ext.h2o.external.k8s.namespace=h2o --conf spark.ext.h2o.external.k8s.docker.image=524466471676.dkr.ecr.us-east-2.amazonaws.com/sw_kubernetes_repo/sparkling-water:external-backend-3.32.0.3-1-2.4 --conf spark.executor.instances=2 --conf spark.ext.h2o.external.cluster.size=2 --class ai.h2o.sparkling.InitTest local:///opt/sparkling-water/tests/initTest.jar

error: timed out waiting for the condition

script returned exit code 1
```

The command references: ```spark-driver-selector=sparkling-water-app``` but ```spark.kubernetes.driver.pod.name=driver-scala``` is created instead.

Headless service used in client mode tests:
```
root@bb1b72223128:/opt/spark/work-dir# kubectl describe svc sparkling-water-app
Name:              sparkling-water-app
Namespace:         default
Labels:            <none>
Annotations:       <none>
Selector:          spark-driver-selector=sparkling-water-app
Type:              ClusterIP
IP:                None
Session Affinity:  None
Events:            <none>

```