### PR TITLE
[SW-2526] Fix Publishing of Nightly Build Images to DockerHub

### DIFF
--- a/ci/commons.groovy
+++ b/ci/commons.groovy
@@ -211,6 +211,7 @@ def gitCommit(files, msg) {
 }
 
 def installDocker() {
+    sh "sudo rm /etc/apt/sources.list.d/hdp.list*"
     sh "sudo apt-get update"
     sh "sudo apt -y install docker.io"
     sh "sudo service docker start"


### PR DESCRIPTION
The publishing fails on apt-get and non-existing HDP repository