### PR TITLE
[SW-2603] Remove Cross-validation-related Parameters from H2OAutoEncoder

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/IgnoredParameters.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/IgnoredParameters.scala
@@ -57,7 +57,12 @@ object IgnoredParameters {
           "regression_stop",
           "autoencoder",
           "col_major",
-          "auc_type")
+          "auc_type",
+          "nfolds",
+          "fold_assignment",
+          "keep_cross_validation_models",
+          "keep_cross_validation_predictions",
+          "keep_cross_validation_fold_assignment")
       case _ => Seq.empty
     }
   }


### PR DESCRIPTION
From [H2O documentation](https://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/deep-learning.html?highlight=autoencoder):

>Note: Cross-validation is not supported when autoencoder is enabled. 