### PR TITLE
[SW-2515] Fix TargetEncoder for Usage in Python Pipeline

### DIFF
--- a/py-scoring/src/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.py
@@ -26,7 +26,7 @@ class H2OTargetEncoderModel(H2OTargetEncoderMOJOParams, JavaModel, JavaMLWritabl
 
     def transform(self, dataset):
         callerFrame = inspect.stack()[1]
-        inTrainingMode = (callerFrame.function == '_fit') & callerFrame.filename.endswith('pyspark/ml/pipeline.py')
+        inTrainingMode = (callerFrame[3] == '_fit') & callerFrame[1].endswith('pyspark/ml/pipeline.py')
         if inTrainingMode:
             return self.transformTrainingDataset(dataset)
         else:

--- a/py-scoring/src/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.py
@@ -19,9 +19,18 @@ from ai.h2o.sparkling.ml.params.H2OTargetEncoderMOJOParams import H2OTargetEncod
 from pyspark.ml.util import JavaMLWritable
 from pyspark.ml.wrapper import JavaModel
 from pyspark.sql import DataFrame
+import inspect
 
 
 class H2OTargetEncoderModel(H2OTargetEncoderMOJOParams, JavaModel, JavaMLWritable):
+
+    def transform(self, dataset):
+        callerFrame = inspect.stack()[1]
+        inTrainingMode = (callerFrame.function == '_fit') & callerFrame.filename.endswith('pyspark/ml/pipeline.py')
+        if inTrainingMode:
+            return self.transformTrainingDataset(dataset)
+        else:
+            return super(H2OTargetEncoderModel, self).transform(dataset)
 
     def transformTrainingDataset(self, dataset):
         self._transfer_params_to_java()

--- a/py/tests/unit/with_runtime_sparkling/test_target_encoder.py
+++ b/py/tests/unit/with_runtime_sparkling/test_target_encoder.py
@@ -227,7 +227,6 @@ def testTargetEncoderInPipelineAppliesNoiseOnTrainingDataset(trainingDataset):
     expected = referenceTEModel.transformTrainingDataset(trainingDataset)
     unexpected = referenceTEModel.transform(trainingDataset)
 
-
     class DummyTransformer(Transformer):
         def _transform(self, dataset):
             return dataset

--- a/py/tests/unit/with_runtime_sparkling/test_target_encoder.py
+++ b/py/tests/unit/with_runtime_sparkling/test_target_encoder.py
@@ -18,6 +18,7 @@
 import os
 import pytest
 from pyspark.ml import Pipeline, PipelineModel
+from pyspark.ml import Estimator, Transformer
 from pysparkling.ml import H2OTargetEncoder, H2OGBM
 from ai.h2o.sparkling.ml.models.H2OTargetEncoderMOJOModel import H2OTargetEncoderMOJOModel
 
@@ -210,3 +211,31 @@ def testTargetEncoderModelProduceSameResultsRegardlessSpecificationOfOutputCols(
     dataFrameCustomOutputCols = trainAndReturnTranformedTestingDataset(targetEncoderCustomOutputCols)
 
     unit_test_utils.assert_data_frames_are_identical(dataFrameDefaultOutputCols, dataFrameCustomOutputCols)
+
+
+def testTargetEncoderInPipelineAppliesNoiseOnTrainingDataset(trainingDataset):
+    def createTargetEncoder():
+        return H2OTargetEncoder() \
+            .setInputCols(["RACE", "DPROS", "DCAPS"]) \
+            .setLabelCol("CAPSULE") \
+            .setHoldoutStrategy("None") \
+            .setBlendedAvgEnabled(False) \
+            .setNoise(5.0) \
+            .setNoiseSeed(42)
+
+    referenceTEModel = createTargetEncoder().fit(trainingDataset)
+    expected = referenceTEModel.transformTrainingDataset(trainingDataset)
+    unexpected = referenceTEModel.transform(trainingDataset)
+
+
+    class DummyTransformer(Transformer):
+        def _transform(self, dataset):
+            return dataset
+
+    class AssertionEstimator(Estimator):
+        def _fit(self, dataset):
+            unit_test_utils.assert_data_frames_are_identical(expected, dataset)
+            unit_test_utils.assert_data_frames_have_different_values(unexpected, dataset)
+            return DummyTransformer()
+
+    Pipeline(stages=[createTargetEncoder(),AssertionEstimator()]).fit(trainingDataset)


### PR DESCRIPTION
A similar logic for the detections of a training dataset is in the [Scala backend](https://github.com/h2oai/sparkling-water/blob/e876be3dfdfc6192fe5b558403a0c8227523f360/ml/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderModel.scala#L86). Since the Spark [Pipeline](https://github.com/apache/spark/blob/master/python/pyspark/ml/pipeline.py#L29) class has no java backend, the [logic](https://github.com/h2oai/sparkling-water/compare/mn/SW-2515?expand=1#diff-a9c840719ab642a05309990ed6049281fc5c16d0e9727feb30449f1c76cfb577R29) must in the Python wrapper as well.