### PR TITLE
[SW-2607] Change Error Caused by Setting MOJO Model Parameters to Warning

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/scala/MOJOModelTemplate.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/scala/MOJOModelTemplate.scala
@@ -126,7 +126,9 @@ object MOJOModelTemplate
            |          set("$swName", convertedValue)
            |        }
            |      } catch {
-           |        case e: Throwable => logError("An error occurred during setting up the '$swName' parameter.", e)
+           |        case e: Throwable =>
+           |          logWarning("An error occurred during setting up the '$swName' parameter. The method " +
+           |          "get${swName.capitalize}() on the MOJO model object won't be able to provide the actual value.", e)
            |      }""".stripMargin
       }
       .mkString("\n\n")


### PR DESCRIPTION
When `H2OMOJOModel` is loaded, it parsers training parameter values from mojo internals. When parsing of an individual parameter goes wrong, an error could be displayed in `sparkling-shell` and that's confusing for users.:
![image](https://user-images.githubusercontent.com/3674621/132203779-dc0d03e8-b288-427d-9693-682ccc3897fa.png)

Since training parameter values are not the key functionality and  the model can be still used for scoring, I'm suggesting to change such errors to warnings.