### PR TITLE
[SW-2535][FOLLOWUP] H2OContextFlowSSLTestSuite Should Catch H2OClusterNotReachableException When Running External Backend

### DIFF
--- a/core/src/integTest/scala/ai/h2o/sparkling/H2OContextFlowSSLTestSuite.scala
+++ b/core/src/integTest/scala/ai/h2o/sparkling/H2OContextFlowSSLTestSuite.scala
@@ -159,7 +159,7 @@ abstract class H2OContextFlowSSLTestSuite_CertificateVerificationEnabledBase(cer
       .set("spark.ext.h2o.internal.rest.verify_ssl_hostnames", false.toString)
       .setClusterSize(1)
 
-    if(conf.runsInInternalClusterMode) {
+    if (conf.runsInInternalClusterMode) {
       intercept[NoSuchElementException] { // No reference to H2O cluster.
         H2OContext.getOrCreate(conf)
       }


### PR DESCRIPTION
The error in tests:
```
ai.h2o.sparkling.H2OContextFlowSSLTestSuite_CertificateVerificationEnabled_SignedByFake > H2OContext won't start since the signedByFake.jks won't be verified FAILED

[2021-03-17T16:23:53.779Z]     org.scalatest.exceptions.TestFailedException: Expected exception java.util.NoSuchElementException to be thrown, but ai.h2o.sparkling.backend.exceptions.H2OClusterNotReachableException was thrown

[2021-03-17T16:23:53.779Z]         at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:530)

[2021-03-17T16:23:53.779Z]         at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:529)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuite.newAssertionFailedException(FunSuite.scala:1560)

[2021-03-17T16:23:53.779Z]         at org.scalatest.Assertions.intercept(Assertions.scala:814)

[2021-03-17T16:23:53.779Z]         at org.scalatest.Assertions.intercept$(Assertions.scala:804)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuite.intercept(FunSuite.scala:1560)

[2021-03-17T16:23:53.779Z]         at ai.h2o.sparkling.H2OContextFlowSSLTestSuite_CertificateVerificationEnabledBase.$anonfun$new$8(H2OContextFlowSSLTestSuite.scala:162)

[2021-03-17T16:23:53.779Z]         at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)

[2021-03-17T16:23:53.779Z]         at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)

[2021-03-17T16:23:53.779Z]         at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)

[2021-03-17T16:23:53.779Z]         at org.scalatest.Transformer.apply(Transformer.scala:22)

[2021-03-17T16:23:53.779Z]         at org.scalatest.Transformer.apply(Transformer.scala:20)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:186)

[2021-03-17T16:23:53.779Z]         at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)

[2021-03-17T16:23:53.779Z]         at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuite.withFixture(FunSuite.scala:1560)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.invokeWithFixture$1(FunSuiteLike.scala:184)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.$anonfun$runTest$1(FunSuiteLike.scala:196)

[2021-03-17T16:23:53.779Z]         at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.runTest(FunSuiteLike.scala:196)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.runTest$(FunSuiteLike.scala:178)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuite.runTest(FunSuite.scala:1560)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.$anonfun$runTests$1(FunSuiteLike.scala:229)

[2021-03-17T16:23:53.779Z]         at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)

[2021-03-17T16:23:53.779Z]         at scala.collection.immutable.List.foreach(List.scala:392)

[2021-03-17T16:23:53.779Z]         at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)

[2021-03-17T16:23:53.779Z]         at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)

[2021-03-17T16:23:53.779Z]         at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.runTests(FunSuiteLike.scala:229)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.runTests$(FunSuiteLike.scala:228)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuite.runTests(FunSuite.scala:1560)

[2021-03-17T16:23:53.779Z]         at org.scalatest.Suite.run(Suite.scala:1124)

[2021-03-17T16:23:53.779Z]         at org.scalatest.Suite.run$(Suite.scala:1106)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1560)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.$anonfun$run$1(FunSuiteLike.scala:233)

[2021-03-17T16:23:53.779Z]         at org.scalatest.SuperEngine.runImpl(Engine.scala:518)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.run(FunSuiteLike.scala:233)

[2021-03-17T16:23:53.779Z]         at org.scalatest.FunSuiteLike.run$(FunSuiteLike.scala:232)

[2021-03-17T16:23:53.779Z]         at ai.h2o.sparkling.H2OContextFlowSSLTestSuite_CertificateVerificationEnabledBase.org$scalatest$BeforeAndAfterAll$$super$run(H2OContextFlowSSLTestSuite.scala:147)

[2021-03-17T16:23:53.779Z]         at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)

[2021-03-17T16:23:53.779Z]         at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)

[2021-03-17T16:23:53.779Z]         at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)

[2021-03-17T16:23:53.779Z]         at ai.h2o.sparkling.H2OContextFlowSSLTestSuite_CertificateVerificationEnabledBase.run(H2OContextFlowSSLTestSuite.scala:147)

[2021-03-17T16:23:53.779Z]         at org.scalatest.junit.JUnitRunner.run(JUnitRunner.scala:100)

[2021-03-17T16:23:53.779Z]         at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)

[2021-03-17T16:23:53.779Z]         at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)

[2021-03-17T16:23:53.779Z]         at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)

[2021-03-17T16:23:53.779Z]         at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)

[2021-03-17T16:23:53.779Z]         at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)

[2021-03-17T16:23:53.779Z]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

[2021-03-17T16:23:53.779Z]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)

[2021-03-17T16:23:53.779Z]         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

[2021-03-17T16:23:53.779Z]         at java.lang.reflect.Method.invoke(Method.java:498)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)

[2021-03-17T16:23:53.780Z]         at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)

[2021-03-17T16:23:53.780Z]         at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:119)

[2021-03-17T16:23:53.780Z]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

[2021-03-17T16:23:53.780Z]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)

[2021-03-17T16:23:53.780Z]         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

[2021-03-17T16:23:53.780Z]         at java.lang.reflect.Method.invoke(Method.java:498)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)

[2021-03-17T16:23:53.780Z]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)

[2021-03-17T16:23:53.780Z]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)

[2021-03-17T16:23:53.780Z]         at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)

[2021-03-17T16:23:53.780Z]         at java.lang.Thread.run(Thread.java:748)

[2021-03-17T16:23:53.780Z] 

[2021-03-17T16:23:53.780Z]         Caused by:

[2021-03-17T16:23:53.780Z]         ai.h2o.sparkling.backend.exceptions.H2OClusterNotReachableException: H2O cluster 172.17.0.2:54321 - H2OContextFlowSSLTestSuite_CertificateVerificationEnabled_SignedByFake is not reachable.

[2021-03-17T16:23:53.780Z]         H2OContext has not been created.

[2021-03-17T16:23:53.780Z]             at ai.h2o.sparkling.backend.utils.H2OContextExtensions.getAndVerifyWorkerNodes(H2OContextExtensions.scala:160)

[2021-03-17T16:23:53.780Z]             at ai.h2o.sparkling.backend.utils.H2OContextExtensions.getAndVerifyWorkerNodes$(H2OContextExtensions.scala:131)

[2021-03-17T16:23:53.780Z]             at ai.h2o.sparkling.H2OContext.getAndVerifyWorkerNodes(H2OContext.scala:65)

[2021-03-17T16:23:53.780Z]             at ai.h2o.sparkling.H2OContext.<init>(H2OContext.scala:85)

[2021-03-17T16:23:53.780Z]             at ai.h2o.sparkling.H2OContext$.getOrCreate(H2OContext.scala:470)

[2021-03-17T16:23:53.780Z]             at ai.h2o.sparkling.H2OContextFlowSSLTestSuite_CertificateVerificationEnabledBase.$anonfun$new$9(H2OContextFlowSSLTestSuite.scala:163)

[2021-03-17T16:23:53.780Z]             at org.scalatest.Assertions.intercept(Assertions.scala:807)

[2021-03-17T16:23:53.780Z]             ... 70 more

[2021-03-17T16:23:53.780Z] 

[2021-03-17T16:23:53.780Z]             Caused by:

[2021-03-17T16:23:53.780Z]             ai.h2o.sparkling.backend.exceptions.RestApiNotReachableException: H2O node https://172.17.0.2:54321 is not reachable.

[2021-03-17T16:23:53.795Z]             Please verify that you are passing ip and port of existing cluster node and the cluster

[2021-03-17T16:23:53.795Z]             is running with web enabled.

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestCommunication.throwRestApiNotReachableException(RestCommunication.scala:415)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestCommunication.readURLContent(RestCommunication.scala:372)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestCommunication.readURLContent$(RestCommunication.scala:352)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestApiUtils$.readURLContent(RestApiUtils.scala:96)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestCommunication.request(RestCommunication.scala:182)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestCommunication.request$(RestCommunication.scala:172)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestApiUtils$.request(RestApiUtils.scala:96)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestCommunication.update(RestCommunication.scala:88)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestCommunication.update$(RestCommunication.scala:81)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.RestApiUtils$.update(RestApiUtils.scala:96)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.H2OContextExtensions.lockCloud(H2OContextExtensions.scala:235)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.H2OContextExtensions.tryToLockCloud(H2OContextExtensions.scala:122)

[2021-03-17T16:23:53.795Z]                 at ai.h2o.sparkling.backend.utils.H2OContextExtensions.getAndVerifyWorkerNodes(H2OContextExtensions.scala:137)

[2021-03-17T16:23:53.795Z]                 ... 76 more

[2021-03-17T16:23:53.795Z] 

[2021-03-17T16:23:53.795Z]                 Caused by:

[2021-03-17T16:23:53.795Z]                 javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.Alerts.getSSLException(Alerts.java:192)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.SSLSocketImpl.fatal(SSLSocketImpl.java:1964)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:328)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:322)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1614)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.ClientHandshaker.processMessage(ClientHandshaker.java:216)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.Handshaker.processLoop(Handshaker.java:1052)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.Handshaker.process_record(Handshaker.java:987)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:1072)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1385)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1413)

[2021-03-17T16:23:53.795Z]                     at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1397)

[2021-03-17T16:23:53.795Z]                     at sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:559)

[2021-03-17T16:23:53.795Z]                     at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:185)

[2021-03-17T16:23:53.795Z]                     at sun.net.www.protocol.http.HttpURLConnection.getOutputStream0(HttpURLConnection.java:1334)

[2021-03-17T16:23:53.795Z]                     at sun.net.www.protocol.http.HttpURLConnection.getOutputStream(HttpURLConnection.java:1309)

[2021-03-17T16:23:53.795Z]                     at sun.net.www.protocol.https.HttpsURLConnectionImpl.getOutputStream(HttpsURLConnectionImpl.java:259)

[2021-03-17T16:23:53.795Z]                     at ai.h2o.sparkling.backend.utils.RestCommunication.setHeaders(RestCommunication.scala:329)

[2021-03-17T16:23:53.795Z]                     at ai.h2o.sparkling.backend.utils.RestCommunication.readURLContent(RestCommunication.scala:367)

[2021-03-17T16:23:53.795Z]                     ... 87 more

[2021-03-17T16:23:53.795Z] 

[2021-03-17T16:23:53.795Z]                     Caused by:

[2021-03-17T16:23:53.795Z]                     sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target

[2021-03-17T16:23:53.795Z]                         at sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:397)

[2021-03-17T16:23:53.795Z]                         at sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:302)

[2021-03-17T16:23:53.795Z]                         at sun.security.validator.Validator.validate(Validator.java:260)

[2021-03-17T16:23:53.795Z]                         at sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManagerImpl.java:324)

[2021-03-17T16:23:53.795Z]                         at sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:229)

[2021-03-17T16:23:53.795Z]                         at sun.security.ssl.X509TrustManagerImpl.checkServerTrusted(X509TrustManagerImpl.java:124)

[2021-03-17T16:23:53.795Z]                         at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1596)

[2021-03-17T16:23:53.795Z]                         ... 101 more

[2021-03-17T16:23:53.795Z] 

[2021-03-17T16:23:53.795Z]                         Caused by:

[2021-03-17T16:23:53.795Z]                         sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target

[2021-03-17T16:23:53.795Z]                             at sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:141)

[2021-03-17T16:23:53.795Z]                             at sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:126)

[2021-03-17T16:23:53.795Z]                             at java.security.cert.CertPathBuilder.build(CertPathBuilder.java:280)

[2021-03-17T16:23:53.795Z]                             at sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:392)

[2021-03-17T16:23:53.795Z]                             ... 107 more


```