### PR TITLE
[SW-2650] Upgrade MOJO runtime to 2.5.12

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ h2oMajorName=zizler
 # H2O Build version, defined here to be overriden by -P option
 h2oBuild=4
 # Version of Mojo Pipeline library
-mojoPipelineVersion=2.5.3
+mojoPipelineVersion=2.5.12
 # Defines whether to run tests with Driverless AI mojo pipelines
 # These tests require the Driverless AI license
 testMojoPipeline=false


### PR DESCRIPTION
Upgrading to 2.5.12 for now. Upgrade to latest will be done in https://github.com/h2oai/sparkling-water/pull/2669 once we know the reason of differences.