### PR TITLE
[SW-2580] Conversion Method ash2oframe Throws Exception When an Input Contains a Column Named "na" or "Null"

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/converters/SparkDataFrameConverter.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/converters/SparkDataFrameConverter.scala
@@ -50,7 +50,7 @@ object SparkDataFrameConverter extends Logging {
     val elemMaxSizes = collectMaxElementSizes(rdd, schema)
     val vecIndices = collectVectorLikeTypes(schema).toArray
     val flattenSchema = expandedSchema(schema, elemMaxSizes)
-    val colNames = flattenSchema.map(_.name).toArray
+    val colNames = flattenSchema.map(field => "\"" + field.name + "\"").toArray
     val maxVecSizes = vecIndices.map(elemMaxSizes(_))
 
     val expectedTypes = DataTypeConverter.determineExpectedTypes(schema)

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
@@ -747,7 +747,7 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     (flattenDF, maxElementSizes, expandedSchema)
   }
 
-  test("The converion of DataFrame to H2OFrame and back with columns named \"na\" and \"null\"") {
+  test("The conversion of DataFrame to H2OFrame and back with columns named \"na\" and \"null\"") {
     val dfInput = sc.parallelize(1 to 6).map(v => (v, v * v)).toDF("na", "null")
     val hf = hc.asH2OFrame(dfInput)
     val dfOutput = hc.asSparkFrame(hf)

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
@@ -746,4 +746,16 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
     val expandedSchema = SchemaUtils.expandedSchema(SchemaUtils.flattenSchema(df), maxElementSizes)
     (flattenDF, maxElementSizes, expandedSchema)
   }
+
+  test("The converion of DataFrame to H2OFrame and back with columns named \"na\" and \"null\"") {
+    val dfInput = sc.parallelize(1 to 6).map(v => (v, v * v)).toDF("na", "null")
+    val hf = hc.asH2OFrame(dfInput)
+    val dfOutput = hc.asSparkFrame(hf)
+
+    hf.columnNames(0) shouldEqual "na"
+    hf.columnNames(1) shouldEqual "null"
+
+    dfOutput.columns(0) shouldEqual "na"
+    dfOutput.columns(1) shouldEqual "null"
+  }
 }


### PR DESCRIPTION
In such a cases, the column names are converted to `null` which leads to following errors.:
```
ERROR water.default: 
java.lang.NullPointerException
	at water.parser.ParseDataset.logParseResults(ParseDataset.java:1068)
	at ai.h2o.sparkling.extensions.rest.api.ImportFrameHandler.finalize(ImportFrameHandler.scala:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at water.api.Handler.handle(Handler.java:60)
	at water.api.RequestServer.serve(RequestServer.java:470)
	at water.api.RequestServer.doGeneric(RequestServer.java:301)
	at water.api.RequestServer.doPost(RequestServer.java:227)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:523)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:590)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:865)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:535)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1317)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1219)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at water.webserver.jetty9.Jetty9ServerAdapter$LoginHandler.handle(Jetty9ServerAdapter.java:130)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:531)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:762)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:680)
	at java.lang.Thread.run(Thread.java:748)
```