### PR TITLE
[SW-2596] Add RMSLE and MAE to model metric maps

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_gridsearch.py
+++ b/py/tests/unit/with_runtime_sparkling/test_gridsearch.py
@@ -109,7 +109,7 @@ def testGetGridModelsMetrics(prostateDataset):
     grid.fit(prostateDataset)
     metrics = grid.getGridModelsMetrics()
     assert metrics.count() == 3
-    assert metrics.columns == ['MOJO Model ID', 'MSE', 'MeanResidualDeviance', 'R2', 'RMSE']
+    assert metrics.columns == ['MOJO Model ID', 'RMSLE', 'RMSE', 'MAE', 'MeanResidualDeviance', 'MSE', 'R2']
     metrics.collect()  # try materializing
 
 

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/internals/H2OMetric.java
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/internals/H2OMetric.java
@@ -20,6 +20,8 @@ package ai.h2o.sparkling.ml.internals;
 public enum H2OMetric {
   AUTO(true),
   MeanResidualDeviance(false),
+  MAE(false),
+  RMSLE(false),
   R2(true),
   ResidualDeviance(false),
   ResidualDegreesOfFreedom(false),


### PR DESCRIPTION
The new feature was tested manually: 
![image](https://user-images.githubusercontent.com/3674621/128539647-0e616b7d-9793-4029-a6ff-2aea456ee428.png)

Both metrics are associated with the ordering `'smaller number -> better model'`.