### PR TITLE
[SW-2539] Disable SSL Certificate Verification in Python Client and Spark Instances Separately

### DIFF
--- a/core/src/integTest/scala/ai/h2o/sparkling/H2OContextFlowSSLTestSuite.scala
+++ b/core/src/integTest/scala/ai/h2o/sparkling/H2OContextFlowSSLTestSuite.scala
@@ -116,6 +116,7 @@ abstract class H2OContextFlowSSLTestSuite_CertificateVerificationDisabledBase(ce
       .set("spark.ext.h2o.jks.pass", "h2oh2o")
       .set("spark.ext.h2o.jks.alias", "h2o")
       .set("spark.ext.h2o.verify_ssl_certificates", false.toString)
+      .set("spark.ext.h2o.internal.rest.verify_ssl_certificates", false.toString)
 }
 
 @RunWith(classOf[JUnitRunner])
@@ -139,7 +140,7 @@ class H2OContextFlowSSLTestSuite_CACertificateInTrustStore_SignedByFake extends 
       .set("spark.ext.h2o.jks", certificatePath)
       .set("spark.ext.h2o.jks.pass", "h2oh2o")
       .set("spark.ext.h2o.jks.alias", "h2o")
-      .set("spark.ext.h2o.verify_ssl_hostnames", false.toString)
+      .set("spark.ext.h2o.internal.rest.verify_ssl_hostnames", false.toString)
       .set("spark.executor.extraJavaOptions", s"-Djavax.net.ssl.trustStore=$caCertificatePath")
 }
 
