### PR TITLE
[SW-2496] Fix the Flow link for Databricks Azure

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/ui/H2OClusterInfo.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/ui/H2OClusterInfo.scala
@@ -19,6 +19,7 @@ package org.apache.spark.h2o.ui
 
 case class H2OClusterInfo(
     localClientIpPort: String,
+    flowURL: String,
     cloudHealthy: Boolean,
     cloudSecured: Boolean,
     cloudNodes: Array[String],

--- a/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterInfoPage.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterInfoPage.scala
@@ -51,8 +51,6 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
     Seq(("Flow UI", flowUrl()), ("Nodes", cloudInfo.cloudNodes.mkString(","))) ++ cloudInfo.extraBackendInfo
   }
 
-
-
   override def render(request: HttpServletRequest): Seq[Node] = {
     val helpText =
       """
@@ -99,10 +97,10 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
       </div>
       <span>
         <h4>Sparkling Water</h4>{swInfoTable}<h4>Sparkling Water Properties</h4>{swPropertiesTable}<h4>H2O Build Information</h4>
-        { h2oInfoTable }
-        { additionalScript() }
+        {h2oInfoTable}
+        {additionalScript()}
       </span>
-     } else {
+    } else {
       <div>
         <h4>Sparkling Water UI not ready yet!</h4>
       </div>
@@ -111,7 +109,7 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
   }
 
   private def additionalScript(): Seq[Node] = {
-    if(AzureDatabricksUtils.isRunningOnAzureDatabricks(parent.parent.conf)) {
+    if (AzureDatabricksUtils.isRunningOnAzureDatabricks(parent.parent.conf)) {
       val javaScript = scala.xml.Unparsed(
         s"""document.getElementById("Flow UI").innerHTML = window.location.protocol + "//" + window.location.hostname + "${flowUrl()}";
            |document.getElementById("Flow UI Link").href = "${flowUrl()}";""".stripMargin)

--- a/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterInfoPage.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/ui/SparklingWaterInfoPage.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.h2o.ui
 
+import ai.h2o.sparkling.backend.utils.AzureDatabricksUtils
 import javax.servlet.http.HttpServletRequest
 import org.apache.spark.h2o.SparkSpecificUtils
 import org.apache.spark.ui.{UIUtils, WebUIPage}
 
-import scala.xml.Node
+import scala.xml.{Attribute, Node, Null, Text}
 
 /**
   * Sparkling Water info page.
@@ -41,7 +42,7 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
       ("H2O Build On", h2oBuildInfo.h2oBuildOn))
   }
 
-  private def flowUrl(): String = s"http://${provider.localIpPort}"
+  private def flowUrl(): String = parent.provider.H2OClusterInfo.flowURL
 
   private def swProperties(): Seq[(String, String, String)] = provider.sparklingWaterProperties
 
@@ -49,6 +50,8 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
     val cloudInfo = provider.H2OClusterInfo
     Seq(("Flow UI", flowUrl()), ("Nodes", cloudInfo.cloudNodes.mkString(","))) ++ cloudInfo.extraBackendInfo
   }
+
+
 
   override def render(request: HttpServletRequest): Seq[Node] = {
     val helpText =
@@ -58,7 +61,7 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
 
     val content = if (provider.isSparklingWaterStarted) {
 
-      val swInfoTable = UIUtils.listingTable(propertyHeader, h2oRow, swInfo(), fixedWidth = true)
+      val swInfoTable = UIUtils.listingTable(propertyHeader, h2oRowWithId, swInfo(), fixedWidth = true)
       val swPropertiesTable =
         UIUtils.listingTable(Seq("Name", "Value", "Documentation"), propertiesRow, swProperties(), fixedWidth = true)
       val h2oInfoTable = UIUtils.listingTable(propertyHeader, h2oRow, h2oInfo(), fixedWidth = true)
@@ -88,24 +91,36 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
             <strong>Memory Info:</strong>{memoryInfo}
           </li>
           <li>
-            <a href={flowUrl()}>
+            <a id="Flow UI Link" target="_blank" href={flowUrl()}>
               <strong>Flow UI</strong>
             </a>
           </li>
         </ul>
       </div>
-        <span>
-          <h4>Sparkling Water</h4>{swInfoTable}<h4>Sparkling Water Properties</h4>{swPropertiesTable}<h4>H2O Build Information</h4>{
-        h2oInfoTable
-      }
-        </span>
-
-    } else {
+      <span>
+        <h4>Sparkling Water</h4>{swInfoTable}<h4>Sparkling Water Properties</h4>{swPropertiesTable}<h4>H2O Build Information</h4>
+        { h2oInfoTable }
+        { additionalScript() }
+      </span>
+     } else {
       <div>
         <h4>Sparkling Water UI not ready yet!</h4>
       </div>
     }
     SparkSpecificUtils.headerSparkPage(request, "Sparkling Water", content, parent, helpText)
+  }
+
+  private def additionalScript(): Seq[Node] = {
+    if(AzureDatabricksUtils.isRunningOnAzureDatabricks(parent.parent.conf)) {
+      val javaScript = scala.xml.Unparsed(
+        s"""document.getElementById("Flow UI").innerHTML = window.location.protocol + "//" + window.location.hostname + "${flowUrl()}";
+           |document.getElementById("Flow UI Link").href = "${flowUrl()}";""".stripMargin)
+      <script type="text/javascript">{
+        javaScript
+      }</script>
+    } else {
+      Seq.empty
+    }
   }
 
   private def propertyHeader = Seq("Name", "Value")
@@ -126,5 +141,13 @@ case class SparklingWaterInfoPage(parent: SparklingWaterUITab) extends WebUIPage
     </td> <td>
       {kv._2}
     </td>
+  </tr>
+
+  private def h2oRowWithId(kv: (String, String)) = <tr>
+    <td>
+      {kv._1}
+    </td> {<td>
+      {kv._2}
+    </td> % Attribute(None, "id", Text(kv._1), Null)}
   </tr>
 }

--- a/core/src/main/scala_spark_others/org/apache/spark/h2o/SparkSpecificUtils.scala
+++ b/core/src/main/scala_spark_others/org/apache/spark/h2o/SparkSpecificUtils.scala
@@ -34,14 +34,7 @@ object SparkSpecificUtils extends CrossSparkUtils {
       activeTab: SparkUITab,
       helpText: String): Seq[Node] = {
     val method = UIUtils.getClass.getMethods.find(m => m.getName == "headerSparkPage").get
-    val arguments = Seq[AnyRef](
-      request,
-      title,
-      () => content,
-      activeTab,
-      Some(helpText),
-      FALSE,
-      FALSE)
+    val arguments = Seq[AnyRef](request, title, () => content, activeTab, Some(helpText), FALSE, FALSE)
     val result = if (arguments.length == method.getParameterCount) {
       method.invoke(UIUtils, arguments: _*)
     } else if (arguments.length + 1 == method.getParameterCount) {


### PR DESCRIPTION
There are two problems.
- Databricks chanced base address which is not easy to resolve since contains a random number which is not stored anywhere on the driver or in the environment properties. The problem is solved via resolving base address in the web browser.

More details on: ```https://docs.microsoft.com/en-us/azure/databricks/workspace/per-workspace-urls```

- The `UIUtils.headerSparkPage` method in   Databricks Spark has more parameters than Apache Spark. I solved the problem via reflection call.

Databricks: ```
request: javax.servlet.http.HttpServletRequest,
title: String,content: => Seq[scala.xml.Node],
activeTab: org.apache.spark.ui.SparkUITab,
helpText: Option[String],
showVisualization: Boolean,
useDataTables: Boolean,
supportScreenshot: Boolean```

Apache: ```
request: javax.servlet.http.HttpServletRequest,
title: String,content: => Seq[scala.xml.Node],
activeTab: org.apache.spark.ui.SparkUITab,
helpText: Option[String],
showVisualization: Boolean,
useDataTables: Boolean```