### PR TITLE
[SW-2562][FOLLOWUP] Add missing setConvertInvalidNumbersToNa back

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OCommonParams.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/H2OCommonParams.scala
@@ -77,4 +77,6 @@ trait H2OCommonParams extends H2OBaseMOJOParams {
 
   def setConvertUnknownCategoricalLevelsToNa(value: Boolean): this.type =
     set(convertUnknownCategoricalLevelsToNa, value)
+
+  def setConvertInvalidNumbersToNa(value: Boolean): this.type = set(convertInvalidNumbersToNa, value)
 }


### PR DESCRIPTION
The setter was accidentally removed during the implementation of `H2OAutoEncoder` (see https://github.com/h2oai/sparkling-water/commit/3c726991238c54e50c5c625a3cb8ceaf17a72042#diff-21d18931af889cef1b94b7b3ce9204d123d9942a3eade6bc7f12773b905956e9L113)