### PR TITLE
[SW-2447] Remove Deprecation of `getTrainingParams` on H2OMOJOModel

### DIFF
--- a/booklet/src/sections/productionazing.tex
+++ b/booklet/src/sections/productionazing.tex
@@ -201,7 +201,9 @@ The method \texttt{getModelCategory} can be used to get the model category (such
 \subsubsection{Obtaining Training Params}
 
 The method \texttt{getTrainingParams} can be used to get map containing all training parameters used in the H2O. It is a map
-from parameter name to the value. The parameters name use the H2O's naming structure.
+from parameter name to the value. The parameters name use the H2O's naming structure. An alternative approach for Scala and
+Python API is to use a getter method on the MOJO model instance for a given training parameter. The getter methods utilize
+Sparkling Water naming conventions (E.g. H2O name: \texttt{max_depth}, getter method name: \texttt{getMaxDepth}).
 
 
 \subsubsection{Obtaining Metrics}

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -40,9 +40,6 @@ From 3.32 to 3.34
 
 - The ``weightCol`` parameter on ``H2OKmeans`` was removed without a replacement.
 
-- The ``getTrainingParams`` method on ``H2OMOJOModel`` and inherited classes has been removed in Python and Scala API.
-  Use a specific getter method for a given training parameter.
-
 - The ``distribution`` parameter on ``H2OGLM`` was removed without a replacement.
 
 - The support for Apache Spark 2.1.x has been removed.

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/H2OMOJOModelParams.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/H2OMOJOModelParams.py
@@ -18,7 +18,6 @@
 from ai.h2o.sparkling.ml.models.H2OMOJOModelBase import H2OMOJOModelBase
 from ai.h2o.sparkling.ml.params.H2OTypeConverters import H2OTypeConverters
 from pyspark.ml.param import *
-import warnings
 
 
 class H2OMOJOModelParams(H2OMOJOModelBase):
@@ -42,8 +41,6 @@ class H2OMOJOModelParams(H2OMOJOModelBase):
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getCurrentMetrics())
 
     def getTrainingParams(self):
-        warnings.warn("The method 'getTrainingParams' is deprecated and will be removed in 3.34."
-                      "Use a dedicated getter method for a given parameter.")
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getTrainingParams())
 
     def getModelCategory(self):

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOModel.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOModel.scala
@@ -84,7 +84,6 @@ class H2OMOJOModel(override val uid: String)
     }
   }
 
-  @DeprecatedMethod("a dedicated getter method for a given parameter", "3.34")
   def getTrainingParams(): Map[String, String] = $(trainingParams)
 
   def getModelCategory(): String = $(modelCategory)


### PR DESCRIPTION
The method can't be removed since it's utilized by `H2OGridSearch` and there is not alternative in R API.