### PR TITLE
[SW-2538] The getGridModelsMetrics() and getGridModelsParams() Methods Do Not Name Columns Correctly

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OGridSearch.scala
@@ -225,27 +225,28 @@ class H2OGridSearch(override val uid: String)
     val hyperParamNames = getHyperParameters().keySet().asScala.toSeq
     val h2oToSwParamMap = getAlgo().getSWtoH2OParamNameMap().map(_.swap)
     val algoName = SupportedAlgos.getEnumValue(getAlgo()).get.toString()
-    val rowValues = gridModels.zip(gridModels.map(_.uid)).map {
-      case (model, id) =>
-        val outputParams = extractParamsToShow(algoName, model, hyperParamNames, h2oToSwParamMap)
-        Row(Seq(id) ++ outputParams.values: _*)
-    }
-    val colNames = gridModels.headOption
+    val columnNames = gridModels.headOption
       .map { model =>
         val outputParams = extractParamsToShow(algoName, model, hyperParamNames, h2oToSwParamMap)
-        outputParams.keys.map(name => StructField(name, StringType, nullable = false)).toList
+        outputParams.keys.toSeq
       }
-      .getOrElse(List.empty)
-    val schema = StructType(List(StructField("MOJO Model ID", StringType, nullable = false)) ++ colNames)
+      .getOrElse(Seq.empty)
+    val rowValues = gridModels.map { model =>
+      val outputParams = extractParamsToShow(algoName, model, hyperParamNames, h2oToSwParamMap)
+      Row(Seq(model.uid) ++ columnNames.map(outputParams): _*)
+    }
+
+    val columns = columnNames.map(StructField(_, StringType, nullable = false))
+    val schema = StructType(List(StructField("MOJO Model ID", StringType, nullable = false)) ++ columns)
     val spark = SparkSessionUtils.active
     spark.createDataFrame(spark.sparkContext.parallelize(rowValues), schema)
   }
 
   def getGridModelsMetrics(): DataFrame = {
     ensureGridSearchIsFitted()
-    val columnNames = gridModels.headOption.map(_.getCurrentMetrics().keys).getOrElse(Set.empty).toSeq
-    val rowValues = gridModels.zip(gridModels.map(_.uid)).map {
-      case (model, id) => Row(Seq(id) ++ columnNames.map(model.getCurrentMetrics()): _*)
+    val columnNames = gridModels.headOption.map(_.getCurrentMetrics().keys.toSeq).getOrElse(Seq.empty)
+    val rowValues = gridModels.map { model =>
+      Row(Seq(model.uid) ++ columnNames.map(model.getCurrentMetrics()): _*)
     }
 
     val columns = columnNames.map(StructField(_, DoubleType, nullable = false))

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/H2OGridSearchTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/H2OGridSearchTestSuite.scala
@@ -17,6 +17,7 @@
 
 package ai.h2o.sparkling.ml.algos
 
+import ai.h2o.sparkling.api.generation.common.IgnoredParameters
 import ai.h2o.sparkling.ml.params.AlgoParam
 import ai.h2o.sparkling.{SharedH2OTestContext, TestUtils}
 import hex.Model
@@ -263,7 +264,7 @@ class H2OGridSearchTestSuite extends FunSuite with Matchers with SharedH2OTestCo
     loadedModel.transform(data).count()
   }
 
-  test("The first row of the result produced by getGridModelsMetrics() method is the same as model's current metrics") {
+  test("The first row returned by getGridModelsMetrics() method is the same as current metrics of the best model") {
     val drf = new H2ODRF()
       .setFeaturesCols(Array("AGE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON"))
       .setLabelCol("CAPSULE")
@@ -281,11 +282,36 @@ class H2OGridSearchTestSuite extends FunSuite with Matchers with SharedH2OTestCo
     val model = search.fit(dataset)
     val expectedMetrics = model.getCurrentMetrics()
 
-    println(model.getCurrentMetrics())
-
     val gridModelMetrics = search.getGridModelsMetrics().drop("MOJO Model ID")
     val modelMetricsFromGrid = gridModelMetrics.columns.zip(gridModelMetrics.head().toSeq).toMap
 
     modelMetricsFromGrid shouldEqual expectedMetrics
+  }
+
+  test("The first row returned by getGridModelsParams() method is the same as training params of the best model") {
+    val drf = new H2ODRF().setLabelCol("AGE")
+    val hyperParams: mutable.HashMap[String, Array[AnyRef]] = mutable.HashMap()
+    hyperParams += "ntrees" -> Array(10, 30).map(_.asInstanceOf[AnyRef])
+    hyperParams += "seed" -> Array(1, 2).map(_.asInstanceOf[AnyRef])
+    hyperParams += "mtries" -> Array(-1, -2).map(_.asInstanceOf[AnyRef])
+    hyperParams += "maxDepth" -> Array(5, 10).map(_.asInstanceOf[AnyRef])
+    hyperParams += "nbins" -> Array(5, 15).map(_.asInstanceOf[AnyRef])
+
+    val grid = new H2OGridSearch()
+      .setHyperParameters(hyperParams)
+      .setAlgo(drf)
+
+    val model = grid.fit(dataset)
+    val h2oToSwParamMap = grid.getAlgo().getSWtoH2OParamNameMap().map(_.swap)
+    val expectedParams = model
+      .getTrainingParams()
+      .filter {
+        case (key, _) => !IgnoredParameters.all("drf").contains(key) && hyperParams.contains(h2oToSwParamMap(key))
+      }
+
+    val df = grid.getGridModelsParams().drop("MOJO Model ID")
+    val paramsFromGrid = df.columns.zip(df.head().toSeq).toMap
+
+    paramsFromGrid shouldEqual expectedParams
   }
 }

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/algos/H2OGridSearchTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/algos/H2OGridSearchTestSuite.scala
@@ -263,4 +263,29 @@ class H2OGridSearchTestSuite extends FunSuite with Matchers with SharedH2OTestCo
     loadedModel.transform(data).count()
   }
 
+  test("The first row of the result produced by getGridModelsMetrics() method is the same as model's current metrics") {
+    val drf = new H2ODRF()
+      .setFeaturesCols(Array("AGE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON"))
+      .setLabelCol("CAPSULE")
+      .setColumnsToCategorical(Array("RACE", "DPROS", "DCAPS", "GLEASON", "CAPSULE"))
+      .setSplitRatio(0.8)
+      .setNfolds(4)
+
+    val hyperParams = Map("ntrees" -> Array(2, 5).map(_.asInstanceOf[AnyRef]))
+
+    val search = new H2OGridSearch()
+      .setHyperParameters(hyperParams)
+      .setAlgo(drf)
+      .setStrategy("RandomDiscrete")
+
+    val model = search.fit(dataset)
+    val expectedMetrics = model.getCurrentMetrics()
+
+    println(model.getCurrentMetrics())
+
+    val gridModelMetrics = search.getGridModelsMetrics().drop("MOJO Model ID")
+    val modelMetricsFromGrid = gridModelMetrics.columns.zip(gridModelMetrics.head().toSeq).toMap
+
+    modelMetricsFromGrid shouldEqual expectedMetrics
+  }
 }


### PR DESCRIPTION
jira: https://h2oai.atlassian.net/jira/software/c/projects/SW/issues
issue for getGridModelsMetrics(): https://github.com/h2oai/sparkling-water/issues/2468

I've noticed getGridModelsParams() has the same problem while fixing getGridModelsMetrics().