### PR TITLE
[SW-2517] Fix TargetEncoder MOJO for Distributed Environment

### DIFF
--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderMOJOModel.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OTargetEncoderMOJOModel.scala
@@ -49,7 +49,7 @@ class H2OTargetEncoderMOJOModel(override val uid: String)
   override def transform(dataset: Dataset[_]): DataFrame = {
     import org.apache.spark.sql.DatasetExtensions._
     val outputCols = getOutputCols()
-    val udfWrapper = H2OTargetEncoderMOJOUdfWrapper(getMojo(), outputCols)
+    val udfWrapper = H2OTargetEncoderMOJOUdfWrapper(getMojo, outputCols)
     val withPredictionsDF = applyPredictionUdf(dataset, _ => udfWrapper.mojoUdf)
     withPredictionsDF
       .withColumns(
@@ -68,9 +68,9 @@ class H2OTargetEncoderMOJOModel(override val uid: String)
 /**
   * The class holds all necessary dependencies of udf that needs to be serialized.
   */
-case class H2OTargetEncoderMOJOUdfWrapper(mojo: File, outputCols: Array[String]) {
+case class H2OTargetEncoderMOJOUdfWrapper(mojoGetter: () => File, outputCols: Array[String]) {
   @transient private lazy val easyPredictModelWrapper: EasyPredictModelWrapper = {
-    val model = Utils.getMojoModel(mojo).asInstanceOf[TargetEncoderMojoModel]
+    val model = Utils.getMojoModel(mojoGetter()).asInstanceOf[TargetEncoderMojoModel]
     val config = new EasyPredictModelWrapper.Config()
     config.setModel(model)
     config.setConvertUnknownCategoricalLevelsToNa(true)


### PR DESCRIPTION
Eech executor has to call get `mojoGetter()` method independently to get [the local path of each executor](https://github.com/h2oai/sparkling-water/blob/master/scoring/src/main/scala/ai/h2o/sparkling/ml/models/HasMojo.scala#L52).

