### PR TITLE
[SW-2575] Upgrade Spark in Testing Docker Image to 3.0.3

### DIFF
--- a/ci/build.gradle
+++ b/ci/build.gradle
@@ -72,9 +72,9 @@ task createDockerfile(type: Dockerfile, dependsOn: copyFiles) {
                 """
 
   runCommand """\\
-                for pythonVersion in ${supportedPythonVersions}; \\
+                for pythonVersion in ${h2oPythonEnvironments}; \\
                 do \\
-                  . /envs/h2o_env_python\$pythonVersion/bin/activate && pip install -U setuptools; \\
+                  . /envs/h2o_env_python\$pythonVersion/bin/activate && pip install colorama && pip install -U setuptools; \\
                 done
                 """
 

--- a/gradle-spark3.0.properties
+++ b/gradle-spark3.0.properties
@@ -1,4 +1,4 @@
-sparkVersion=3.0.2
+sparkVersion=3.0.3
 minSupportedJavaVersion=1.8
 supportedEmrVersion=emr-5.26.0
 unsupportedMinorSparkVersions=

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,5 +32,5 @@ version=3.34.0.1-1-SNAPSHOT
 kubernetesSupportSinceSpark=2.4
 databricksTestSinceSpark=2.4
 spotlessModern=true
-testH2OBranch=master
+testH2OBranch=rel-zipf
 makeBooklet=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Version of Terraform used in the script creating the docker image
 terraformVersion=0.12.25
 # Version of docker image used in Jenkins tests
-dockerImageVersion=46
+dockerImageVersion=47
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,8 @@ dockerImageVersion=46
 isNightlyBuild=false
 # Supported Major Spark Versions
 supportedSparkVersions=2.1 2.2 2.3 2.4 3.0 3.1
+# The list of python environments used in automated tests
+h2oPythonEnvironments=2.7 3.6
 # Select for which Spark version is Sparkling Water built by default
 spark=3.1
 # Sparkling Water Version
@@ -32,5 +34,5 @@ version=3.34.0.1-1-SNAPSHOT
 kubernetesSupportSinceSpark=2.4
 databricksTestSinceSpark=2.4
 spotlessModern=true
-testH2OBranch=rel-zipf
+testH2OBranch=master
 makeBooklet=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Version of Terraform used in the script creating the docker image
 terraformVersion=0.12.25
 # Version of docker image used in Jenkins tests
-dockerImageVersion=45
+dockerImageVersion=46
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,5 +34,5 @@ version=3.34.0.1-1-SNAPSHOT
 kubernetesSupportSinceSpark=2.4
 databricksTestSinceSpark=2.4
 spotlessModern=true
-testH2OBranch=rel-zipf
+testH2OBranch=master
 makeBooklet=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,5 +34,5 @@ version=3.34.0.1-1-SNAPSHOT
 kubernetesSupportSinceSpark=2.4
 databricksTestSinceSpark=2.4
 spotlessModern=true
-testH2OBranch=master
+testH2OBranch=rel-zipf
 makeBooklet=false


### PR DESCRIPTION
This PR also fixes a problem with missing colorama dependency in rel-3.32.1 branch