### PR TITLE
[SW-2537] Add support for Spark 3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ User Documentation
 ~~~~~~~~~~~~~~~~~~
 The documentation contains also documentation for our clients, PySparkling and RSparkling.
 
+- `Sparkling Water For Spark 3.1 <http://docs.h2o.ai/sparkling-water/3.1/latest-stable/doc/index.html>`__
 - `Sparkling Water For Spark 3.0 <http://docs.h2o.ai/sparkling-water/3.0/latest-stable/doc/index.html>`__
 - `Sparkling Water For Spark 2.4 <http://docs.h2o.ai/sparkling-water/2.4/latest-stable/doc/index.html>`__
 - `Sparkling Water For Spark 2.3 <http://docs.h2o.ai/sparkling-water/2.3/latest-stable/doc/index.html>`__
@@ -27,6 +28,7 @@ The documentation contains also documentation for our clients, PySparkling and R
 Download Binaries
 ~~~~~~~~~~~~~~~~~
 
+- `Latest version for Spark 3.1 <http://h2o-release.s3.amazonaws.com/sparkling-water/spark-3.1/latest.html>`__
 - `Latest version for Spark 3.0 <http://h2o-release.s3.amazonaws.com/sparkling-water/spark-3.0/latest.html>`__
 - `Latest version for Spark 2.4 <http://h2o-release.s3.amazonaws.com/sparkling-water/spark-2.4/latest.html>`__
 - `Latest version for Spark 2.3 <http://h2o-release.s3.amazonaws.com/sparkling-water/spark-2.3/latest.html>`__
@@ -53,13 +55,13 @@ Each Sparkling Water release is published into Maven central with following coor
 The full list of published packages is available
 `here <http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22ai.h2o%22%20AND%20a%3Asparkling-water*>`__.
 
-Sparkling Water Requirements for Spark 3.0
+Sparkling Water Requirements for Spark 3.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Linux/OS X/Windows
 -  Java 8+
 -  Python 2.7+ For Python version of Sparkling Water (PySparkling)
--  `Spark 3.0 <https://spark.apache.org/downloads.html>`__ and ``SPARK_HOME`` shell variable must point to your local Spark installation
+-  `Spark 3.1 <https://spark.apache.org/downloads.html>`__ and ``SPARK_HOME`` shell variable must point to your local Spark installation
 
 To see requirements for older Spark version, please visit relevant documentation.
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/TimeZoneConversions.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/TimeZoneConversions.scala
@@ -18,6 +18,7 @@
 package ai.h2o.sparkling.backend.converters
 
 import java.sql.{Date, Timestamp}
+import java.time.ZoneId
 import java.util.TimeZone
 
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -30,7 +31,7 @@ trait TimeZoneConversions {
   def fromSparkTimeZoneToUTC(timestamp: Timestamp): Long = fromSparkTimeZoneToUTC(timestamp.getTime * 1000) / 1000
 
   def fromSparkTimeZoneToUTC(date: Date): Long = {
-    DateTimeUtils.fromUTCTime(date.getTime * 1000, DateTimeUtils.defaultTimeZone.getID) / 1000
+    DateTimeUtils.fromUTCTime(date.getTime * 1000, ZoneId.systemDefault) / 1000
   }
 
   def fromUTCToSparkTimeZone(timestamp: Long): Long = DateTimeUtils.toUTCTime(timestamp, sparkTimeZone.getID)

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -32,13 +32,13 @@ You can run examples by typing ``./bin/run-example.sh <name of demo>`` or follow
 Building and Running Examples
 -----------------------------
 
-Please see `Running Sparkling Water Examples <http://docs.h2o.ai/sparkling-water/3.0/latest-stable/doc/devel/running_examples.html>`__ for more information how to build
+Please see `Running Sparkling Water Examples <http://docs.h2o.ai/sparkling-water/3.1/latest-stable/doc/devel/running_examples.html>`__ for more information how to build
 and run examples.
 
 Configuring Sparkling Water Variables
 -------------------------------------
 
-Please see `Available Sparkling Water Configuration Properties <http://docs.h2o.ai/sparkling-water/3.0/latest-stable/doc/configuration/configuration_properties.html>`__ for
+Please see `Available Sparkling Water Configuration Properties <http://docs.h2o.ai/sparkling-water/3.1/latest-stable/doc/configuration/configuration_properties.html>`__ for
 more information about possible Sparkling Water configurations.
 
 Step-by-Step Weather Data Example

--- a/gradle-spark3.1.properties
+++ b/gradle-spark3.1.properties
@@ -1,0 +1,8 @@
+sparkVersion=3.1.1
+minSupportedJavaVersion=1.8
+supportedEmrVersion=emr-5.26.0
+unsupportedMinorSparkVersions=
+scalaBaseVersion=2.12
+databricksVersion=8.0.x-cpu-ml-scala2.12
+executorOverheadMemoryOption=spark.executor.memoryOverhead
+driverOverheadMemoryOption=spark.driver.memoryOverhead

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,9 +23,9 @@ dockerImageVersion=39
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions
-supportedSparkVersions=2.1 2.2 2.3 2.4 3.0
+supportedSparkVersions=2.1 2.2 2.3 2.4 3.0 3.1
 # Select for which Spark version is Sparkling Water built by default
-spark=3.0
+spark=3.1
 # Sparkling Water Version
 version=3.34.0.1-1-SNAPSHOT
 # Spark version from which is Kubernetes Supported

--- a/py/README.rst
+++ b/py/README.rst
@@ -8,6 +8,7 @@ to use this package for scoring with Driverless AI MOJO models.
 
 PySparkling Documentation is hosted at our documentation page:
 
+- For Spark 3.1 - http://docs.h2o.ai/sparkling-water/3.1/latest-stable/doc/pysparkling.html
 - For Spark 3.0 - http://docs.h2o.ai/sparkling-water/3.0/latest-stable/doc/pysparkling.html
 - For Spark 2.4 - http://docs.h2o.ai/sparkling-water/2.4/latest-stable/doc/pysparkling.html
 - For Spark 2.3 - http://docs.h2o.ai/sparkling-water/2.3/latest-stable/doc/pysparkling.html

--- a/r/README.rst
+++ b/r/README.rst
@@ -5,6 +5,7 @@ RSparkling
 
 RSparkling Documentation is hosted at our documentation page:
 
+- For Spark 3.1 - http://docs.h2o.ai/sparkling-water/3.1/latest-stable/doc/rsparkling.html
 - For Spark 3.0 - http://docs.h2o.ai/sparkling-water/3.0/latest-stable/doc/rsparkling.html
 - For Spark 2.4 - http://docs.h2o.ai/sparkling-water/2.4/latest-stable/doc/rsparkling.html
 - For Spark 2.3 - http://docs.h2o.ai/sparkling-water/2.3/latest-stable/doc/rsparkling.html


### PR DESCRIPTION
* Add Spark 3.1 required gradle properties and change default Spark version
* update documentation links
* Use `ZoneId.systemDefault` instead of `DateTimeUtils.defaultTimeZone.getID` (see [commit in spark repository](https://github.com/apache/spark/commit/17a5007fd8b9249593a703ba7659847ec09be2e8))