### PR TITLE
[SW-2504][FOLLOWUP] Fix Bootstrap of Pysparkling

### DIFF
--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -175,7 +175,7 @@ export SPARK_MAJOR_VERSION
 SPARK_MAJOR_VERSION=$(echo "$SPARK_VERSION" | cut -d . -f 1,2)
 
 PY_ZIP="h2o_pysparkling_${SPARK_MAJOR_VERSION}-${VERSION}.zip"
-export PY_ZIP_FILE="$TOPDIR/py/build/dist/$PY_ZIP"
+export PY_ZIP_FILE="$TOPDIR/py/$PY_ZIP"
 export AVAILABLE_H2O_DRIVERS
 AVAILABLE_H2O_DRIVERS=$( [ -f "$TOPDIR/h2o_drivers.txt" ] && cat "$TOPDIR/h2o_drivers.txt" || echo "N/A" )
 

--- a/booklet/src/sections/deployment.tex
+++ b/booklet/src/sections/deployment.tex
@@ -42,7 +42,7 @@ zip package
 
 \begin{lstlisting}[style=Bash]
 $SPARK_HOME/bin/spark-submit \
-  --py-files /sparkling-water-distribution/py/build/dist/h2o_pysparkling_3.0-3.30.1.1-1-3.0.zip \
+  --py-files /sparkling-water-distribution/py/h2o_pysparkling_3.0-3.30.1.1-1-3.0.zip \
   app.py
 \end{lstlisting}
 
@@ -203,7 +203,7 @@ You can access Flow by going to localhost:54321.
 \begin{enumerate}
 \item Create a new Python library containing the PySparkling zip file.
 \item Download the selected Sparkling Water version from \url{https://www.h2o.ai/download/}.
-\item The PySparkling zip file is located in the sparkling water zip file at the following location: `py/build/dist/h2o\_pysparkling\_*.zip.`
+\item The PySparkling zip file is located in the sparkling water zip file at the following location: `py/h2o\_pysparkling\_*.zip.`
 \item Create libraries for the following python modules: request, tabulate, future and colorama.
 \item Attach the PySparkling library and python modules to the cluster.
 \item Create a new python notebook.

--- a/booklet/src/sections/productionazing.tex
+++ b/booklet/src/sections/productionazing.tex
@@ -288,7 +288,7 @@ or
 In case of Python, run:
 
 \begin{lstlisting}[style=Bash]
-./bin/pyspark --jars license.sig --py-files py/build/dist/h2o_pysparkling_3.0-3.30.1.1-1-3.0.zip
+./bin/pyspark --jars license.sig --py-files py/h2o_pysparkling_3.0-3.30.1.1-1-3.0.zip
 \end{lstlisting}
 
 or


### PR DESCRIPTION
Pysparkling package was moved inside SW zip file from `py/build/dist` to `py` during introduction of the python scoring package.