### PR TITLE
[SW-2537][FOLLOWUP] Fix Conda Stages in Release Pipeline

### DIFF
--- a/ci/Jenkinsfile-release
+++ b/ci/Jenkinsfile-release
@@ -278,9 +278,10 @@ def buildConda() {
                 def packages = [
                     [path: "py/build/conda", name: "h2o_pysparkling_${params.spark}"],
                     [path: "py-scoring/build/conda", name: "h2o_pysparkling_scoring_${params.spark}"]]
+                def pythonVersions = params.commons.getSupportedPythonVersions(params.spark)
                 for (packageDetails in packages) {
                     dir(packageDetails.path) {
-                        for (pyVersion in params.commons.getSupportedPythonVersions(params.spark)) {
+                        for (pyVersion in pythonVersions) {
                             sh """
                                . /envs/h2o_env_python3.6/bin/activate
     
@@ -386,10 +387,11 @@ def publishToConda() {
                 def packages = [
                     [path: "py/build/conda", name: "h2o_pysparkling_${params.spark}"],
                     [path: "py-scoring/build/conda", name: "h2o_pysparkling_scoring_${params.spark}"]]
+                def pythonVersions = params.commons.getSupportedPythonVersions(params.spark)
                 for (packageDetails in packages) {
                     dir(packageDetails.path) {
                         params.commons.withCondaCredentials {
-                            for (pyVersion in params.commons.getSupportedPythonVersions(params.spark)) {
+                            for (pyVersion in pythonVersions) {
                                 def pkgName = getCondaPkgName(pyVersion, packageDetails.name)
                                 for (arch in ['osx-64', 'linux-64', 'win-64']) {
                                     publishCondaArtifact(arch, pkgName)


### PR DESCRIPTION
`params.commons.getSupportedPythonVersions(params.spark)` can' be called inside `dir(packageDetails.path) {}`, otherwise gradle properties are read at wrong location:
```/home/jenkins/workspace/RELEASE_rel-3.32.1-spark-2.4/py/build/conda/gradle-spark2.4.properties```

The correct path is: 
```/home/jenkins/workspace/RELEASE_rel-3.32.1-spark-2.4/gradle-spark2.4.properties```