### PR TITLE
[SW-2640] InternalBackend Should Set IP Address Explicitly to H2O Node

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/internal/InternalBackendConf.scala
@@ -53,6 +53,9 @@ trait InternalBackendConf extends SharedBackendConf with InternalBackendConfExte
   def spreadRddRetriesTimeout: Int =
     sparkConf.getInt(PROP_SPREADRDD_RETRIES_TIMEOUT._1, PROP_SPREADRDD_RETRIES_TIMEOUT._2)
 
+  def isDirectIpConfigurationEnabled: Boolean =
+    sparkConf.getBoolean(PROP_DIRECT_IP_CONFIGURATION._1, PROP_DIRECT_IP_CONFIGURATION._2)
+
   /** Setters */
   def setNumH2OWorkers(numWorkers: Int): H2OConf = set(PROP_CLUSTER_SIZE._1, numWorkers.toString)
 
@@ -78,6 +81,10 @@ trait InternalBackendConf extends SharedBackendConf with InternalBackendConfExte
   }
 
   def setSpreadRddRetriesTimeout(timeout: Int): H2OConf = set(PROP_SPREADRDD_RETRIES_TIMEOUT._1, timeout.toString)
+
+  def setDirectIpConfigurationEnabled(): H2OConf = set(PROP_DIRECT_IP_CONFIGURATION._1, true)
+
+  def setDirectIpConfigurationDisabled(): H2OConf = set(PROP_DIRECT_IP_CONFIGURATION._1, false)
 }
 
 object InternalBackendConf {
@@ -145,4 +152,13 @@ object InternalBackendConf {
       |mechanism. That means that as long as the timeout hasn't expired, we keep
       |trying to discover new executors. This option might be useful in environments
       |where Spark executors might join the cloud with some delays.""".stripMargin)
+
+  val PROP_DIRECT_IP_CONFIGURATION: BooleanOption = (
+    "spark.ext.h2o.direct.configuration.ip",
+    true,
+    """setDirectIpConfigurationEnabled()
+      |setDirectIpConfigurationDisabled()""".stripMargin,
+    """If the property is disabled, Spark executor doesn't assign its IP address to H2O node directly. The IP address is
+      |suggested to H2O node and its bootstrap logic performs additional network interface availability checks before
+      |the IP is assigned to the node.""".stripMargin)
 }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -151,6 +151,7 @@ object InternalH2OBackend extends InternalBackendUtils {
     val args = getH2OWorkerArgs(conf)
     val launcherArgs = toH2OArgs(args)
     initializeH2OKerberizedHiveSupport(conf)
+    setSelfAddressToH2ONode(conf)
     H2OStarter.start(launcherArgs, true)
     NodeDesc(SparkEnv.get.executorId, H2O.SELF_ADDRESS.getHostAddress, H2O.API_PORT)
   }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -143,6 +143,7 @@ object InternalH2OBackend extends InternalBackendUtils {
     val args = getH2OWorkerAsClientArgs(conf)
     val launcherArgs = toH2OArgs(args)
     initializeH2OKerberizedHiveSupport(conf)
+    setSelfAddressToH2ONode(launcherArgs)
     H2OStarter.start(launcherArgs, true)
     conf.set(ExternalBackendConf.PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, H2O.getIpPortString)
   }
@@ -151,7 +152,7 @@ object InternalH2OBackend extends InternalBackendUtils {
     val args = getH2OWorkerArgs(conf)
     val launcherArgs = toH2OArgs(args)
     initializeH2OKerberizedHiveSupport(conf)
-    setSelfAddressToH2ONode(conf)
+    setSelfAddressToH2ONode(launcherArgs)
     H2OStarter.start(launcherArgs, true)
     NodeDesc(SparkEnv.get.executorId, H2O.SELF_ADDRESS.getHostAddress, H2O.API_PORT)
   }

--- a/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/backends/internal/InternalH2OBackend.scala
@@ -143,7 +143,7 @@ object InternalH2OBackend extends InternalBackendUtils {
     val args = getH2OWorkerAsClientArgs(conf)
     val launcherArgs = toH2OArgs(args)
     initializeH2OKerberizedHiveSupport(conf)
-    setSelfAddressToH2ONode(launcherArgs)
+    if (conf.isDirectIpConfigurationEnabled) setSelfAddressToH2ONode(launcherArgs)
     H2OStarter.start(launcherArgs, true)
     conf.set(ExternalBackendConf.PROP_EXTERNAL_CLUSTER_REPRESENTATIVE._1, H2O.getIpPortString)
   }
@@ -152,7 +152,7 @@ object InternalH2OBackend extends InternalBackendUtils {
     val args = getH2OWorkerArgs(conf)
     val launcherArgs = toH2OArgs(args)
     initializeH2OKerberizedHiveSupport(conf)
-    setSelfAddressToH2ONode(launcherArgs)
+    if (conf.isDirectIpConfigurationEnabled) setSelfAddressToH2ONode(launcherArgs)
     H2OStarter.start(launcherArgs, true)
     NodeDesc(SparkEnv.get.executorId, H2O.SELF_ADDRESS.getHostAddress, H2O.API_PORT)
   }


### PR DESCRIPTION
It seems that Databricks HC cluster doesn't allow ICMP echo requests to the address of eth0 worker interfaces. H2O nodes uses ICMP echo requests to check if the address and its interface is in the healthy state. The explicit setting of IP address should bypass this check which is in the context of SW unnecessary.