### PR TITLE
[SW-2503] Tried using port 54321 for Flow proxy, but port was already occupied

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/ProxyStarter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/ProxyStarter.scala
@@ -107,7 +107,8 @@ private[sparkling] object ProxyStarter extends Logging {
         val serverSocket = new ServerSocket()
         serverSocket.setReuseAddress(false)
         val host = SparkEnv.get.blockManager.blockManagerId.host
-        val socketAddress = new InetSocketAddress(InetAddress.getByName(host), port)
+        logInfo(s"Trying to bind on $host:$port using 0.0.0.0 ip address")
+        val socketAddress = new InetSocketAddress("0.0.0.0", port)
         serverSocket.bind(socketAddress, 1)
         serverSocket.close()
         true


### PR DESCRIPTION
Updated `ProxyStarter.scala`. so that when tries to bind on a port it uses the address `0.0.0.0`

The problem description: https://github.com/h2oai/sparkling-water/issues/2414