### PR TITLE
[SW-2504][FOLLOWUP] Fix Execution of Integration Tests in Nightly Builds

### DIFF
--- a/py/build.gradle
+++ b/py/build.gradle
@@ -361,13 +361,13 @@ if (project.property("testMojoPipeline") == "true") {
   testPython.dependsOn testPythonMojoPipeline
 }
 
-task integTestPython(type: PythonTask, dependsOn: [distPython, checkSparkVersionTask]) {
+task integTestPython(type: PythonTask, dependsOn: [buildTests, distPython, checkSparkVersionTask]) {
   extraArgs(*createIntegTestArgs())
   def buildDir = getBuildDir()
   command = "${buildDir}/tests/test_runner.py '${buildDir}/tests/integration --ignore=${buildDir}/tests/integration/external_only'"
 }
 
-task integTestPythonExternal(type: PythonTask, dependsOn: [distPython, checkSparkVersionTask]) {
+task integTestPythonExternal(type: PythonTask, dependsOn: [buildTests, distPython, checkSparkVersionTask]) {
   extraArgs(*createIntegTestArgs())
   def buildDir = getBuildDir()
   command = "${buildDir}/tests/test_runner.py ${buildDir}/tests/integration/external_only"


### PR DESCRIPTION

The error is caused by the creation of scoring packaning and moving test files under the `build` folder:
```
Task :sparkling-water-py:integTestPython FAILED

[2021-01-24T18:56:07.319Z] [python] /home/jenkins/.gradle/python/3.6.10/2.3.4/bin/python /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_master-spark-2.3-external/py/build/tests/test_runner.py '/home/jenkins/workspace/NIGHTLY_H2O_BRANCH_master-spark-2.3-external/py/build/tests/integration --ignore=/home/jenkins/workspace/NIGHTLY_H2O_BRANCH_master-spark-2.3-external/py/build/tests/integration/external_only' /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_master-spark-2.3-external/py/build/dist/h2o_pysparkling_2.3-3.34.0.1-1-2.3.zip spark.testing=true spark.ext.h2o.backend.cluster.mode=external spark.test.home=/home/jenkins/spark-2.3.4-bin-hadoop2.7 spark.ext.h2o.log.dir=/home/jenkins/workspace/NIGHTLY_H2O_BRANCH_master-spark-2.3-external/py/build/h2ologs-itest spark.ext.h2o.external.disable.version.check=true spark.ext.h2o.testing.path.to.sw.jar=/home/jenkins/workspace/NIGHTLY_H2O_BRANCH_master-spark-2.3-external/assembly/build/libs/sparkling-water-assembly_2.11-3.34.0.1-1-2.3-all.jar

[2021-01-24T18:56:07.319Z] 	 /home/jenkins/.gradle/python/3.6.10/2.3.4/bin/python: can't open file '/home/jenkins/workspace/NIGHTLY_H2O_BRANCH_master-spark-2.3-external/py/build/tests/test_runner.py'
```