### PR TITLE
[SW-2588] Expose Model Metrics as Objects on H2OMOJOModel in Python API

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/MOJOModelAPIRunner.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/MOJOModelAPIRunner.scala
@@ -29,7 +29,7 @@ object MOJOModelAPIRunner
   private val mojoTemplates = Map("scala" -> scala.MOJOModelTemplate, "py" -> python.MOJOModelTemplate)
   private val mojoFactoryTemplates =
     Map("scala" -> scala.MOJOModelFactoryTemplate, "py" -> python.MOJOModelFactoryTemplate)
-  private val metricsTemplates = Map("scala" -> scala.ModelMetricsTemplate)
+  private val metricsTemplates = Map("scala" -> scala.ModelMetricsTemplate, "py" -> python.ModelMetricsTemplate)
 
   def main(args: Array[String]): Unit = {
     val languageExtension = args(0)
@@ -51,10 +51,19 @@ object MOJOModelAPIRunner
     val content = mojoFactoryTemplates(languageExtension)(mojoConfiguration)
     writeResultToFile(content, mojoFactoryContext, languageExtension, destinationDir)
 
-    if (languageExtension == "scala")
-      for (metricsContext <- metricsConfiguration) {
-        val content = metricsTemplates(languageExtension)(metricsContext)
-        writeResultToFile(content, metricsContext, languageExtension, destinationDir)
-      }
+    for (metricsContext <- metricsConfiguration) {
+      val content = metricsTemplates(languageExtension)(metricsContext)
+      writeResultToFile(content, metricsContext, languageExtension, destinationDir)
+    }
+
+    if (languageExtension == "py") {
+      val metricsFactoryContext = metricsConfiguration.head.copy(entityName = "H2OMetricsFactory")
+      val content = python.MetricsBaseTemplate(metricsConfiguration)
+      writeResultToFile(content, metricsFactoryContext, languageExtension, destinationDir)
+
+      val metricsInitContext = metricsConfiguration.head.copy(entityName = "__init__")
+      val initContent = python.MetricsInitTemplate(metricsConfiguration :+ metricsFactoryContext)
+      writeResultToFile(initContent, metricsInitContext, languageExtension, destinationDir)
+    }
   }
 }

--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/python/MetricsBaseTemplate.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/python/MetricsBaseTemplate.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.h2o.sparkling.api.generation.python
+
+import ai.h2o.sparkling.api.generation.common.{EntitySubstitutionContext, ModelMetricsSubstitutionContext}
+
+object MetricsBaseTemplate extends ((Seq[ModelMetricsSubstitutionContext]) => String) with PythonEntityTemplate {
+
+  def apply(metricSubstitutionContexts: Seq[ModelMetricsSubstitutionContext]): String = {
+    val metricClasses = metricSubstitutionContexts.map(_.entityName)
+    val imports = Seq("py4j.java_gateway.JavaObject") ++
+      metricClasses.map(metricClass => s"ai.h2o.sparkling.ml.metrics.$metricClass.$metricClass")
+
+    val entitySubstitutionContext = EntitySubstitutionContext(
+      metricSubstitutionContexts.head.namespace,
+      "H2OMetricsFactory",
+      inheritedEntities = Seq.empty,
+      imports)
+
+    generateEntity(entitySubstitutionContext) {
+      s"""    def __init__(self, javaObject):
+         |        self._java_obj = javaObject
+         |
+         |    @staticmethod
+         |    def fromJavaObject(javaObject):
+         |        if javaObject is None:
+         |            return None
+         |${generatePatternMatchingCases(metricSubstitutionContexts)}
+         |        else:
+         |            return H2OCommonMetrics(javaObject)""".stripMargin
+    }
+  }
+
+  private def generatePatternMatchingCases(metricSubstitutionContexts: Seq[ModelMetricsSubstitutionContext]): String = {
+    metricSubstitutionContexts
+      .map { metricSubstitutionContext =>
+        val metricsObjectName = metricSubstitutionContext.entityName
+        s"""        elif javaObject.getClass().getSimpleName() == "$metricsObjectName":
+           |            return $metricsObjectName(javaObject)""".stripMargin
+      }
+      .mkString("\n")
+  }
+}

