### PR TITLE
[SW-2552] Delete Train and Validation Frame after MOJO Model is Downloaded inside H2OAutoML.fit()

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
@@ -92,9 +92,11 @@ class H2OAutoML(override val uid: String)
     val leaderModelId = getLeaderModelId(autoMLId)
     val downloadedModel = downloadBinaryModel(leaderModelId, H2OContext.ensure().getConf)
     binaryModel = Some(H2OBinaryModel.read("file://" + downloadedModel.getAbsolutePath, Some(leaderModelId)))
-    deleteRegisteredH2OFrames()
-    H2OModel(leaderModelId)
+
+    val result = H2OModel(leaderModelId)
       .toMOJOModel(Identifiable.randomUID(algoName), H2OMOJOSettings.createFromModelParams(this))
+    deleteRegisteredH2OFrames()
+    result
   }
 
   private def determineIncludedAlgos(): Array[String] = {


### PR DESCRIPTION
Error when stacked ensemble become the best (selected) model :
```
[2021-04-16T17:44:53.130Z]     	at water.fvec.Frame.checksum_impl(Frame.java:577)

[2021-04-16T17:44:53.130Z]     	at water.Keyed.checksum(Keyed.java:108)

[2021-04-16T17:44:53.130Z]     	at water.api.schemas3.ModelMetricsBaseV3.fillFromImpl(ModelMetricsBaseV3.java:78)

[2021-04-16T17:44:53.130Z]     	at water.api.schemas3.ModelMetricsBinomialV3.fillFromImpl(ModelMetricsBinomialV3.java:50)

[2021-04-16T17:44:53.130Z]     	at water.api.schemas3.ModelMetricsBinomialV3.fillFromImpl(ModelMetricsBinomialV3.java:10)

[2021-04-16T17:44:53.130Z]     	at water.api.schemas3.ModelMetricsBinomialGLMV3.fillFromImpl(ModelMetricsBinomialGLMV3.java:26)

[2021-04-16T17:44:53.130Z]     	at water.api.schemas3.ModelMetricsBinomialGLMV3.fillFromImpl(ModelMetricsBinomialGLMV3.java:7)

[2021-04-16T17:44:53.130Z]     	at water.util.PojoUtils.copyProperties(PojoUtils.java:291)

[2021-04-16T17:44:53.130Z]     	at water.util.PojoUtils.copyProperties(PojoUtils.java:83)

[2021-04-16T17:44:53.130Z]     	at water.api.Schema.fillFromImpl(Schema.java:205)

[2021-04-16T17:44:53.130Z]     	at water.api.Schema.fillFromImpl(Schema.java:201)

[2021-04-16T17:44:53.130Z]     	at water.api.schemas3.ModelOutputSchemaV3.fillFromImpl(ModelOutputSchemaV3.java:94)

[2021-04-16T17:44:53.130Z]     	at water.api.schemas3.ModelSchemaV3.fillFromImpl(ModelSchemaV3.java:90)

[2021-04-16T17:44:53.130Z]     	at water.api.schemas3.ModelSchemaV3.fillFromImpl(ModelSchemaV3.java:22)

[2021-04-16T17:44:53.130Z]     	at hex.ModelMojoWriter.writeModelDetails(ModelMojoWriter.java:97)

[2021-04-16T17:44:53.130Z]     	at hex.ModelMojoWriter.writeExtraInfo(ModelMojoWriter.java:89)

[2021-04-16T17:44:53.130Z]     	at hex.genmodel.AbstractMojoWriter.writeTo(AbstractMojoWriter.java:152)

[2021-04-16T17:44:53.130Z]     	at hex.genmodel.AbstractMojoWriter.writeTo(AbstractMojoWriter.java:143)

[2021-04-16T17:44:53.130Z]     	at hex.MultiModelMojoWriter.writeTo(MultiModelMojoWriter.java:33)

[2021-04-16T17:44:53.130Z]     	at hex.ModelMojoWriter.writeTo(ModelMojoWriter.java:77)

[2021-04-16T17:44:53.130Z]     	at water.api.NanoStreamResponse.writeTo(NanoStreamResponse.java:17)

[2021-04-16T17:44:53.130Z]     	at water.api.RequestServer.doGeneric(RequestServer.java:319)

[2021-04-16T17:44:53.130Z]     	at water.api.RequestServer.doGet(RequestServer.java:225)

[2021-04-16T17:44:53.130Z]     	at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)

[2021-04-16T17:44:53.130Z]     	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:865)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:535)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1317)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1219)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)

[2021-04-16T17:44:53.130Z]     	at water.webserver.jetty9.Jetty9ServerAdapter$LoginHandler.handle(Jetty9ServerAdapter.java:130)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.Server.handle(Server.java:531)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:762)

[2021-04-16T17:44:53.130Z]     	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:680)

[2021-04-16T17:44:53.130Z]     	at java.lang.Thread.run(Thread.java:748)
```
