### PR TITLE
[SW-2537][FOLLOWUP] Fix "guava" Dependency Collision on Spark 2.2-2.4

### DIFF
--- a/ci/Jenkinsfile-from-h2o-branch
+++ b/ci/Jenkinsfile-from-h2o-branch
@@ -6,7 +6,7 @@ properties(
         [
                 parameters(
                         [
-                                booleanParam(name: 'runAllSparkVersions', defaultValue: isPrJob(), 'Run pipeline against all Spark versions'),
+                                booleanParam(name: 'runAllSparkVersions', defaultValue: !isPrJob(), description: 'Run pipeline against all Spark versions'),
                                 booleanParam(name: 'runUnitTests', defaultValue: true, description: 'Run Scala unit tests'),
                                 booleanParam(name: 'runPyUnitTests', defaultValue: true, description: 'Run Python unit tests'),
                                 booleanParam(name: 'runRUnitTests', defaultValue: true, description: 'Run R unit tests'),

--- a/ci/Jenkinsfile-from-h2o-branch
+++ b/ci/Jenkinsfile-from-h2o-branch
@@ -6,6 +6,7 @@ properties(
         [
                 parameters(
                         [
+                                booleanParam(name: 'runAllSparkVersions', defaultValue: isPrJob(), 'Run pipeline against all Spark versions'),
                                 booleanParam(name: 'runUnitTests', defaultValue: true, description: 'Run Scala unit tests'),
                                 booleanParam(name: 'runPyUnitTests', defaultValue: true, description: 'Run Python unit tests'),
                                 booleanParam(name: 'runRUnitTests', defaultValue: true, description: 'Run R unit tests'),
@@ -33,6 +34,10 @@ node("docker") {
     pipeline = load 'ci/sparklingWaterPipeline.groovy'
     def commons = load 'ci/commons.groovy'
     sparkVersions = commons.getSupportedSparkVersions()
+    if (p.runAllSparkVersions) {
+        // test PRs only on first and last supported Spark
+        sparkVersions = [sparkVersions.first(), sparkVersions.last()]
+    }
     testH2OBranch = commons.loadGradleProperties("gradle.properties")["testH2OBranch"]
 }
 

--- a/ci/Jenkinsfile-from-h2o-branch
+++ b/ci/Jenkinsfile-from-h2o-branch
@@ -34,7 +34,7 @@ node("docker") {
     pipeline = load 'ci/sparklingWaterPipeline.groovy'
     def commons = load 'ci/commons.groovy'
     sparkVersions = commons.getSupportedSparkVersions()
-    if (!p.runAllSparkVersions) {
+    if (!params.runAllSparkVersions) {
         // test PRs only on first and last supported Spark
         sparkVersions = [sparkVersions.first(), sparkVersions.last()]
     }

--- a/ci/Jenkinsfile-from-h2o-branch
+++ b/ci/Jenkinsfile-from-h2o-branch
@@ -34,7 +34,7 @@ node("docker") {
     pipeline = load 'ci/sparklingWaterPipeline.groovy'
     def commons = load 'ci/commons.groovy'
     sparkVersions = commons.getSupportedSparkVersions()
-    if (p.runAllSparkVersions) {
+    if (!p.runAllSparkVersions) {
         // test PRs only on first and last supported Spark
         sparkVersions = [sparkVersions.first(), sparkVersions.last()]
     }

--- a/ci/commons.groovy
+++ b/ci/commons.groovy
@@ -37,11 +37,6 @@ def getSupportedSparkVersions() {
     def versionLine = readFile("gradle.properties").split("\n").find() { line -> line.startsWith('supportedSparkVersions') }
     sparkVersions = versionLine.split("=")[1].split(" ")
 
-    if (isPrJob()) {
-        // test PRs only on first and last supported Spark
-        sparkVersions = [sparkVersions.first(), sparkVersions.last()]
-    }
-
     return sparkVersions
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,9 +76,7 @@ dependencies {
   api("ai.h2o:h2o-persist-s3:${h2oVersion}") {
     exclude(group: "com.fasterxml.jackson.core")
   }
-  api("ai.h2o:h2o-persist-gcs:${h2oVersion}") {
-    exclude(group: "com.google.guava")
-  }
+  api("ai.h2o:h2o-persist-gcs:${h2oVersion}")
   api("ai.h2o:h2o-jetty-9:${h2oVersion}")
   api("ai.h2o:h2o-webserver-iface:${h2oVersion}")
   api("ai.h2o:h2o-automl:${h2oVersion}")

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,7 +76,9 @@ dependencies {
   api("ai.h2o:h2o-persist-s3:${h2oVersion}") {
     exclude(group: "com.fasterxml.jackson.core")
   }
-  api("ai.h2o:h2o-persist-gcs:${h2oVersion}")
+  api("ai.h2o:h2o-persist-gcs:${h2oVersion}") {
+    exclude(group: "com.google.guava")
+  }
   api("ai.h2o:h2o-jetty-9:${h2oVersion}")
   api("ai.h2o:h2o-webserver-iface:${h2oVersion}")
   api("ai.h2o:h2o-automl:${h2oVersion}")

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   integTestImplementation("org.scala-lang:scala-library:${scalaVersion}")
 
   if (sparkMajorVersion <= "2.4") {
-    // ai.h2o:h2o-persist-gcs has com.google.guava:guava:20.0 as a dependency, which is incompatible with 
+    // ai.h2o:h2o-persist-gcs has com.google.guava:guava:20.0 as a dependency, which is incompatible with
     // Hadoop 2.6.5. This version of Spark is a default dependency of Spark 2.2-2.4.
     integTestImplementation('org.apache.hadoop:hadoop-mapreduce-client-core') { version { strictly '2.7.2' } }
     integTestImplementation('org.apache.hadoop:hadoop-common') { version { strictly '2.7.2' } }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -17,6 +17,14 @@ dependencies {
   integTestImplementation("junit:junit:4.11")
   integTestImplementation(project(path: ':sparkling-water-core', configuration: 'testArchives'))
   integTestImplementation("org.scala-lang:scala-library:${scalaVersion}")
+
+  if (sparkMajorVersion <= "2.4") {
+    // ai.h2o:h2o-persist-gcs has com.google.guava:guava:20.0 as a dependency, which is incompatible with 
+    // Hadoop 2.6.5. This version of Spark is a default dependency of Spark 2.2-2.4.
+    integTestImplementation('org.apache.hadoop:hadoop-mapreduce-client-core') { version { strictly '2.7.2' } }
+    integTestImplementation('org.apache.hadoop:hadoop-common') { version { strictly '2.7.2' } }
+    integTestImplementation('commons-io:commons-io') { version { strictly '2.4' } }
+  }
 }
 
 defineStandardPublication().call()

--- a/ml/build.gradle
+++ b/ml/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   testImplementation(project(path: ':sparkling-water-core', configuration: 'testArchives'))
 
   if (sparkMajorVersion <= "2.4") {
-    // ai.h2o:h2o-persist-gcs has com.google.guava:guava:20.0 as a dependency, which is incompatible with 
+    // ai.h2o:h2o-persist-gcs has com.google.guava:guava:20.0 as a dependency, which is incompatible with
     // Hadoop 2.6.5. This version of Spark is a default dependency of Spark 2.2-2.4.
     testImplementation('org.apache.hadoop:hadoop-mapreduce-client-core') { version { strictly '2.7.2' } }
     testImplementation('org.apache.hadoop:hadoop-common') { version { strictly '2.7.2' } }

--- a/ml/build.gradle
+++ b/ml/build.gradle
@@ -41,6 +41,14 @@ dependencies {
   testImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
   testImplementation("junit:junit:4.11")
   testImplementation(project(path: ':sparkling-water-core', configuration: 'testArchives'))
+
+  if (sparkMajorVersion <= "2.4") {
+    // ai.h2o:h2o-persist-gcs has com.google.guava:guava:20.0 as a dependency, which is incompatible with 
+    // Hadoop 2.6.5. This version of Spark is a default dependency of Spark 2.2-2.4.
+    testImplementation('org.apache.hadoop:hadoop-mapreduce-client-core') { version { strictly '2.7.2' } }
+    testImplementation('org.apache.hadoop:hadoop-common') { version { strictly '2.7.2' } }
+    testImplementation('commons-io:commons-io') { version { strictly '2.4' } }
+  }
 }
 
 test {

--- a/py/tests/unit/with_runtime_sparkling/test_gcs_import.py
+++ b/py/tests/unit/with_runtime_sparkling/test_gcs_import.py
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import h2o
+
+def testImportFromGCS(hc):
+    path = "gs://solutions-public-assets/time-series-master/GBPUSD_2014_01.csv"
+    frame = h2o.import_file(path=path)
+    df = hc.asSparkFrame(frame)
+    assert df.count() == 1280546


### PR DESCRIPTION
Spark 2.2 - 2.4 has hadoop-client 2.6.5 as a dependency. This dependency is incompatible with guava  17+.
Error:
```

[2021-04-20T17:44:34.936Z]     java.lang.IllegalAccessError: tried to access method com.google.common.base.Stopwatch.<init>()V from class org.apache.hadoop.mapred.FileInputFormat

[2021-04-20T17:44:34.936Z]         at org.apache.hadoop.mapred.FileInputFormat.getSplits(FileInputFormat.java:312)

[2021-04-20T17:44:34.936Z]         at org.apache.spark.rdd.HadoopRDD.getPartitions(HadoopRDD.scala:199)

[2021-04-20T17:44:34.936Z]         at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:252)

[2021-04-20T17:44:34.936Z]         at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:250)

[2021-04-20T17:44:34.936Z]         at scala.Option.getOrElse(Option.scala:121)

[2021-04-20T17:44:34.936Z]         at org.apache.spark.rdd.RDD.partitions(RDD.scala:250)

[2021-04-20T17:44:34.936Z]         at org.apache.spark.rdd.MapPartitionsRDD.getPartitions(MapPartitionsRDD.scala:46)

[2021-04-20T17:44:34.936Z]         at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:252)

[2021-04-20T17:44:34.936Z]         at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:250)

[2021-04-20T17:44:34.936Z]         at scala.Option.getOrElse(Option.scala:121)
...
```

ai.h2o:h2o-persist-gcs brings guava 20:
```
com.google.guava:guava:20.0
+--- com.google.api:gax:1.19.0
|    +--- com.google.cloud:google-cloud-core:1.19.0
|    |    +--- com.google.cloud:google-cloud-storage:1.19.0
|    |    |    \--- ai.h2o:h2o-persist-gcs:3.32.1.1
|    |    |         \--- project :sparkling-water-core
|    |    |              \--- compileClasspath
```