### PR TITLE
Revert "[SW-2245] Remove deprecated setClientExtraProperties, setNodeExtraProperties, clientExtraProperties, nodeExtraProperties (#2373)"

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -109,6 +109,9 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def mojoDestroyTimeout: Int = sparkConf.getInt(PROP_MOJO_DESTROY_TIMEOUT._1, PROP_MOJO_DESTROY_TIMEOUT._2)
 
+  @DeprecatedMethod("extraProperties", "3.34")
+  def nodeExtraProperties: Option[String] = extraProperties
+
   def extraProperties: Option[String] = sparkConf.getOption(PROP_EXTRA_PROPERTIES._1)
 
   def flowExtraHttpHeaders: Option[String] = sparkConf.getOption(PROP_FLOW_EXTRA_HTTP_HEADERS._1)
@@ -142,6 +145,9 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def clientNetworkMask: Option[String] = sparkConf.getOption(PROP_CLIENT_NETWORK_MASK._1)
 
   def clientFlowBaseurlOverride: Option[String] = sparkConf.getOption(PROP_CLIENT_FLOW_BASEURL_OVERRIDE._1)
+
+  @DeprecatedMethod("extraProperties", "3.34")
+  def clientExtraProperties: Option[String] = extraProperties
 
   def runsInExternalClusterMode: Boolean = backendClusterMode.toLowerCase() == BACKEND_MODE_EXTERNAL
 
@@ -282,6 +288,9 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def setMojoDestroyTimeout(timeoutInMilliseconds: Int): H2OConf =
     set(PROP_MOJO_DESTROY_TIMEOUT._1, timeoutInMilliseconds.toString)
 
+  @DeprecatedMethod("setExtraProperties", "3.34")
+  def setNodeExtraProperties(extraProperties: String): H2OConf = setExtraProperties(extraProperties)
+
   def setExtraProperties(extraProperties: String): H2OConf = set(PROP_EXTRA_PROPERTIES._1, extraProperties)
 
   def setFlowExtraHttpHeaders(headers: String): H2OConf = { // R mapping
@@ -332,6 +341,9 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def setClientFlowBaseurlOverride(baseUrl: String): H2OConf = set(PROP_CLIENT_FLOW_BASEURL_OVERRIDE._1, baseUrl)
 
   def setClientCheckRetryTimeout(timeout: Int): H2OConf = set(PROP_EXTERNAL_CLIENT_RETRY_TIMEOUT._1, timeout.toString)
+
+  @DeprecatedMethod("setExtraProperties", "3.34")
+  def setClientExtraProperties(extraProperties: String): H2OConf = setExtraProperties(extraProperties)
 
   def setVerifySslCertificates(verify: Boolean): H2OConf = set(PROP_VERIFY_SSL_CERTIFICATES._1, verify)
 


### PR DESCRIPTION
This reverts commit 44c96ef3 in rel-3.32.1 (forked from master)