### PR TITLE
[SW-2543] Extend Deprecation of withDetailedPredictionCol to 3.36

### DIFF
--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -3,6 +3,12 @@ Migration Guide
 
 Migration guide between Sparkling Water versions.
 
+From 3.34 to 3.36
+-----------------
+
+- The methods ``getWithDetailedPredictionCol`` and ``setWithDetailedPredictionCol`` on all SW Algorithms and
+  MOJO models were removed without replacement.
+
 From 3.32.1 to 3.34
 -------------------
 
@@ -32,9 +38,6 @@ From 3.32.1 to 3.34
 
 - On ``H2OConf``, the setter ``setMapperXmx`` is replaced by ``setExternalMemory`` and the getter ``mapperXmx``
   is replaced by ``externalMemory``. Also the Spark option ``spark.ext.h2o.hadoop.memory`` is replaced by ``spark.ext.h2o.external.memory``.
-
-- The methods ``getWithDetailedPredictionCol`` and ``setWithDetailedPredictionCol`` on all SW Algorithms and
-  MOJO models were removed without replacement.
 
 - The ``withDetailedPredictionCol`` field on ``H2OMOJOSettings`` was removed without a replacement.
 

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OCommonParams.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OCommonParams.scala
@@ -85,7 +85,7 @@ trait H2OCommonParams extends H2OBaseMOJOParams with H2OAlgoParamsBase {
 
   def setDetailedPredictionCol(columnName: String): this.type = set(detailedPredictionCol, columnName)
 
-  @DeprecatedMethod(version = "3.34")
+  @DeprecatedMethod(version = "3.36")
   def setWithDetailedPredictionCol(enabled: Boolean): this.type = this
 
   def setWithContributions(enabled: Boolean): this.type = set(withContributions, enabled)

--- a/py-scoring/src/ai/h2o/sparkling/ml/models/H2OMOJOModelBase.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/models/H2OMOJOModelBase.py
@@ -40,7 +40,7 @@ class H2OMOJOModelBase(JavaModel, JavaMLWritable, H2OJavaMLReadable):
         return self._java_obj.getDetailedPredictionCol()
 
     def getWithDetailedPredictionCol(self):
-        warnings.warn("The method will be removed without a replacement in the version 3.34."
+        warnings.warn("The method will be removed without a replacement in the version 3.36."
                       "Detailed prediction columns is always enabled.", DeprecationWarning)
         return True
 

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.py
@@ -91,7 +91,7 @@ class H2OBaseMOJOParams(Params):
         return self.getOrDefault(self.detailedPredictionCol)
 
     def getWithDetailedPredictionCol(self):
-        warnings.warn("The method will be removed without a replacement in the version 3.34."
+        warnings.warn("The method will be removed without a replacement in the version 3.36."
                       "Detailed prediction columns is always enabled.", DeprecationWarning)
         return True
 

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/H2OCommonParams.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/H2OCommonParams.py
@@ -88,7 +88,7 @@ class H2OCommonParams(H2OBaseMOJOParams):
         return self._set(detailedPredictionCol=value)
 
     def setWithDetailedPredictionCol(self, value):
-        warnings.warn("The method will be removed without a replacement in the version 3.34."
+        warnings.warn("The method will be removed without a replacement in the version 3.36."
                       "Detailed prediction columns is enabled by default.", DeprecationWarning)
         return self
 

--- a/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOModelBase.R
+++ b/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOModelBase.R
@@ -27,7 +27,7 @@ H2OMOJOModelBase <- setRefClass("H2OMOJOModelBase", fields = list(jmojo = "ANY")
     invoke(.self$jmojo, "getDetailedPredictionCol")
   },
   getWithDetailedPredictionCol = function() {
-    warning("The method 'getWithDetailedPredictionCol' is deprecated and will be removed without replacement in 3.34.
+    warning("The method 'getWithDetailedPredictionCol' is deprecated and will be removed without replacement in 3.36.
     Detailed prediction columns is always enabled.")
     TRUE
   },

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/params/H2OBaseMOJOParams.scala
@@ -92,7 +92,7 @@ trait H2OBaseMOJOParams extends Params with Logging {
 
   def getDetailedPredictionCol(): String = $(detailedPredictionCol)
 
-  @DeprecatedMethod(version = "3.34")
+  @DeprecatedMethod(version = "3.36")
   def getWithDetailedPredictionCol(): Boolean = true
 
   def getWithContributions(): Boolean = $(withContributions)


### PR DESCRIPTION
This PR follows the discussion in https://github.com/h2oai/sparkling-water/pull/2457.