### PR TITLE
[SW-2558] Upgrade dbplyr in SW Testing Docker Image

### DIFF
--- a/ci/build.gradle
+++ b/ci/build.gradle
@@ -36,7 +36,7 @@ task createDockerfile(type: Dockerfile, dependsOn: copyFiles) {
 
   runCommand """\\
                 R -e 'install.packages("testthat", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'install.packages("dbplyr", repos = "http://cran.us.r-project.org")' && \\                 
+                R -e 'install.packages("dbplyr", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("sparklyr", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("devtools", repos = "http://cran.us.r-project.org")'
                 """

--- a/ci/build.gradle
+++ b/ci/build.gradle
@@ -36,7 +36,7 @@ task createDockerfile(type: Dockerfile, dependsOn: copyFiles) {
 
   runCommand """\\
                 R -e 'install.packages("testthat", repos = "http://cran.us.r-project.org")' && \\
-                R -e 'require(devtools); install_version("dbplyr", version = "1.4.2", repos = "http://cran.us.r-project.org", upgrade = "never")' && \\                
+                R -e 'install.packages("dbplyr", repos = "http://cran.us.r-project.org")' && \\                 
                 R -e 'install.packages("sparklyr", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("devtools", repos = "http://cran.us.r-project.org")'
                 """

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Version of Terraform used in the script creating the docker image
 terraformVersion=0.12.8
 # Version of docker image used in Jenkins tests
-dockerImageVersion=43
+dockerImageVersion=44
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions


### PR DESCRIPTION
Since dbplyr is fixed 1.4.2 and it's not compatible with Sparklyr 1.6.2, R tests fail.

```
13:06:39  Failed to connect to localhost port 54323: Connection refused
13:06:39  Backtrace:
13:06:39    1. dplyr::collect(mojo$transform(sdf)) testMojo.R:54:2
13:06:39   25. h2o:::.h2o.__remoteSend(...)
13:06:39   26. h2o:::.h2o.__checkConnectionHealth()
```
