### PR TITLE
Revert "[SW-2230] Remove deprecated setClientIcedDir, setNodeIcedDir, clientIcedDir and nodeIcedDir (#2370)"

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/H2OConf.scala
@@ -120,7 +120,13 @@ object H2OConf extends Logging {
 
   def apply(sparkConf: SparkConf): H2OConf = new H2OConf(sparkConf)
 
-  private val deprecatedOptions = Map[String, String]()
+  private val deprecatedOptions = Map[String, String](
+    "spark.ext.h2o.node.iced.dir" -> "spark.ext.h2o.iced.dir",
+    "spark.ext.h2o.client.iced.dir" -> "spark.ext.h2o.iced.dir",
+    "spark.ext.h2o.node.log.dir" -> "spark.ext.h2o.log.dir",
+    "spark.ext.h2o.client.log.dir" -> "spark.ext.h2o.log.dir",
+    "spark.ext.h2o.node.extra" -> "spark.ext.h2o.extra.properties",
+    "spark.ext.h2o.client.extra" -> "spark.ext.h2o.extra.properties")
 
   private def checkDeprecatedOptions(sparkConf: SparkConf): Unit = {
     deprecatedOptions.foreach {

--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -114,6 +114,12 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
 
   def clientIp: Option[String] = sparkConf.getOption(PROP_CLIENT_IP._1)
 
+  @DeprecatedMethod("icedDir", "3.34")
+  def clientIcedDir: Option[String] = icedDir
+
+  @DeprecatedMethod("logDir", "3.34")
+  def h2oClientLogDir: Option[String] = logDir
+
   def clientWebPort: Int = sparkConf.getInt(PROP_CLIENT_WEB_PORT._1, PROP_CLIENT_WEB_PORT._2)
 
   def clientVerboseOutput: Boolean = sparkConf.getBoolean(PROP_CLIENT_VERBOSE._1, PROP_CLIENT_VERBOSE._2)
@@ -278,6 +284,12 @@ trait SharedBackendConf extends SharedBackendConfExtensions {
   def setFlowDir(dir: String): H2OConf = set(PROP_FLOW_DIR._1, dir)
 
   def setClientIp(ip: String): H2OConf = set(PROP_CLIENT_IP._1, ip)
+
+  @DeprecatedMethod("setIcedDir", "3.34")
+  def setClientIcedDir(icedDir: String): H2OConf = setIcedDir(icedDir)
+
+  @DeprecatedMethod("setLogDir", "3.34")
+  def setH2OClientLogDir(dir: String): H2OConf = setLogDir(dir)
 
   def setClientWebPort(port: Int): H2OConf = set(PROP_CLIENT_WEB_PORT._1, port.toString)
 

--- a/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
@@ -47,6 +47,9 @@ trait InternalBackendConf extends SharedBackendConf with InternalBackendConfExte
 
   def subseqTries: Int = sparkConf.getInt(PROP_SUBSEQ_TRIES._1, PROP_SUBSEQ_TRIES._2)
 
+  @DeprecatedMethod("icedDir", "3.34")
+  def nodeIcedDir: Option[String] = sparkConf.getOption(SharedBackendConf.PROP_ICED_DIR._1)
+
   def hdfsConf: Option[String] = sparkConf.getOption(PROP_HDFS_CONF._1)
 
   def spreadRddRetriesTimeout: Int =
@@ -63,6 +66,9 @@ trait InternalBackendConf extends SharedBackendConf with InternalBackendConfExte
     set(PROP_DEFAULT_CLUSTER_SIZE._1, defaultClusterSize.toString)
 
   def setSubseqTries(subseqTriesNum: Int): H2OConf = set(PROP_SUBSEQ_TRIES._1, subseqTriesNum.toString)
+
+  @DeprecatedMethod("setIcedDir", "3.34")
+  def setNodeIcedDir(dir: String): H2OConf = set(SharedBackendConf.PROP_ICED_DIR._1, dir)
 
   def setHdfsConf(path: String): H2OConf = set(PROP_HDFS_CONF._1, path)
 


### PR DESCRIPTION
This reverts commit 0d25269d in rel-3.32.1 (forked from master)