### PR TITLE
[SW-2602][HOTFIX] Fix booklet build for Spark 2.4

### DIFF
--- a/booklet/build.gradle
+++ b/booklet/build.gradle
@@ -2,6 +2,7 @@ description = "Sparkling Water Booklet"
 
 dependencies {
   implementation("org.scala-lang:scala-library:${scalaVersion}")
+  implementation("org.scala-lang:scala-reflect:${scalaVersion}")
   implementation(project(':sparkling-water-utils'))
   implementation(project(':sparkling-water-core'))
   implementation("org.apache.spark:spark-core_${scalaBaseVersion}:${sparkVersion}")


### PR DESCRIPTION
SW relese build for Spark 2.4 fails on the following error:
```

[2021-08-20T16:00:29.351Z] 

[2021-08-20T16:00:29.351Z] > Task :sparkling-water-booklet:generateConfiguration FAILED

[2021-08-20T16:00:29.351Z] Exception in thread "main" java.lang.NoClassDefFoundError: scala/reflect/api/TypeCreator

[2021-08-20T16:00:29.351Z] 	at ai.h2o.sparkling.booklet.generation.ConfigurationRunner$.main(ConfigurationRunner.scala:36)

[2021-08-20T16:00:29.351Z] 	at ai.h2o.sparkling.booklet.generation.ConfigurationRunner.main(ConfigurationRunner.scala)

[2021-08-20T16:00:29.351Z] Caused by: java.lang.ClassNotFoundException: scala.reflect.api.TypeCreator

[2021-08-20T16:00:29.351Z] 	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)

[2021-08-20T16:00:29.352Z] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)

[2021-08-20T16:00:29.352Z] 	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)

[2021-08-20T16:00:29.352Z] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)

[2021-08-20T16:00:29.352Z] 	... 2 more
```

I've managed to repreduce the problem. After adding the dependecy, I'm able to execute the task