### PR TITLE
[SW-2492] Disable Kubernetes R Tests for External Backend

### DIFF
--- a/ci/Jenkinsfile-kubernetes
+++ b/ci/Jenkinsfile-kubernetes
@@ -640,8 +640,9 @@ node("docker") {
                 withTestEnv(commons, image) {
                     // R sets deployment mode automatically
                     testRInternalBackend(registryId, master, version, sparkVersion)
-                    testRExternalBackendManual(registryId, master, version, sparkVersion)
-                    testRExternalBackendAuto(registryId, master, version, sparkVersion)
+                    // Uncomment after the release Sparklyr 1.5.1, see description of the Jira ticket SW-2492
+                    //testRExternalBackendManual(registryId, master, version, sparkVersion)
+                    //testRExternalBackendAuto(registryId, master, version, sparkVersion)
                 }
             } catch (Exception e) {
                 stopEKSCluster(commons)


### PR DESCRIPTION
The R tests will  be enabled again after Sparklyr 1.5.1. due to https://github.com/sparklyr/sparklyr/issues/2832. In the external beckend a multiple --conf options needs to be passed.