### PR TITLE
[SW-2030] Fix Intermittent Failure of PCA Tests

### DIFF
--- a/ml/src/test/scala/ai/h2o/sparkling/ml/features/H2OPCATestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/features/H2OPCATestSuite.scala
@@ -121,10 +121,12 @@ class H2OPCATestSuite extends FunSuite with Matchers with SharedH2OTestContext {
         .setInputCols("RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON")
         .setK(4)
         .setImputeMissing(true)
+        .setSeed(42)
 
       val gbm = new H2OGBM()
         .setFeaturesCol(pca.getOutputCol())
         .setLabelCol("CAPSULE")
+        .setSeed(42)
 
       val pipeline = new Pipeline().setStages(Array(pca, gbm))
 
@@ -141,15 +143,18 @@ class H2OPCATestSuite extends FunSuite with Matchers with SharedH2OTestContext {
       val autoEncoder = new H2OAutoEncoder()
         .setInputCols("RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON")
         .setHidden(Array(100))
+        .setSeed(42)
 
       val pca = new H2OPCA()
         .setInputCols(autoEncoder.getOutputCol())
         .setK(3)
         .setImputeMissing(true)
+        .setSeed(42)
 
       val gbm = new H2OGBM()
         .setFeaturesCol(pca.getOutputCol())
         .setLabelCol("CAPSULE")
+        .setSeed(42)
 
       val pipeline = new Pipeline().setStages(Array(autoEncoder, pca, gbm))
 

--- a/py/tests/unit/with_runtime_sparkling/test_pca.py
+++ b/py/tests/unit/with_runtime_sparkling/test_pca.py
@@ -39,11 +39,13 @@ def testUsageOfPCAInAPipeline(prostateDataset):
     pca = H2OPCA() \
         .setInputCols(["RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON"]) \
         .setK(3) \
-        .setImputeMissing(True)
+        .setImputeMissing(True) \
+        .setSeed(42)
 
     gbm = H2OGBM() \
         .setFeaturesCols([pca.getOutputCol()]) \
-        .setLabelCol("CAPSULE")
+        .setLabelCol("CAPSULE") \
+        .setSeed(42)
 
     pipeline = Pipeline(stages=[pca, gbm])
 


### PR DESCRIPTION
It happens time to time that one of the PCA tests fails with the following error:
```

[2021-09-15T12:29:48.534Z] ai.h2o.sparkling.ml.features.H2OPCATestSuite > A pipeline with a PCA model sourcing data from vector column transforms testing dataset without an exception FAILED

[2021-09-15T12:29:48.534Z]     org.scalatest.exceptions.TestFailedException: 1 was not greater than or equal to 2

[2021-09-15T12:29:48.534Z]         at org.scalatest.MatchersHelper$.newTestFailedException(MatchersHelper.scala:160)

[2021-09-15T12:29:48.534Z]         at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6482)

[2021-09-15T12:29:48.534Z]         at ai.h2o.sparkling.ml.features.H2OPCATestSuite$$anonfun$6.apply$mcV$sp(H2OPCATestSuite.scala:159)

[2021-09-15T12:29:48.534Z]         at ai.h2o.sparkling.ml.features.H2OPCATestSuite$$anonfun$6.apply(H2OPCATestSuite.scala:140)

[2021-09-15T12:29:48.534Z]         at ai.h2o.sparkling.ml.features.H2OPCATestSuite$$anonfun$6.apply(H2OPCATestSuite.scala:140)

[2021-09-15T12:29:48.534Z]         at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)

[2021-09-15T12:29:48.534Z]         at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)

[2021-09-15T12:29:48.534Z]         at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)

[2021-09-15T12:29:48.534Z]         at org.scalatest.Transformer.apply(Transformer.scala:22)

[2021-09-15T12:29:48.534Z]         at org.scalatest.Transformer.apply(Transformer.scala:20)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:166)

[2021-09-15T12:29:48.534Z]         at org.scalatest.Suite$class.withFixture(Suite.scala:1122)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuite.withFixture(FunSuite.scala:1555)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$class.invokeWithFixture$1(FunSuiteLike.scala:163)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)

[2021-09-15T12:29:48.534Z]         at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$class.runTest(FunSuiteLike.scala:175)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuite.runTest(FunSuite.scala:1555)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$$anonfun$runTests$1.apply(FunSuiteLike.scala:208)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$$anonfun$runTests$1.apply(FunSuiteLike.scala:208)

[2021-09-15T12:29:48.534Z]         at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:413)

[2021-09-15T12:29:48.534Z]         at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:401)

[2021-09-15T12:29:48.534Z]         at scala.collection.immutable.List.foreach(List.scala:392)

[2021-09-15T12:29:48.534Z]         at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)

[2021-09-15T12:29:48.534Z]         at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:396)

[2021-09-15T12:29:48.534Z]         at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:483)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$class.runTests(FunSuiteLike.scala:208)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuite.runTests(FunSuite.scala:1555)

[2021-09-15T12:29:48.534Z]         at org.scalatest.Suite$class.run(Suite.scala:1424)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1555)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$$anonfun$run$1.apply(FunSuiteLike.scala:212)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$$anonfun$run$1.apply(FunSuiteLike.scala:212)

[2021-09-15T12:29:48.534Z]         at org.scalatest.SuperEngine.runImpl(Engine.scala:545)

[2021-09-15T12:29:48.534Z]         at org.scalatest.FunSuiteLike$class.run(FunSuiteLike.scala:212)

[2021-09-15T12:29:48.534Z]         at ai.h2o.sparkling.ml.features.H2OPCATestSuite.org$scalatest$BeforeAndAfterAll$$super$run(H2OPCATestSuite.scala:32)

[2021-09-15T12:29:48.534Z]         at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:257)

[2021-09-15T12:29:48.534Z]         at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:256)


```