### PR TITLE
[SW-2519] Fix Flaky Test in AnomalyPredictionTestSuite

### DIFF
--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/AnomalyPredictionTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/AnomalyPredictionTestSuite.scala
@@ -37,7 +37,7 @@ class AnomalyPredictionTestSuite extends FunSuite with Matchers with SharedH2OTe
   }
 
   test("predictionCol content") {
-    val algo = new H2OIsolationForest()
+    val algo = new H2OIsolationForest().setSeed(42)
 
     val model = algo.fit(dataset)
     val transformed = model.transform(dataset)


### PR DESCRIPTION
The random error in nightly builds:
```
[2021-01-19T19:09:56.562Z] ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite > predictionCol content FAILED

[2021-01-19T19:09:56.562Z]     org.scalatest.exceptions.TestFailedException: 6.28 equaled 6.28

[2021-01-19T19:09:56.562Z]         at org.scalatest.Assertions$class.newAssertionFailedException(Assertions.scala:500)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuite.newAssertionFailedException(FunSuite.scala:1555)

[2021-01-19T19:09:56.562Z]         at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:466)

[2021-01-19T19:09:56.562Z]         at ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite$$anonfun$1.apply$mcV$sp(AnomalyPredictionTestSuite.scala:46)

[2021-01-19T19:09:56.562Z]         at ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite$$anonfun$1.apply(AnomalyPredictionTestSuite.scala:39)

[2021-01-19T19:09:56.562Z]         at ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite$$anonfun$1.apply(AnomalyPredictionTestSuite.scala:39)

[2021-01-19T19:09:56.562Z]         at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)

[2021-01-19T19:09:56.562Z]         at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)

[2021-01-19T19:09:56.562Z]         at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)

[2021-01-19T19:09:56.562Z]         at org.scalatest.Transformer.apply(Transformer.scala:22)

[2021-01-19T19:09:56.562Z]         at org.scalatest.Transformer.apply(Transformer.scala:20)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:166)

[2021-01-19T19:09:56.562Z]         at org.scalatest.Suite$class.withFixture(Suite.scala:1122)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuite.withFixture(FunSuite.scala:1555)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuiteLike$class.invokeWithFixture$1(FunSuiteLike.scala:163)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)

[2021-01-19T19:09:56.562Z]         at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuiteLike$class.runTest(FunSuiteLike.scala:175)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuite.runTest(FunSuite.scala:1555)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuiteLike$$anonfun$runTests$1.apply(FunSuiteLike.scala:208)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuiteLike$$anonfun$runTests$1.apply(FunSuiteLike.scala:208)

[2021-01-19T19:09:56.562Z]         at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:413)

[2021-01-19T19:09:56.562Z]         at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:401)

[2021-01-19T19:09:56.562Z]         at scala.collection.immutable.List.foreach(List.scala:381)

[2021-01-19T19:09:56.562Z]         at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)

[2021-01-19T19:09:56.562Z]         at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:396)

[2021-01-19T19:09:56.562Z]         at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:483)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuiteLike$class.runTests(FunSuiteLike.scala:208)

[2021-01-19T19:09:56.562Z]         at org.scalatest.FunSuite.runTests(FunSuite.scala:1555)

[2021-01-19T19:09:56.562Z]         at org.scalatest.Suite$class.run(Suite.scala:1424)

[2021-01-19T19:09:56.563Z]         at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1555)

[2021-01-19T19:09:56.563Z]         at org.scalatest.FunSuiteLike$$anonfun$run$1.apply(FunSuiteLike.scala:212)

[2021-01-19T19:09:56.563Z]         at org.scalatest.FunSuiteLike$$anonfun$run$1.apply(FunSuiteLike.scala:212)

[2021-01-19T19:09:56.563Z]         at org.scalatest.SuperEngine.runImpl(Engine.scala:545)

[2021-01-19T19:09:56.563Z]         at org.scalatest.FunSuiteLike$class.run(FunSuiteLike.scala:212)

[2021-01-19T19:09:56.563Z]         at ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite.org$scalatest$BeforeAndAfterAll$$super$run(AnomalyPredictionTestSuite.scala:28)

[2021-01-19T19:09:56.563Z]         at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:257)

[2021-01-19T19:09:56.563Z]         at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:256)

[2021-01-19T19:09:56.563Z]         at ai.h2o.sparkling.ml.algos.AnomalyPredictionTestSuite.run(AnomalyPredictionTestSuite.scala:28)
```