--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/python/ModelMetricsTemplate.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/python/ModelMetricsTemplate.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.h2o.sparkling.api.generation.python
+
+import ai.h2o.sparkling.api.generation.common._
+
+object ModelMetricsTemplate
+  extends (ModelMetricsSubstitutionContext => String)
+  with PythonEntityTemplate
+  with MetricResolver {
+
+  def apply(substitutionContext: ModelMetricsSubstitutionContext): String = {
+    val metrics = resolveMetrics(substitutionContext)
+
+    val parentEntities = substitutionContext.parentEntities.diff(Seq("H2OMetrics", "H2OGLMMetrics"))
+
+    val imports = Seq("pyspark.ml.param.*", "ai.h2o.sparkling.ml.params.H2OTypeConverters.H2OTypeConverters") ++
+      parentEntities.map(parent => s"ai.h2o.sparkling.ml.metrics.$parent.$parent")
+
+    val entitySubstitutionContext =
+      EntitySubstitutionContext(substitutionContext.namespace, substitutionContext.entityName, parentEntities, imports)
+
+    generateEntity(entitySubstitutionContext) {
+      s"""    def __init__(self, java_obj):
+        |        self._java_obj = java_obj
+        |
+        |${generateGetterMethods(metrics)}""".stripMargin
+    }
+  }
+
+  private def generateGetterMethods(metrics: Seq[Metric]): String = {
+    metrics
+      .map { metric =>
+        val valueConversion = generateValueConversion(metric)
+        s"""    def get${metric.swMetricName}(self):
+           |        \"\"\"
+           |        ${resolveComment(metric)}
+           |        \"\"\"
+           |        value = self._java_obj.get${metric.swMetricName}()
+           |        return $valueConversion""".stripMargin
+      }
+      .mkString("\n\n")
+  }
+
+  private def generateValueConversion(metric: Metric): String = metric.dataType match {
+    case x if x.isPrimitive => "value"
+    case x if x.getSimpleName == "String" => "value"
+    case x if x.getSimpleName == "TwoDimTableV3" => "H2OTypeConverters.scalaToPythonDataFrame(value)"
+    case x if x.getSimpleName == "ConfusionMatrixV3" => "H2OTypeConverters.scalaToPythonDataFrame(value)"
+  }
+
+  private def resolveComment(metric: Metric): String = {
+    if (metric.comment.endsWith(".")) metric.comment else metric.comment + "."
+  }
+}

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/H2OMOJOModelParams.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/H2OMOJOModelParams.py
@@ -31,30 +31,66 @@ class H2OMOJOModelParams:
         return H2OTypeConverters.scalaMapStringDictStringToStringDictString(self._java_obj.getDomainValues())
 
     def getTrainingMetrics(self):
+        """
+        :return: A map of all metrics of the float type calculated on the training dataset.
+        """
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getTrainingMetrics())
 
     def getTrainingMetricsObject(self):
+        """
+        :return: An object holding all metrics of the float type and also more complex performance information
+        calculated on the training dataset.
+        """
         return H2OMetricsFactory.fromJavaObject(self._java_obj.getTrainingMetricsObject())
 
     def getValidationMetrics(self):
+        """
+        :return: A map of all metrics of the float type calculated on the validation dataset.
+        """
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getValidationMetrics())
 
     def getValidationMetricsObject(self):
+        """
+        :return: An object holding all metrics of the float type and also more complex performance information
+        calculated on the validation dataset.
+        """
         return H2OMetricsFactory.fromJavaObject(self._java_obj.getValidationMetricsObject())
 
     def getCrossValidationMetrics(self):
+        """
+        :return: A map of all combined cross-validation holdout metrics of the float type.
+        """
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getCrossValidationMetrics())
 
     def getCrossValidationMetricsObject(self):
+        """
+        :return: An object holding all metrics of the Double type and also more complex performance information
+        combined from cross-validation holdouts.
+        """
         return H2OMetricsFactory.fromJavaObject(self._java_obj.getCrossValidationMetricsObject())
 
     def getCurrentMetrics(self):
