### PR TITLE
[SW-2567] Fix CoxPH docs example for Scala and Python

### DIFF
--- a/doc/src/site/sphinx/ml/sw_coxph.rst
+++ b/doc/src/site/sphinx/ml/sw_coxph.rst
@@ -42,6 +42,10 @@ See also :ref:`parameters_H2OCoxPH`.
 
             import ai.h2o.sparkling.ml.algos.H2OCoxPH
             val estimator = new H2OCoxPH()
+                .setStartCol("start")
+                .setStopCol("stop")
+                .setTies("breslow")
+                .setLabelCol("event")
             val model = estimator.fit(trainingDF)
 
         You can also get raw model details by calling the *getModelDetails()* method available on the model as:
@@ -88,7 +92,11 @@ See also :ref:`parameters_H2OCoxPH`.
         .. code:: python
 
             from pysparkling.ml import H2OCoxPH
-            estimator = H2OCoxPH()
+            estimator = H2OCoxPH()\
+                .setStartCol('start')\
+                .setStopCol('stop')\
+                .setTies('breslow')\
+                .setLabelCol('event')
             model = estimator.fit(trainingDF)
 
         You can also get raw model details by calling the *getModelDetails()* method available on the model as:

--- a/doc/src/site/sphinx/ml/sw_coxph.rst
+++ b/doc/src/site/sphinx/ml/sw_coxph.rst
@@ -87,7 +87,7 @@ See also :ref:`parameters_H2OCoxPH`.
             testingFrame = h2o.import_file("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/coxph_test/heart_test.csv")
             testingDF = hc.asSparkFrame(testingFrame)
 
-        Train the model. You can configure all the available Isolation Forest arguments using provided setters or constructor parameters.
+        Train the model. You can configure all the available CoxPH arguments using provided setters or constructor parameters.
 
         .. code:: python
 

--- a/doc/src/site/sphinx/ml/sw_coxph.rst
+++ b/doc/src/site/sphinx/ml/sw_coxph.rst
@@ -32,20 +32,19 @@ See also :ref:`parameters_H2OCoxPH`.
 
             import org.apache.spark.SparkFiles
             spark.sparkContext.addFile("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/coxph_test/heart.csv")
-            spark.sparkContext.addFile("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/coxph_test/heart_test.csv")
-            val trainingDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("heart.csv"))
-            val testingDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("heart_test.csv"))
+            val heartDF = spark.read.option("header", "true").option("inferSchema", "true").csv(SparkFiles.get("heart.csv"))
+            val Array(trainingDF, testingDF) = heartDF.randomSplit(Array(0.8, 0.2), seed = 12345)
 
         Train the model. You can configure all the available CoxPH parameters using provided setters.
 
         .. code:: scala
 
             import ai.h2o.sparkling.ml.algos.H2OCoxPH
-            val estimator = new H2OCoxPH()
-                .setStartCol("start")
-                .setStopCol("stop")
-                .setTies("breslow")
-                .setLabelCol("event")
+            val estimator = new H2OCoxPH().
+                setStartCol("start").
+                setStopCol("stop").
+                setTies("breslow").
+                setLabelCol("event")
             val model = estimator.fit(trainingDF)
 
         You can also get raw model details by calling the *getModelDetails()* method available on the model as:
@@ -82,9 +81,9 @@ See also :ref:`parameters_H2OCoxPH`.
         .. code:: python
 
             import h2o
-            trainingFrame = h2o.import_file("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/coxph_test/heart.csv")
+            heartFrame = h2o.import_file("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/coxph_test/heart.csv")
+            trainingFrame, testingFrame = heartFrame.split_frame(ratios = [.8], seed = 1234)
             trainingDF = hc.asSparkFrame(trainingFrame)
-            testingFrame = h2o.import_file("https://raw.githubusercontent.com/h2oai/sparkling-water/master/examples/smalldata/coxph_test/heart_test.csv")
             testingDF = hc.asSparkFrame(testingFrame)
 
         Train the model. You can configure all the available CoxPH arguments using provided setters or constructor parameters.


### PR DESCRIPTION
Fixes JIRA: https://h2oai.atlassian.net/browse/SW-2567

Current example fails for 
```
org.apache.spark.sql.AnalysisException: cannot resolve '`label`' given input columns: [start, transplant, stop, age, event, year, id, surgery];;
'Project [start#2305, stop#2306, event#2307, age#2308, year#2309, surgery#2310, transplant#2311, id#2312, 'label]
+- Relation[start#2305,stop#2306,event#2307,age#2308,year#2309,surgery#2310,transplant#2311,id#2312] csv
```
need to add parameters that are needed for CoxPH
