### PR TITLE
[SW-2595] Add 'mean_per_class_error' to model trainings map

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_mojo.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo.py
@@ -63,7 +63,7 @@ def testModelCategory(gbmModel):
 def testTrainingMetrics(gbmModel):
     metrics = gbmModel.getTrainingMetrics()
     assert metrics is not None
-    assert len(metrics) is 6
+    assert len(metrics) is 7
 
 
 def testFeatureTypes(gbmModel):

--- a/r/src/tests/testthat/testMojo.R
+++ b/r/src/tests/testthat/testMojo.R
@@ -108,7 +108,7 @@ test_that("test training metrics", {
   model <- H2OMOJOModel.createFromMojo(paste0("file://", normalizePath("../../../../../ml/src/test/resources/binom_model_prostate.mojo")))
   metrics <- model$getTrainingMetrics()
   expect_equal(as.character(metrics[["AUC"]]), "0.896878869021911")
-  expect_equal(length(metrics), 6)
+  expect_equal(length(metrics), 7)
 })
 
 test_that("test current metrics", {

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/internals/H2OMetric.java
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/internals/H2OMetric.java
@@ -43,7 +43,8 @@ public enum H2OMetric {
   Withinss(false),
   Betweenss(true),
   TotWithinss(false),
-  Totss(false);
+  Totss(false),
+  MeanPerClassError(false);
 
   public boolean higherTheBetter() {
     return higherTheBetter;


### PR DESCRIPTION
I've tested the feature manually:
![image](https://user-images.githubusercontent.com/3674621/128370526-b43fc2e3-9006-4193-8d7e-b4e5616503b5.png)