+        """
+        :return: A map of all metrics of the Double type. If the nfolds parameter was set, the metrics were combined
+        from cross-validation holdouts. If cross validations wasn't enabled, the metrics were calculated from
+        a validation dataset. If the validation dataset wasn't available, the metrics were calculated from
+        the training dataset.
+        """
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getCurrentMetrics())
 
     def getCurrentMetricsObject(self):
+        """
+        :return: An object holding all metrics of the Double type and also more complex performance information.
+        If the nfolds parameter was set, the object was combined from cross-validation holdouts. If cross validations
+        wasn't enabled, the object was calculated from a validation dataset. If the validation dataset wasn't available,
+        the object was calculated from the training dataset.
+        """
         return H2OMetricsFactory.fromJavaObject(self._java_obj.getCurrentMetricsObject())
 
     def getCrossValidationMetricsSummary(self):
+        """
+        :return: A data frame with information about performance of individual folds according to various model metrics.
+        """
         return H2OTypeConverters.scalaToPythonDataFrame(self._java_obj.getCrossValidationMetricsSummary())
 
     def getTrainingParams(self):

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/H2OMOJOModelParams.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/H2OMOJOModelParams.py
@@ -18,6 +18,7 @@
 from ai.h2o.sparkling.ml.models.H2OMOJOModelBase import H2OMOJOModelBase
 from ai.h2o.sparkling.ml.models.H2OAlgorithmMOJOModelBase import H2OAlgorithmMOJOModelBase
 from ai.h2o.sparkling.ml.params.H2OTypeConverters import H2OTypeConverters
+from ai.h2o.sparkling.ml.metrics.H2OMetricsFactory import H2OMetricsFactory
 from pyspark.ml.param import *
 
 
@@ -32,17 +33,29 @@ class H2OMOJOModelParams:
     def getTrainingMetrics(self):
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getTrainingMetrics())
 
+    def getTrainingMetricsObject(self):
+        return H2OMetricsFactory.fromJavaObject(self._java_obj.getTrainingMetricsObject())
+
     def getValidationMetrics(self):
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getValidationMetrics())
+
+    def getValidationMetricsObject(self):
+        return H2OMetricsFactory.fromJavaObject(self._java_obj.getValidationMetricsObject())
 
     def getCrossValidationMetrics(self):
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getCrossValidationMetrics())
 
-    def getCrossValidationMetricsSummary(self):
-        return H2OTypeConverters.scalaToPythonDataFrame(self._java_obj.getCrossValidationMetricsSummary())
+    def getCrossValidationMetricsObject(self):
+        return H2OMetricsFactory.fromJavaObject(self._java_obj.getCrossValidationMetricsObject())
 
     def getCurrentMetrics(self):
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getCurrentMetrics())
+
+    def getCurrentMetricsObject(self):
+        return H2OMetricsFactory.fromJavaObject(self._java_obj.getCurrentMetricsObject())
+
+    def getCrossValidationMetricsSummary(self):
+        return H2OTypeConverters.scalaToPythonDataFrame(self._java_obj.getCrossValidationMetricsSummary())
 
     def getTrainingParams(self):
         return H2OTypeConverters.scalaMapStringStringToDictStringAny(self._java_obj.getTrainingParams())

