### PR TITLE
[SW-2616] Enable Publishing of api-generation Project

### DIFF
--- a/api-generation/build.gradle
+++ b/api-generation/build.gradle
@@ -17,8 +17,6 @@ shadowJar {
   mergeServiceFiles()
 }
 
-artifacts {
-  api shadowJar
-}
-
 build.dependsOn shadowJar
+
+defineStandardPublication().call()

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ if (project.hasProperty("doRelease")) {
 ext {
   // Published projects
   publishedProjects = [
+    project(':sparkling-water-api-generation'),
     project(':sparkling-water-repl'),
     project(':sparkling-water-core'),
     project(':sparkling-water-examples'),

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -126,6 +126,7 @@ def distTaskDependencies = [
   ":sparkling-water-py:distPython",
   ":sparkling-water-py-scoring:distPython",
   ":sparkling-water-r:createCranRepo",
+  ":sparkling-water-api-generation:publish",
   ":sparkling-water-core:publish",
   ":sparkling-water-doc:publish",
   ":sparkling-water-repl:publish",


### PR DESCRIPTION
The [`sparkling-water-ml` project references](https://github.com/h2oai/sparkling-water/blob/master/ml/build.gradle#L29) `sparkling-water-api-generation` which is not currently published. 