@@ -155,7 +156,7 @@ abstract class H2OContextFlowSSLTestSuite_CertificateVerificationEnabledBase(cer
       .set("spark.ext.h2o.jks", certificatePath)
       .set("spark.ext.h2o.jks.pass", "h2oh2o")
       .set("spark.ext.h2o.jks.alias", "h2o")
-      .set("spark.ext.h2o.verify_ssl_hostnames", false.toString)
+      .set("spark.ext.h2o.internal.rest.verify_ssl_hostnames", false.toString)
 
     intercept[NoSuchElementException] { // No reference to H2O cluster.
       H2OContext.getOrCreate(conf)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -132,8 +132,15 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def verifySslCertificates: Boolean =
     sparkConf.getBoolean(PROP_VERIFY_SSL_CERTIFICATES._1, PROP_VERIFY_SSL_CERTIFICATES._2)
 
-  def verifySslHostnames: Boolean =
-    sparkConf.getBoolean(PROP_VERIFY_SSL_HOSTNAMES._1, PROP_VERIFY_SSL_HOSTNAMES._2)
+  def isSslHostnameVerificationInInternalRestConnectionsEnabled: Boolean =
+    sparkConf.getBoolean(
+      PROP_SSL_HOSTNAME_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS._1,
+      PROP_SSL_HOSTNAME_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS._2)
+
+  def isSslCertificateVerificationInInternalRestConnectionsEnabled: Boolean =
+    sparkConf.getBoolean(
+      PROP_SSL_CERTIFICATE_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS._1,
+      PROP_SSL_CERTIFICATE_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS._2)
 
   def isKerberizedHiveEnabled: Boolean =
     sparkConf.getBoolean(PROP_KERBERIZED_HIVE_ENABLED._1, PROP_KERBERIZED_HIVE_ENABLED._2)
@@ -286,7 +293,17 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def setVerifySslCertificates(verify: Boolean): H2OConf = set(PROP_VERIFY_SSL_CERTIFICATES._1, verify)
 
-  def setVerifySslHostnames(verify: Boolean): H2OConf = set(PROP_VERIFY_SSL_HOSTNAMES._1, verify)
+  def setSslHostnameVerificationInInternalRestConnectionsEnabled(): H2OConf =
+    set(PROP_SSL_HOSTNAME_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS._1, true)
+
+  def setSslHostnameVerificationInInternalRestConnectionsDisabled(): H2OConf =
+    set(PROP_SSL_HOSTNAME_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS._1, false)
+
+  def setSslCertificateVerificationInInternalRestConnectionsEnabled(): H2OConf =
+    set(PROP_SSL_CERTIFICATE_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS._1, true)
+
+  def setSslCertificateVerificationInInternalRestConnectionsDisabled(): H2OConf =
+    set(PROP_SSL_CERTIFICATE_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS._1, false)
 
   def setKerberizedHiveEnabled(): H2OConf = set(PROP_KERBERIZED_HIVE_ENABLED._1, true)
 
@@ -585,15 +602,24 @@ object SharedBackendConf {
     "spark.ext.h2o.verify_ssl_certificates",
     true,
     "setVerifySslCertificates(Boolean)",
+    """If the property is enabled, Pysparkling or RSparkling client will verify certificates when connecting
+      |Sparkling Water Flow UI.""".stripMargin)
+
+  val PROP_SSL_CERTIFICATE_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS: BooleanOption = (
+    "spark.ext.h2o.internal.rest.verify_ssl_certificates",
+    true,
+    """setSslCertificateVerificationInInternalRestConnectionsEnabled()
+      |setSslCertificateVerificationInInternalRestConnectionsDisabled()""",
     """If the property is enabled, Sparkling Water will verify ssl certificates during establishing secured http connections
       |to one of H2O nodes. Such connections are utilized for delegation of Flow UI calls to H2O leader node or
       |during data exchange between Spark executors and H2O nodes. If the property is disabled, hostname verification is
       |disabled as well.""".stripMargin)
 
-  val PROP_VERIFY_SSL_HOSTNAMES: BooleanOption = (
-    "spark.ext.h2o.verify_ssl_hostnames",
+  val PROP_SSL_HOSTNAME_VERIFICATION_IN_INTERNAL_REST_CONNECTIONS: BooleanOption = (
+    "spark.ext.h2o.internal.rest.verify_ssl_hostnames",
     true,
-    "setVerifySslHostnames(Boolean)",
+    """setSslHostnameVerificationInInternalRestConnectionsEnabled()
+      |setSslHostnameVerificationInInternalRestConnectionsDisabled()""".stripMargin,
     """If the property is enabled, Sparkling Water will verify a hostname during establishing of secured http connections
       |to one of H2O nodes. Such connections are utilized for delegation of Flow UI calls to H2O leader node or
       |during data exchange between Spark executors and H2O nodes.""".stripMargin)

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/RestCommunication.scala
@@ -229,20 +229,22 @@ trait RestCommunication extends Logging with RestEncodingUtils {
     }
   }
 
-  private def urlToString(url: URL) = s"${url.getHost}:${url.getPort}"
+  private def urlToString(url: URL) = s"${url.getProtocol}://${url.getHost}:${url.getPort}"
 
   private def openUrlConnection(url: URL, conf: H2OConf): HttpURLConnection = {
     val connection = url.openConnection()
     if (connection.isInstanceOf[HttpsURLConnection]) {
       val secureConnection = connection.asInstanceOf[HttpsURLConnection]
 
-      if (!conf.verifySslCertificates) {
+      if (!conf.isSslCertificateVerificationInInternalRestConnectionsEnabled) {
         disableCertificateVerification(secureConnection)
       } else if (conf.autoFlowSsl) {
         setSelfSignedCertificateVerification(secureConnection, conf)
       }
 
-      if (!conf.verifySslCertificates || !conf.verifySslHostnames || conf.autoFlowSsl) {
+      if (!conf.isSslHostnameVerificationInInternalRestConnectionsEnabled ||
+          !conf.isSslCertificateVerificationInInternalRestConnectionsEnabled ||
+          conf.autoFlowSsl) {
         disableHostnameVerification(secureConnection)
       }
 

--- a/doc/src/site/sphinx/tutorials/secured_flow.rst
+++ b/doc/src/site/sphinx/tutorials/secured_flow.rst
@@ -24,7 +24,7 @@ In order to use https correctly, the following two options need to be specified:
 
 If the certificate doesn't cover all hostnames of all H2O nodes and contains just hostname of Spark driver where H2O FLOW UI
 lives, hostname verification on Spark instances (driver + executor) for connections to H2O nodes must be disabled by setting
-the property ``spark.ext.h2o.verify_ssl_hostnames`` to ``false``.
+the property ``spark.ext.h2o.internal.rest.verify_ssl_hostnames`` to ``false``.
 
 .. content-tabs::
 
@@ -91,9 +91,8 @@ the property ``spark.ext.h2o.verify_ssl_hostnames`` to ``false``.
             hc <- H2OContext.getOrCreate(conf)
 
 
-In case your certificates are self-signed, the connection to the H2O cluster will fail due to the security
-limitations. In this case, you can skip the certificates verification
-by calling ``setVerifySslCertificates`` on ``H2OConf`` as:
+In case your certificates are self-signed or signed by an untrusted CA, the connection to the H2O cluster will fail due to
+the security limitations. In this case, you can skip the certificates verification as follows:
 
 .. content-tabs::
 
@@ -102,7 +101,7 @@ by calling ``setVerifySslCertificates`` on ``H2OConf`` as:
 
         .. code:: scala
 
-            val conf = new H2OConf().setVerifySslCertificates(false)
+            val conf = new H2OConf().setSslHostnameVerificationInInternalRestConnectionsDisabled()
             val hc = H2OContext.getOrCreate(conf)
 
     .. tab-container:: Python
@@ -110,7 +109,9 @@ by calling ``setVerifySslCertificates`` on ``H2OConf`` as:
 
         .. code:: python
 
-            conf = H2OConf().setVerifySslCertificates(False)
+            conf = H2OConf()
+            conf.setSslHostnameVerificationInInternalRestConnectionsDisabled()
+            conf.setVerifySslCertificates(False)
             hc = H2OContext.getOrCreate(conf)
 
     .. tab-container:: R
@@ -118,7 +119,9 @@ by calling ``setVerifySslCertificates`` on ``H2OConf`` as:
 
         .. code:: r
 
-            conf <- H2OConf()$setVerifySslCertificates(FALSE)
+            conf <- H2OConf()
+            conf$setSslHostnameVerificationInInternalRestConnectionsDisabled()
+            conf$setVerifySslCertificates(FALSE)
             hc <- H2OContext.getOrCreate(conf)
 
 Generate the files automatically
@@ -138,7 +141,7 @@ certificates are created.
 
         .. code:: shell
 
-            bin/sparkling-shell --conf "spark.ext.h2o.auto.flow.ssl=true" --conf "spark.ext.h2o.verify_ssl_certificates=false"
+            bin/sparkling-shell --conf "spark.ext.h2o.auto.flow.ssl=true"
 
         and when you have the shell running, start ``H2OContext`` as:
 
@@ -153,7 +156,7 @@ certificates are created.
         .. code:: scala
 
             import ai.h2o.sparkling._
-            val conf = new H2OConf().setAutoFlowSslEnabled().setVerifySslCertificates(false)
+            val conf = new H2OConf().setAutoFlowSslEnabled()
             val hc = H2OContext.getOrCreate(conf)
 
 


### PR DESCRIPTION
This PR introduces new configuration option `spark.ext.h2o.internal.rest.verify_ssl_certificates` and renames the unreleased property `spark.ext.h2o.verify_ssl_hostnames` to `spark.ext.h2o.internal.rest.verify_ssl_hostnames`.