### PR TITLE
Revert "[SW-2340] Remove deprecated mapperXmx getter an setter in favor of externalH2OMemory (#2367)"

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -131,7 +131,8 @@ object H2OConf extends Logging {
     "spark.ext.h2o.node.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.client.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.node.extra" -> "spark.ext.h2o.extra.properties",
-    "spark.ext.h2o.client.extra" -> "spark.ext.h2o.extra.properties")
+    "spark.ext.h2o.client.extra" -> "spark.ext.h2o.extra.properties",
+    "spark.ext.h2o.hadoop.memory" -> "spark.ext.h2o.external.memory")
 
   private def checkDeprecatedOptions(sparkConf: SparkConf): Unit = {
     deprecatedOptions.foreach {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/ExternalBackendConf.scala
@@ -49,6 +49,9 @@ trait ExternalBackendConf extends SharedBackendConf with Logging with ExternalBa
 
   def clusterInfoFile: Option[String] = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_INFO_FILE._1)
 
+  @DeprecatedMethod("externalMemory", "3.34")
+  def mapperXmx: String = externalMemory
+
   def externalMemory: String = sparkConf.get(PROP_EXTERNAL_MEMORY._1, PROP_EXTERNAL_MEMORY._2)
 
   def HDFSOutputDir: Option[String] = sparkConf.getOption(PROP_EXTERNAL_CLUSTER_HDFS_DIR._1)
@@ -139,6 +142,9 @@ trait ExternalBackendConf extends SharedBackendConf with Logging with ExternalBa
     set(PROP_EXTERNAL_CLUSTER_START_TIMEOUT._1, clusterStartTimeout.toString)
 
   def setClusterInfoFile(path: String): H2OConf = set(PROP_EXTERNAL_CLUSTER_INFO_FILE._1, path)
+
+  @DeprecatedMethod("setExternalMemory", "3.34")
+  def setMapperXmx(mem: String): H2OConf = setExternalMemory(mem)
 
   def setExternalMemory(memory: String): H2OConf = set(PROP_EXTERNAL_MEMORY._1, memory)
 


### PR DESCRIPTION
This reverts commit 17f6f954 in rel-3.32.1 (forked from master)