### PR TITLE
[SW-2493] Proper Removal of Sparkling Water Images from Local Docker Registry

### DIFF
--- a/ci/sparklingWaterPipeline.groovy
+++ b/ci/sparklingWaterPipeline.groovy
@@ -402,6 +402,7 @@ def publishSparklingWaterDockerImage(String type, version, sparkMajorVersion) {
         docker tag sparkling-water-${type}:${version} h2oai/sparkling-water-${type}:latest-nightly-${sparkMajorVersion}
         docker push h2oai/sparkling-water-${type}:latest-nightly-${sparkMajorVersion}
         docker rmi h2oai/sparkling-water-${type}:latest-nightly-${sparkMajorVersion}
+        docker rmi sparkling-water-${type}:${version}
     """
 }
 


### PR DESCRIPTION
The build docker images were just untagged not deleted. 

```
[2020-11-29T20:32:01.676Z] + docker rmi h2oai/sparkling-water-python:latest-nightly-2.4

[2020-11-29T20:32:01.676Z] Untagged: h2oai/sparkling-water-python:latest-nightly-2.4

[2020-11-29T20:32:01.676Z] Untagged: h2oai/sparkling-water-python@sha256:0fe7ec838c4325e8adeeee86dda5a8ce9c858be71bc3e77df0de1d214afab23d
```

From documentation https://docs.docker.com/engine/reference/commandline/rmi/: 

```If an image has multiple tags, using this command with the tag as a parameter only removes the tag. If the tag is the only one for the image, both the image and the tag are removed.```