### PR TITLE
[SW-2612] Change K8s Base Image for Spark 2.4 to openjdk:8-jdk-slim-buster

### DIFF
--- a/ci/build.gradle
+++ b/ci/build.gradle
@@ -50,7 +50,7 @@ task createDockerfile(type: Dockerfile, dependsOn: copyFiles) {
                     rm -rf spark-${version}-bin-hadoop2.7.tgz
                     """
     if (version.startsWith("2.4")) {
-      runCommand "sed -i 's/openjdk:8-jdk-slim/openjdk:11-jre-slim/g' /home/jenkins/spark-${version}-bin-hadoop2.7/kubernetes/dockerfiles/spark/Dockerfile"
+      runCommand "sed -i 's/openjdk:8-jdk-slim/openjdk:8-jdk-slim-buster/g' /home/jenkins/spark-${version}-bin-hadoop2.7/kubernetes/dockerfiles/spark/Dockerfile"
     }
     def first = version.split("\\.")[0]
     def second = version.split("\\.")[1]

--- a/ci/build.gradle
+++ b/ci/build.gradle
@@ -49,7 +49,9 @@ task createDockerfile(type: Dockerfile, dependsOn: copyFiles) {
                     tar zxvf spark-${version}-bin-hadoop2.7.tgz -C spark-${version}-bin-hadoop2.7 --strip-components 1 && \\
                     rm -rf spark-${version}-bin-hadoop2.7.tgz
                     """
-
+    if (version.startsWith("2.4")) {
+      runCommand "sed -i 's/openjdk:8-jdk-slim/openjdk:11-jre-slim/g' /home/jenkins/spark-${version}-bin-hadoop2.7/kubernetes/dockerfiles/spark/Dockerfile"
+    }
     def first = version.split("\\.")[0]
     def second = version.split("\\.")[1]
     environmentVariable("SPARK_HOME_${first}_${second}", "/home/jenkins/spark-${version}-bin-hadoop2.7")

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Version of Terraform used in the script creating the docker image
 terraformVersion=0.12.25
 # Version of docker image used in Jenkins tests
-dockerImageVersion=48
+dockerImageVersion=49
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions


### PR DESCRIPTION
`openjdk:8-jdk-slim` used to be based on the buster (debian apt) repository:
```
/etc/apt/sources.list:# deb http://snapshot.debian.org/archive/debian/20210621T000000Z buster main
/etc/apt/sources.list:deb http://deb.debian.org/debian buster main
/etc/apt/sources.list:# deb http://snapshot.debian.org/archive/debian-security/20210621T000000Z buster/updates main
/etc/apt/sources.list:deb http://security.debian.org/debian-security buster/updates main
/etc/apt/sources.list:# deb http://snapshot.debian.org/archive/debian/20210621T000000Z buster-updates main
/etc/apt/sources.list:deb http://deb.debian.org/debian buster-updates main
```

now it's based on the bullseye (debian apt) repository:
```
/etc/apt/sources.list:# deb http://snapshot.debian.org/archive/debian/20210902T000000Z bullseye main
/etc/apt/sources.list:deb http://deb.debian.org/debian bullseye main
/etc/apt/sources.list:# deb http://snapshot.debian.org/archive/debian-security/20210902T000000Z bullseye-security main
/etc/apt/sources.list:deb http://security.debian.org/debian-security bullseye-security main
/etc/apt/sources.list:# deb http://snapshot.debian.org/archive/debian/20210902T000000Z bullseye-updates main
/etc/apt/sources.list:deb http://deb.debian.org/debian bullseye-updates main
```

This repository change causes failure of building `spark-py` docker image for the version 2.4. The newer repo is missing packages for python 2.7. 

This PR changes the base image for Spark 2.4 images to `openjdk:8-jdk-slim-buster`. The change was manually verified on EKS cluster.