### PR TITLE
[SW-2615] Change K8s Base Image for Spark 3.0, 3.1 to openjdk:11-jre-slim-buster

### DIFF
--- a/bin/build-kubernetes-images.sh
+++ b/bin/build-kubernetes-images.sh
@@ -39,7 +39,7 @@ fi
 (cd "$SPARK_HOME" && \
  TMP_SPARK_R_DOCKERFILE=$(mktemp) && \
  sed  "s/apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'/apt-key adv --keyserver keyserver.ubuntu.com --recv-key FCAE2A0E115C3D8A/g" ./kubernetes/dockerfiles/spark/bindings/R/Dockerfile >> "$TMP_SPARK_R_DOCKERFILE" && \
- ./bin/docker-image-tool.sh -t "$INSTALLED_SPARK_FULL_VERSION" -p ./kubernetes/dockerfiles/spark/bindings/python/Dockerfile -R "$TMP_SPARK_R_DOCKERFILE" build && \
+ ./bin/docker-image-tool.sh -t "$INSTALLED_SPARK_FULL_VERSION" -p ./kubernetes/dockerfiles/spark/bindings/python/Dockerfile -R "$TMP_SPARK_R_DOCKERFILE" -b java_image_tag=11-jre-slim-buster build && \
  rm "$TMP_SPARK_R_DOCKERFILE")
 
 if [ "$1" = "scala" ]; then


### PR DESCRIPTION
The default image openjdk:11-jre-slim used to be based on the buster (debian apt) repository. It has been recently changed to bullseye. This repository change causes failure of building spark-py docker image for the version 3.0 and 3.1. The newer repo is missing packages for python 2.7. This PR changes the base image for Spark 3.0 and 3.1 images to openjdk:11-jre-slim-buster. 

The change was manually verified on EKS cluster.