### PR TITLE
 [HOTFIX] setuptools Cannot Be Found during Publishing Artifacts to PyPi

### DIFF
--- a/ci/Jenkinsfile-release
+++ b/ci/Jenkinsfile-release
@@ -353,6 +353,7 @@ def publishToPipy() {
                         params.commons.withPipyCredentials {
                             sh """
                                . /envs/h2o_env_python3.6/bin/activate
+                               pip install -U setuptools
                                python setup.py sdist
                                twine upload dist/* -u $PIPY_USERNAME -p $PIPY_PASSWORD
                                """


### PR DESCRIPTION
```
[2021-03-18T15:06:17.814Z] + . /envs/****_env_python3.6/bin/activate

[2021-03-18T15:06:17.814Z] + [  = /home/jenkins/workspace/RELEASE_rel-3.32-spark-3.0/py/build/pkg@tmp/durable-e5f03771/script.sh ]

[2021-03-18T15:06:17.814Z] + deactivate nondestructive

[2021-03-18T15:06:17.814Z] + unset -f pydoc

[2021-03-18T15:06:17.814Z] + [ -z  ]

[2021-03-18T15:06:17.814Z] + [ -z  ]

[2021-03-18T15:06:17.814Z] + [ -n  ]

[2021-03-18T15:06:17.814Z] + [ -n  ]

[2021-03-18T15:06:17.814Z] + [ -z  ]

[2021-03-18T15:06:17.814Z] + unset VIRTUAL_ENV

[2021-03-18T15:06:17.814Z] + [ ! nondestructive = nondestructive ]

[2021-03-18T15:06:17.814Z] + VIRTUAL_ENV=/envs/****_env_python3.6

[2021-03-18T15:06:17.814Z] + [  = cygwin ]

[2021-03-18T15:06:17.814Z] + [  = msys ]

[2021-03-18T15:06:17.814Z] + export VIRTUAL_ENV

[2021-03-18T15:06:17.814Z] + _OLD_VIRTUAL_PATH=/home/jenkins/miniconda/bin:/usr/local/R/current/bin/:/usr/lib/jvm/java-8-oracle/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

[2021-03-18T15:06:17.814Z] + PATH=/envs/****_env_python3.6/bin:/home/jenkins/miniconda/bin:/usr/local/R/current/bin/:/usr/lib/jvm/java-8-oracle/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

[2021-03-18T15:06:17.814Z] + export PATH

[2021-03-18T15:06:17.814Z] + [ -z  ]

[2021-03-18T15:06:17.814Z] + [ -z  ]

[2021-03-18T15:06:17.814Z] + _OLD_VIRTUAL_PS1=$ 

[2021-03-18T15:06:17.814Z] + [ x != x ]

[2021-03-18T15:06:17.814Z] + basename /envs/****_env_python3.6

[2021-03-18T15:06:17.814Z] + PS1=(****_env_python3.6) $ 

[2021-03-18T15:06:17.814Z] + export PS1

[2021-03-18T15:06:17.814Z] + alias pydoc

[2021-03-18T15:06:17.814Z] + true

[2021-03-18T15:06:17.814Z] + [ -n  ]

[2021-03-18T15:06:17.814Z] + [ -n  ]

[2021-03-18T15:06:17.814Z] + python setup.py sdist

[2021-03-18T15:06:17.814Z] Traceback (most recent call last):

[2021-03-18T15:06:17.814Z]   File "setup.py", line 5, in <module>

[2021-03-18T15:06:17.814Z]     from setuptools import setup, find_packages

[2021-03-18T15:06:17.814Z] ModuleNotFoundError: No module named 'setuptools'
```

I've tested locally in docker container that upgrade of setuptools helps