--- a/py/tests/unit/with_runtime_sparkling/test_mojo.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo.py
@@ -235,3 +235,29 @@ def testCrossValidationModelsAreNoneIfKeepCrossValidationModelsIsFalse(prostateD
     model = gbm.fit(prostateDataset)
 
     assert model.getCrossValidationModels() is None
+
+
+def testMetricObjects(prostateDataset):
+    gbm = H2OGBM(ntrees=2, seed=42, distribution="bernoulli", labelCol="capsule",
+                 nfolds=3, keepCrossValidationModels=False)
+    model = gbm.fit(prostateDataset)
+
+    def compareMetricValues(metricsObject, metricsMap):
+        for metric in metricsMap:
+            metricValue = metricsMap[metric]
+            objectValue = getattr(metricsObject, "get" + metric)()
+            assert(metricValue == objectValue)
+        assert metricsObject.getConfusionMatrix().count() > 0
+        assert len(metricsObject.getConfusionMatrix().columns) > 0
+        assert metricsObject.getGainsLiftTable().count() > 0
+        assert len(metricsObject.getGainsLiftTable().columns) > 0
+        assert metricsObject.getMaxCriteriaAndMetricScores().count() > 0
+        assert len(metricsObject.getMaxCriteriaAndMetricScores().columns) > 0
+        assert metricsObject.getThresholdsAndMetricScores().count() > 0
+        assert len(metricsObject.getThresholdsAndMetricScores().columns) > 0
+
+    compareMetricValues(model.getTrainingMetricsObject(), model.getTrainingMetrics())
+    compareMetricValues(model.getCrossValidationMetricsObject(), model.getCrossValidationMetrics())
+    compareMetricValues(model.getCurrentMetricsObject(), model.getCurrentMetrics())
+    assert model.getValidationMetricsObject() is None
+    assert model.getValidationMetrics() == {}

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOModel.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOModel.scala
@@ -125,7 +125,7 @@ abstract class H2OMOJOModel
   def getValidationMetricsObject(): H2OMetrics = $(validationMetricsObject)
 
   /**
-    * Returns a map of all combined cross-validation holdout metrics of the Double Type.
+    * Returns a map of all combined cross-validation holdout metrics of the Double type.
     */
   def getCrossValidationMetrics(): Map[String, Double] = $(crossValidationMetrics)
 
@@ -153,9 +153,10 @@ abstract class H2OMOJOModel
   }
 
   /**
-    * Returns a map of all metrics of the Double type. If the nfolds parameter was set, the object was combined from
-    * cross-validation holdouts. If cross validations wasn't enabled, the object was calculated from a validation
-    * dataset. If the validation dataset wasn't available, the object was calculated from the training dataset.
+    * Returns an object holding all metrics of the Double type and also more complex performance information.
+    * If the nfolds parameter was set, the object was combined from cross-validation holdouts. If cross validations
+    * wasn't enabled, the object was calculated from a validation dataset. If the validation dataset wasn't available,
+    * the object was calculated from the training dataset.
     */
   def getCurrentMetricsObject(): H2OMetrics = {
     val nfolds = $(trainingParams).get("nfolds")
@@ -169,6 +170,9 @@ abstract class H2OMOJOModel
     }
   }
 
+  /**
+    * Returns a data frame with information about performance of individual folds according to various model metrics.
+    */
   def getCrossValidationMetricsSummary(): DataFrame = $(crossValidationMetricsSummary)
 
   def getTrainingParams(): Map[String, String] = $(trainingParams)


### PR DESCRIPTION
Generated files:
[__init__.py.txt](https://github.com/h2oai/sparkling-water/files/7068576/__init__.py.txt)
[H2OAnomalyMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068577/H2OAnomalyMetrics.py.txt)
[H2OAutoEncoderMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068578/H2OAutoEncoderMetrics.py.txt)
[H2OBinomialGLMMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068579/H2OBinomialGLMMetrics.py.txt)
[H2OBinomialMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068580/H2OBinomialMetrics.py.txt)
[H2OClusteringMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068581/H2OClusteringMetrics.py.txt)
[H2OCommonMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068582/H2OCommonMetrics.py.txt)
[H2OGLRMMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068583/H2OGLRMMetrics.py.txt)
[H2OMetricsFactory.py.txt](https://github.com/h2oai/sparkling-water/files/7068584/H2OMetricsFactory.py.txt)
[H2OMultinomialGLMMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068585/H2OMultinomialGLMMetrics.py.txt)
[H2OMultinomialMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068586/H2OMultinomialMetrics.py.txt)
[H2OOrdinalGLMMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068587/H2OOrdinalGLMMetrics.py.txt)
[H2OOrdinalMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068588/H2OOrdinalMetrics.py.txt)
[H2OPCAMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068589/H2OPCAMetrics.py.txt)
[H2ORegressionCoxPHMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068590/H2ORegressionCoxPHMetrics.py.txt)
[H2ORegressionGLMMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068591/H2ORegressionGLMMetrics.py.txt)
[H2ORegressionMetrics.py.txt](https://github.com/h2oai/sparkling-water/files/7068592/H2ORegressionMetrics.py.txt)
