### PR TITLE
[SW-2609] Update AutoML Tests to Consider 3 StackEnsamble Models in Leaderboard

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_automl.py
+++ b/py/tests/unit/with_runtime_sparkling/test_automl.py
@@ -159,12 +159,13 @@ def testBlendingDataFrameHasImpactOnAutoMLStackedEnsambleModels(classificationDa
     automl = setParametersForTesting(H2OAutoML())
     automl.fit(trainingDateset)
     defaultLeaderboard = separateEnsembleModels(prepareLeaderboardForComparison(automl.getLeaderboard()))
+    automl.getLeaderboard().show(truncate=False)
 
     automl = setParametersForTesting(H2OAutoML()).setBlendingDataFrame(blendingDataset)
     automl.fit(trainingDateset)
     leaderboardWithBlendingFrameSet = separateEnsembleModels(prepareLeaderboardForComparison(automl.getLeaderboard()))
 
-    assert defaultLeaderboard[0].count() == 2
+    assert defaultLeaderboard[0].count() == 3
     unit_test_utils.assert_data_frames_have_different_values(defaultLeaderboard[0], leaderboardWithBlendingFrameSet[0])
     unit_test_utils.assert_data_frames_are_identical(defaultLeaderboard[1], leaderboardWithBlendingFrameSet[1])
 


### PR DESCRIPTION
The other PR fails because of the change in AutoML. The number of StackEnsemble models was increased from 2 to 3.