### PR TITLE
[SW-2498] Try to Lock Cloud Multiple Times

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OContextExtensions.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/H2OContextExtensions.scala
@@ -115,17 +115,17 @@ trait H2OContextExtensions extends RestCommunication with RestApiUtils with Shel
   }
 
   private def tryToLockCloud(conf: H2OConf, catchException: Boolean): Boolean = {
-      val h2oCluster = conf.h2oCluster.get + conf.contextPath.getOrElse("")
-      val h2oClusterName = conf.cloudName.get
-      try {
-        logInfo(s"Trying to lock H2O cluster $h2oCluster - $h2oClusterName.")
-        lockCloud(conf)
-        true
-      } catch {
-        case cause: RestApiException if catchException =>
-          logWarning(s"Locking of the H2O cluster $h2oCluster - $h2oClusterName failed.", cause)
-          false
-      }
+    val h2oCluster = conf.h2oCluster.get + conf.contextPath.getOrElse("")
+    val h2oClusterName = conf.cloudName.get
+    try {
+      logInfo(s"Trying to lock H2O cluster $h2oCluster - $h2oClusterName.")
+      lockCloud(conf)
+      true
+    } catch {
+      case cause: RestApiException if catchException =>
+        logWarning(s"Locking of the H2O cluster $h2oCluster - $h2oClusterName failed.", cause)
+        false
+    }
   }
 
   protected def getAndVerifyWorkerNodes(conf: H2OConf): Array[NodeDesc] = {


### PR DESCRIPTION
In automatic external backend of K8s deployment, cloud locking may fail since H2O headless service may route a call to a non leader node during its initialization phase.