### PR TITLE
[SW-2491] Loading of Pipeline Containing SW Stage Throws NPE

### DIFF
--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOReader.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOReader.scala
@@ -17,7 +17,7 @@
 
 package ai.h2o.sparkling.ml.models
 
-import java.nio.file.Paths
+import org.apache.hadoop.fs.Path
 
 import ai.h2o.sparkling.ml.utils.H2OReaderBase
 import ai.h2o.sparkling.utils.SparkSessionUtils
@@ -27,7 +27,7 @@ private[models] class H2OMOJOReader[T <: HasMojo] extends H2OReaderBase[T] {
 
   override def load(path: String): T = {
     val model = super.load(path)
-    val inputPath = Paths.get(path, H2OMOJOProps.serializedFileName).toString
+    val inputPath = new Path(path, H2OMOJOProps.serializedFileName)
     withResource(SparkSessionUtils.readHDFSFile(inputPath)) { inputStream =>
       model.setMojo(inputStream)
     }

--- a/utils/src/main/scala/ai/h2o/sparkling/utils/SparkSessionUtils.scala
+++ b/utils/src/main/scala/ai/h2o/sparkling/utils/SparkSessionUtils.scala
@@ -52,7 +52,7 @@ object SparkSessionUtils extends Logging {
   }
 
   def readHDFSFile(path: String): InputStream = {
-    val hadoopPath = new Path (path)
+    val hadoopPath = new Path(path)
     readHDFSFile(hadoopPath)
   }
 

--- a/utils/src/main/scala/ai/h2o/sparkling/utils/SparkSessionUtils.scala
+++ b/utils/src/main/scala/ai/h2o/sparkling/utils/SparkSessionUtils.scala
@@ -52,7 +52,11 @@ object SparkSessionUtils extends Logging {
   }
 
   def readHDFSFile(path: String): InputStream = {
-    val hadoopPath = new Path(path)
+    val hadoopPath = new Path (path)
+    readHDFSFile(hadoopPath)
+  }
+
+  def readHDFSFile(hadoopPath: Path): InputStream = {
     val fs = hadoopPath.getFileSystem(SparkSessionUtils.active.sparkContext.hadoopConfiguration)
     val qualifiedPath = hadoopPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
     fs.open(qualifiedPath)


### PR DESCRIPTION
Jira ticket: https://h2oai.atlassian.net/browse/SW-2491
Reported problem: https://github.com/h2oai/sparkling-water/issues/2344

`Paths.get(path, H2OMOJOProps.serializedFileName)` removes the second slash from the path and produces: 
```
s3:/marek-test2/target_encodingpipeline/stages/0_H2OTargetEncoder_01b1058521ed/mojo_model
```

new Path(path, H2OMOJOProps.serializedFileName) is used internally in Spark for path concatenation and will produce:
```
s3://marek-test2/target_encodingpipeline/stages/0_H2OTargetEncoder_01b1058521ed/mojo_model
```

Tested the fix manually on EMR.