### PR TITLE
[SW-2577] Fix Building of RSparkling Docker Images

### DIFF
--- a/bin/build-kubernetes-images.sh
+++ b/bin/build-kubernetes-images.sh
@@ -36,7 +36,11 @@ if [ "$1" = "external-backend" ]; then
   exit 0
 fi
 
-(cd "$SPARK_HOME" && ./bin/docker-image-tool.sh -t "$INSTALLED_SPARK_FULL_VERSION" -p ./kubernetes/dockerfiles/spark/bindings/python/Dockerfile -R ./kubernetes/dockerfiles/spark/bindings/R/Dockerfile build)
+(cd "$SPARK_HOME" && \
+ TMP_SPARK_R_DOCKERFILE=$(mktemp) && \
+ sed  "s/apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'/apt-key adv --keyserver keyserver.ubuntu.com --recv-key FCAE2A0E115C3D8A/g" ./kubernetes/dockerfiles/spark/bindings/R/Dockerfile >> "$TMP_SPARK_R_DOCKERFILE" && \
+ ./bin/docker-image-tool.sh -t "$INSTALLED_SPARK_FULL_VERSION" -p ./kubernetes/dockerfiles/spark/bindings/python/Dockerfile -R "$TMP_SPARK_R_DOCKERFILE" build && \
+ rm "$TMP_SPARK_R_DOCKERFILE")
 
 if [ "$1" = "scala" ]; then
   cp "$K8DIR/Dockerfile-Scala" "$WORKDIR"


### PR DESCRIPTION
The signature of repo `http://cloud.r-project.org/bin/linux/debian buster-cran35/` has changed.

Error:
```

[2021-07-12T20:59:36.896Z] Hit:1 http://security.debian.org/debian-security buster/updates InRelease

[2021-07-12T20:59:36.896Z] Get:2 http://cloud.r-project.org/bin/linux/debian buster-cran35/ InRelease [4375 B]

[2021-07-12T20:59:36.896Z] Hit:3 https://deb.debian.org/debian buster InRelease

[2021-07-12T20:59:36.896Z] Hit:4 https://deb.debian.org/debian buster-updates InRelease

[2021-07-12T20:59:36.896Z] Err:2 http://cloud.r-project.org/bin/linux/debian buster-cran35/ InRelease

[2021-07-12T20:59:36.896Z]   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY FCAE2A0E115C3D8A

[2021-07-12T20:59:38.077Z] Reading package lists...

[2021-07-12T20:59:38.077Z] W: GPG error: http://cloud.r-project.org/bin/linux/debian buster-cran35/ InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY FCAE2A0E115C3D8A

[2021-07-12T20:59:38.077Z] E: The repository 'http://cloud.r-project.org/bin/linux/debian buster-cran35/ InRelease' is not signed.

[2021-07-12T20:59:38.077Z] The command '/bin/sh -c apt-get update &&   apt install -y gnupg &&   echo "deb http://cloud.r-project.org/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list &&   (apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF' || apt-key adv --keyserver keys.openpgp.org --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF') &&   apt-get update &&   apt install -y -t buster-cran35 r-base r-base-dev &&   rm -rf /var/cache/apt/*' returned a non-zero code: 100

[2021-07-12T20:59:38.077Z] Failed to build SparkR Docker image, please refer to Docker build output for details.
```