### PR TITLE
[SW-2556] Upgrade "setuptools" during the build of testing docker image

### DIFF
--- a/ci/Jenkinsfile-release
+++ b/ci/Jenkinsfile-release
@@ -352,7 +352,6 @@ def publishToPipy() {
                         params.commons.withPipyCredentials {
                             sh """
                                . /envs/h2o_env_python3.6/bin/activate
-                               pip install -U setuptools
                                python setup.py sdist
                                twine upload dist/* -u $PIPY_USERNAME -p $PIPY_PASSWORD
                                """

--- a/ci/build.gradle
+++ b/ci/build.gradle
@@ -71,6 +71,13 @@ task createDockerfile(type: Dockerfile, dependsOn: copyFiles) {
                 done && cd .. && rm -rf sparkling-water
                 """
 
+  runCommand """\\
+                for pythonVersion in ${supportedPythonVersions}; \\
+                do \\
+                  . /envs/h2o_env_python\$pythonVersion/bin/activate && pip install -U setuptools; \\
+                done
+                """
+
   user("root")
 
   runCommand """\\

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Version of Terraform used in the script creating the docker image
 terraformVersion=0.12.8
 # Version of docker image used in Jenkins tests
-dockerImageVersion=41
+dockerImageVersion=42
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Version of Terraform used in the script creating the docker image
 terraformVersion=0.12.8
 # Version of docker image used in Jenkins tests
-dockerImageVersion=42
+dockerImageVersion=43
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions


### PR DESCRIPTION
Databricks tests fails because of setuptools incompatibility. Release pipeline setuptools in each run.