### PR TITLE
[SW-2507] Set Seed in AnomalyPredictionTestSuite

### DIFF
--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/AnomalyPredictionTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/AnomalyPredictionTestSuite.scala
@@ -50,6 +50,7 @@ class AnomalyPredictionTestSuite extends FunSuite with Matchers with SharedH2OTe
     val algo = new H2OIsolationForest()
       .setWithLeafNodeAssignments(true)
       .setWithStageResults(true)
+      .setSeed(42)
 
     val model = algo.fit(dataset)
 
@@ -77,6 +78,7 @@ class AnomalyPredictionTestSuite extends FunSuite with Matchers with SharedH2OTe
     val algo = new H2OIsolationForest()
       .setWithStageResults(true)
       .setWithLeafNodeAssignments(true)
+      .setSeed(42)
 
     val model = algo.fit(dataset)
 
@@ -103,7 +105,7 @@ class AnomalyPredictionTestSuite extends FunSuite with Matchers with SharedH2OTe
   }
 
   test("transformSchema without leafNodeAssignments and stageResults") {
-    val algo = new H2OIsolationForest()
+    val algo = new H2OIsolationForest().setSeed(42)
 
     val model = algo.fit(dataset)
 


### PR DESCRIPTION
Tests randomly fail:
```
[2020-12-23T11:40:38.708Z]     org.scalatest.exceptions.TestFailedException: 4.64 equaled 4.64

[2020-12-23T11:40:38.708Z]         at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:530)

[2020-12-23T11:40:38.708Z]         at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:529)

[2020-12-23T11:40:38.708Z]         at org.scalatest.FunSuite.newAssertionFailedException(FunSuite.scala:1560)

[2020-12-23T11:40:38.708Z]         at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:503)

[2020-12-23T11:40:38.708Z]         at ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite.$anonfun$new$3(AnomalyPredictionTestSuite.scala:62)

[2020-12-23T11:40:38.709Z]         at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)

[2020-12-23T11:40:38.709Z]         at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)

[2020-12-23T11:40:38.709Z]         at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)

[2020-12-23T11:40:38.709Z]         at org.scalatest.Transformer.apply(Transformer.scala:22)

[2020-12-23T11:40:38.709Z]         at org.scalatest.Transformer.apply(Transformer.scala:20)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:186)

[2020-12-23T11:40:38.709Z]         at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)

[2020-12-23T11:40:38.709Z]         at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuite.withFixture(FunSuite.scala:1560)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.invokeWithFixture$1(FunSuiteLike.scala:184)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.$anonfun$runTest$1(FunSuiteLike.scala:196)

[2020-12-23T11:40:38.709Z]         at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.runTest(FunSuiteLike.scala:196)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.runTest$(FunSuiteLike.scala:178)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuite.runTest(FunSuite.scala:1560)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.$anonfun$runTests$1(FunSuiteLike.scala:229)

[2020-12-23T11:40:38.709Z]         at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)

[2020-12-23T11:40:38.709Z]         at scala.collection.immutable.List.foreach(List.scala:392)

[2020-12-23T11:40:38.709Z]         at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)

[2020-12-23T11:40:38.709Z]         at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)

[2020-12-23T11:40:38.709Z]         at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.runTests(FunSuiteLike.scala:229)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.runTests$(FunSuiteLike.scala:228)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuite.runTests(FunSuite.scala:1560)

[2020-12-23T11:40:38.709Z]         at org.scalatest.Suite.run(Suite.scala:1124)

[2020-12-23T11:40:38.709Z]         at org.scalatest.Suite.run$(Suite.scala:1106)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1560)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.$anonfun$run$1(FunSuiteLike.scala:233)

[2020-12-23T11:40:38.709Z]         at org.scalatest.SuperEngine.runImpl(Engine.scala:518)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.run(FunSuiteLike.scala:233)

[2020-12-23T11:40:38.709Z]         at org.scalatest.FunSuiteLike.run$(FunSuiteLike.scala:232)

[2020-12-23T11:40:38.709Z]         at ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite.org$scalatest$BeforeAndAfterAll$$super$run(AnomalyPredictionTestSuite.scala:28)

[2020-12-23T11:40:38.709Z]         at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)

[2020-12-23T11:40:38.709Z]         at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)

[2020-12-23T11:40:38.709Z]         at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)

[2020-12-23T11:40:38.709Z]         at ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite.run(AnomalyPredictionTestSuite.scala:28)
```