### PR TITLE
[SW-2561] Fix Deployment of Testing Infrastructure for K8s Tests

### DIFF
--- a/ci/Jenkinsfile-kubernetes
+++ b/ci/Jenkinsfile-kubernetes
@@ -575,16 +575,16 @@ def testPythonExternalBackendAutoClientMode(registryId, master, version) {
 
 def stopEKSCluster(commons) {
     commons.withAWSCredentials {
-        dir("kubernetes/src/terraform/aws") {
-            sh "rm -f terraform.tfstate"
-            unstash "tf_state"
-            def code = {
+        def code = {
+            dir("kubernetes/src/terraform/aws") {
+                sh "rm -f terraform.tfstate"
+                unstash "tf_state"
                 commons.terraformDestroy("-var aws_region=${awsRegion()}")
             }
-            retryWithDelay(3, 600, {
-                commons.withDocker("hashicorp/terraform:0.12.25", code, "--entrypoint='' --network host")
-            })
         }
+        retryWithDelay(3, 600, {
+            commons.withTerraform(code, "--entrypoint='' --network host")
+        })
     }
 }
 
@@ -617,18 +617,20 @@ node("docker") {
 
     stage("Start EKS & ECR") {
         commons.withAWSCredentials {
-            dir("kubernetes/src/terraform/aws") {
-                def code = {
+            def code = {
+                dir("kubernetes/src/terraform/aws") {
                     commons.terraformApply("-var aws_region=${awsRegion()}")
                     def values = commons.extractTerraformOutputs(["docker_registry_id", "cluster_name", "cluster_endpoint"])
-                    def valuesAsString = values.collect { "${it.key}=${it.value}" }.join("\n") + "\n" + "version=$sparklingVersion" + "\n"
+                    def valuesAsString = values.collect {
+                        "${it.key}=${it.value}"
+                    }.join("\n") + "\n" + "version=$sparklingVersion" + "\n"
                     writeFile file: "properties", text: valuesAsString
                     stash name: "properties", includes: "properties"
                     arch "terraform.tfstate"
                     stash name: "tf_state", includes: "terraform.tfstate"
                 }
-                commons.withDocker("hashicorp/terraform:0.12.25", code, "--entrypoint='' --network host")
             }
+            commons.withTerraform(code, "--entrypoint='' --network host")
         }
     }
 

--- a/ci/commons.groovy
+++ b/ci/commons.groovy
@@ -67,8 +67,9 @@ def withSparklingWaterDockerImage(code) {
     }
 }
 
-def withTerraform(groovy.lang.Closure code) {
-    withDocker("hashicorp/terraform:0.12.25", code, "--entrypoint=''")
+def withTerraform(groovy.lang.Closure code, dockerOptions = "--entrypoint=''") {
+    def terraformVersion = loadGradleProperties("gradle.properties")['terraformVersion']
+    withDocker("hashicorp/terraform:$terraformVersion", code, dockerOptions)
 }
 
 def withPacker(groovy.lang.Closure code) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.daemon=false
 # https://issues.sonatype.org/browse/MVNCENTRAL-5276
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Version of Terraform used in the script creating the docker image
-terraformVersion=0.12.8
+terraformVersion=0.12.25
 # Version of docker image used in Jenkins tests
 dockerImageVersion=44
 # Is this build nightly build

--- a/kubernetes/src/terraform/aws/eks_cluster.tf
+++ b/kubernetes/src/terraform/aws/eks_cluster.tf
@@ -1,5 +1,6 @@
 module "eks" {
   source = "terraform-aws-modules/eks/aws"
+  version = "13.2.1"
   cluster_name = local.cluster_name
   cluster_version = var.eks_cluster_version
   subnets = module.vpc.private_subnets

--- a/kubernetes/src/terraform/aws/vpc.tf
+++ b/kubernetes/src/terraform/aws/vpc.tf
@@ -23,6 +23,7 @@ resource "random_string" "suffix" {
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "2.78.0"
 
   name = "SWKubernetes-vpc"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
Before the change, the deployment has thrown the following error :
```
+ terraform init

Initializing modules...

Downloading terraform-aws-modules/eks/aws 15.2.0 for eks...

- eks in .terraform/modules/eks

- eks.fargate in .terraform/modules/eks/modules/fargate

- eks.node_groups in .terraform/modules/eks/modules/node_groups

Downloading terraform-aws-modules/vpc/aws 3.0.0 for vpc...

- vpc in .terraform/modules/vpc



Error: Unsupported Terraform Core version



Module eks (from "terraform-aws-modules/eks/aws") does not support Terraform

version 0.12.25. To proceed, either choose another supported Terraform version

or update the module's version constraint. Version constraints are normally

set for good reason, so updating the constraint may lead to other errors or

unexpected behavior.





Error: Unsupported Terraform Core version



Module eks.fargate (from "./modules/fargate") does not support Terraform

version 0.12.25. To proceed, either choose another supported Terraform version

or update the module's version constraint. Version constraints are normally

set for good reason, so updating the constraint may lead to other errors or

unexpected behavior.





Error: Unsupported Terraform Core version



Module eks.node_groups (from "./modules/node_groups") does not support

Terraform version 0.12.25. To proceed, either choose another supported

Terraform version or update the module's version constraint. Version

constraints are normally set for good reason, so updating the constraint may

lead to other errors or unexpected behavior.





Error: Unsupported Terraform Core version



Module vpc (from "terraform-aws-modules/vpc/aws") does not support Terraform

version 0.12.25. To proceed, either choose another supported Terraform version

or update the module's version constraint. Version constraints are normally

set for good reason, so updating the constraint may lead to other errors or

unexpected behavior.
```
After this change:
![image](https://user-images.githubusercontent.com/3674621/117317967-4e75e080-ae8a-11eb-97b3-831078afab93.png)
