### PR TITLE
[SW-2621] Fix Tests to Consider More Stacked Ensemble Models in AutoML Leaderborad

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_automl.py
+++ b/py/tests/unit/with_runtime_sparkling/test_automl.py
@@ -149,7 +149,7 @@ def testDeserializationOfUnfittedPipelineWithAutoML(classificationDataset):
 
 
 def testBlendingDataFrameHasImpactOnAutoMLStackedEnsambleModels(classificationDataset):
-    [trainingDateset, blendingDataset] = classificationDataset.randomSplit([0.9, 0.1], 42)
+    [trainingDateset, blendingDataset] = classificationDataset.randomSplit([0.8, 0.2], 42)
 
     def separateEnsembleModels(df):
         stackedEnsembleDF = df.filter(df.model_id.startswith('StackedEnsemble'))

--- a/py/tests/unit/with_runtime_sparkling/test_automl.py
+++ b/py/tests/unit/with_runtime_sparkling/test_automl.py
@@ -159,13 +159,13 @@ def testBlendingDataFrameHasImpactOnAutoMLStackedEnsambleModels(classificationDa
     automl = setParametersForTesting(H2OAutoML())
     automl.fit(trainingDateset)
     defaultLeaderboard = separateEnsembleModels(prepareLeaderboardForComparison(automl.getLeaderboard()))
-    automl.getLeaderboard().show(truncate=False)
 
     automl = setParametersForTesting(H2OAutoML()).setBlendingDataFrame(blendingDataset)
     automl.fit(trainingDateset)
     leaderboardWithBlendingFrameSet = separateEnsembleModels(prepareLeaderboardForComparison(automl.getLeaderboard()))
 
-    assert defaultLeaderboard[0].count() == 3
+    assert defaultLeaderboard[0].count() >= 3
+    assert defaultLeaderboard[0].count() == leaderboardWithBlendingFrameSet[0].count()
     unit_test_utils.assert_data_frames_have_different_values(defaultLeaderboard[0], leaderboardWithBlendingFrameSet[0])
     unit_test_utils.assert_data_frames_are_identical(defaultLeaderboard[1], leaderboardWithBlendingFrameSet[1])
 


### PR DESCRIPTION
The leaderboard from the current H2O-3 master:
```
         +---+--------------------------------------------------------+------------------+------------------+------------------+--------------------+-------------------+-------------------+
         |   |model_id                                                |auc               |logloss           |aucpr             |mean_per_class_error|rmse               |mse                |
         +---+--------------------------------------------------------+------------------+------------------+------------------+--------------------+-------------------+-------------------+
         |0  |GBM_2_AutoML_12_20211005_125025                         |0.8189505267823656|0.51098447144185  |0.7254775942015933|0.2210610658392717  |0.4099098864296385 |0.16802611499275913|
         |1  |StackedEnsemble_BestOfFamily_2_AutoML_12_20211005_125025|0.8138361348835624|0.5145285256992699|0.7126386867001973|0.22482866787139008 |0.41229128622838324|0.16998410469985464|
         |2  |StackedEnsemble_AllModels_4_AutoML_12_20211005_125025   |0.8135974632616182|0.5193676713371027|0.7159108131970929|0.2322786320706468  |0.41548867061921785|0.1726308354129249 |
         |3  |StackedEnsemble_AllModels_1_AutoML_12_20211005_125025   |0.8081762078488868|0.5177666450632897|0.7101197846736859|0.2273688158477957  |0.4136589970704447 |0.17111376585732616|
         |4  |StackedEnsemble_BestOfFamily_5_AutoML_12_20211005_125025|0.8055849159534931|0.5273658142697957|0.6970318898679998|0.23676224896859766 |0.42006801114899367|0.17645713399067106|
         |5  |XGBoost_2_AutoML_12_20211005_125025                     |0.805158716628593 |0.5352020934285693|0.6939419538468904|0.23710320842851784 |0.421333219489438  |0.17752168184533498|
         |6  |XGBoost_1_AutoML_12_20211005_125025                     |0.8007262436496301|0.5266346943864031|0.688158584634934 |0.24780933547001263 |0.4172537059941907 |0.17410065516588652|
         |7  |DRF_1_AutoML_12_20211005_125025                         |0.7955436598588428|0.5390491762275   |0.6937855470893075|0.250008523986498   |0.42506935565632503|0.18068395711808335|
         |8  |GBM_1_AutoML_12_20211005_125025                         |0.7949810767499745|0.538488449284472 |0.6922838909198165|0.24832077465989294 |0.4225585860982571 |0.17855575868535814|
         |9  |StackedEnsemble_BestOfFamily_1_AutoML_12_20211005_125025|0.7925432166115449|0.5351099783792104|0.6744397691805493|0.24675236114425994 |0.4208385964296348 |0.17710512424486502|
         |10 |StackedEnsemble_BestOfFamily_4_AutoML_12_20211005_125025|0.7840533260595315|0.5739099141007877|0.6542209760924224|0.2588905179174196  |0.4365256342776882 |0.190554629381538  |
         |11 |StackedEnsemble_BestOfFamily_3_AutoML_12_20211005_125025|0.7702615159057588|0.6697543682495838|0.6701693558769626|0.2812404105151898  |0.45607779339289317|0.20800695362613056|
         |12 |StackedEnsemble_AllModels_3_AutoML_12_20211005_125025   |0.7454396672235671|0.6414602177362841|0.587080734554267 |0.26782365576732925 |0.4567024742422281 |0.20857714997897303|
         |13 |StackedEnsemble_AllModels_2_AutoML_12_20211005_125025   |0.7439053496539261|0.7630363725572983|0.5836859523180545|0.2794162774046166  |0.473979601345055  |0.2246566624912173 |
         +---+--------------------------------------------------------+------------------+------------------+------------------+--------------------+-------------------+-------------------+
```