### PR TITLE
[SW-2598] Fix Version Check in sparkling-env.sh Script

### DIFF
--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -123,14 +123,17 @@ if [ -z $(which java) ]; then
     exit -1
 fi
 
-version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+fullVersion=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+versionWithoutPrefix=${fullVersion#"1."} # Remove prefix "1." if exists
+majorVersion=${versionWithoutPrefix%%.*} # Remove everything after first dot
+
 if [ "$SPARK_MAJOR_VERSION" == "2.1" ]; then
-   if [[ "$version" < "1.7" ]]; then
+   if [[ "$majorVersion" -lt 7 ]]; then
       echo "Java 7 or higher is required to run Spark $SPARK_VERSION"
       exit -1
    fi
 else
-   if [[ "$version" < "1.8" ]]; then
+   if [[ "$majorVersion" -lt 8 ]]; then
       echo "Java 8 or higher is required to run Spark $SPARK_VERSION"
       exit -1
    fi


### PR DESCRIPTION
The current check expects Java version to start with "1.x". This requirement doesn't go well with Java 11+ where the prefix `1.` is omitted.