### PR TITLE
Revert "[SW-2232] Remove deprecated setH2OClientLogLevel, setH2ONodeLogLevel, h2oClientLogLevel, h2oNodeLogLevel (#2369)"

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -123,6 +123,11 @@ object H2OConf extends Logging {
   private val deprecatedOptions = Map[String, String](
     "spark.ext.h2o.node.iced.dir" -> "spark.ext.h2o.iced.dir",
     "spark.ext.h2o.client.iced.dir" -> "spark.ext.h2o.iced.dir",
+    "spark.ext.h2o.client.log.level" -> "spark.ext.h2o.log.level",
+    "spark.ext.h2o.node.log.level" -> "spark.ext.h2o.log.level",
+    "spark.ext.h2o.client.flow.dir" -> "spark.ext.h2o.flow.dir",
+    "spark.ext.h2o.client.port.base" -> "spark.ext.h2o.base.port",
+    "spark.ext.h2o.node.port.base" -> "spark.ext.h2o.base.port",
     "spark.ext.h2o.node.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.client.log.dir" -> "spark.ext.h2o.log.dir",
     "spark.ext.h2o.node.extra" -> "spark.ext.h2o.extra.properties",

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -73,6 +73,9 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def autoFlowSsl: Boolean = sparkConf.getBoolean(PROP_AUTO_SSL_FLOW._1, PROP_AUTO_SSL_FLOW._2)
 
+  @DeprecatedMethod("logLevel", "3.34")
+  def h2oNodeLogLevel: String = logLevel
+
   def logLevel: String = sparkConf.get(PROP_LOG_LEVEL._1, PROP_LOG_LEVEL._2)
 
   def logDir: Option[String] = sparkConf.getOption(PROP_LOG_DIR._1)
@@ -117,8 +120,14 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   @DeprecatedMethod("icedDir", "3.34")
   def clientIcedDir: Option[String] = icedDir
 
+  @DeprecatedMethod("logLevel", "3.34")
+  def h2oClientLogLevel: String = logLevel
+
   @DeprecatedMethod("logDir", "3.34")
   def h2oClientLogDir: Option[String] = logDir
+
+  @DeprecatedMethod("basePort", "3.34")
+  def clientBasePort: Int = basePort
 
   def clientWebPort: Int = sparkConf.getInt(PROP_CLIENT_WEB_PORT._1, PROP_CLIENT_WEB_PORT._2)
 
@@ -230,6 +239,9 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def setAutoFlowSslDisabled(): H2OConf = set(PROP_AUTO_SSL_FLOW._1, value = false)
 
+  @DeprecatedMethod("setLogLevel", "3.34")
+  def setH2ONodeLogLevel(level: String): H2OConf = setLogLevel(level)
+
   def setLogLevel(level: String): H2OConf = set(PROP_LOG_LEVEL._1, level)
 
   def setLogDir(dir: String): H2OConf = set(PROP_LOG_DIR._1, dir)
@@ -288,8 +300,14 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   @DeprecatedMethod("setIcedDir", "3.34")
   def setClientIcedDir(icedDir: String): H2OConf = setIcedDir(icedDir)
 
+  @DeprecatedMethod("setLogLevel", "3.34")
+  def setH2OClientLogLevel(level: String): H2OConf = setLogLevel(level)
+
   @DeprecatedMethod("setLogDir", "3.34")
   def setH2OClientLogDir(dir: String): H2OConf = setLogDir(dir)
+
+  @DeprecatedMethod("setBasePort", "3.34")
+  def setClientBasePort(basePort: Int): H2OConf = setBasePort(basePort)
 
   def setClientWebPort(port: Int): H2OConf = set(PROP_CLIENT_WEB_PORT._1, port.toString)
 


### PR DESCRIPTION
This reverts commit 6fa2759c in rel-3.32.1 (forked from master).