### PR TITLE
[SW-2573] Fix interactionConstraints on H2OXGBoostMOJOModel in Python

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/python/MOJOModelTemplate.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/python/MOJOModelTemplate.scala
@@ -78,6 +78,7 @@ object MOJOModelTemplate
   }
 
   private def generateValueConversion(parameter: Parameter): String = parameter.dataType match {
+    case x if x.isArray && x.getComponentType.isArray() => "H2OTypeConverters.scala2DArrayToPython2DArray(value)"
     case x if x.isArray => "H2OTypeConverters.scalaArrayToPythonArray(value)"
     case _ => "value"
   }

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/H2OTypeConverters.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/H2OTypeConverters.py
@@ -502,6 +502,15 @@ class H2OTypeConverters(object):
             raise TypeError("Invalid type.")
 
     @staticmethod
+    def scala2DArrayToPython2DArray(array):
+        if array is None:
+            return None
+        elif isinstance(array, JavaObject):
+            return [H2OTypeConverters.scalaArrayToPythonArray(v) for v in array]
+        else:
+            raise TypeError("Invalid type.")
+
+    @staticmethod
     def scalaToPythonDataFrame(jdf):
         if jdf is None:
             return None

--- a/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
@@ -39,7 +39,7 @@ def testXGBoostParameters(prostateDataset):
                            monotoneConstraints={'AGE': 1, 'RACE': -1},
                            interactionConstraints=[['AGE', 'RACE', 'DPROS'], ['DCAPS', 'PSA']])
     model = algorithm.fit(prostateDataset)
-    ignored=["getInteractionConstraints", "getMonotoneConstraints"]  # Will be fixed by SW-2573 and SW-2572
+    ignored=["getMonotoneConstraints"]  # Will be fixed by SW-2572
     compareParameterValues(algorithm, model, ignored)
 
 


### PR DESCRIPTION
The inner arrays were represented as java objects of py4j.