### PR TITLE
[SW-2660] Use pypandoc 1.6.4 during Execution of Tests

### DIFF
--- a/py-scoring/build.gradle
+++ b/py-scoring/build.gradle
@@ -32,6 +32,7 @@ python {
 
   pip "pytz:2019.1" // Needed in Integration tests, but not PySparkling dependency
   pip "pytest:4.6.9" // For running tests
+  pip "pypandoc:1.6.4" // Dependency of PySpark (1.7+ is not compatible with Python 2.7)
   pip "numpy:${numpyVersion}"
   pip "pyspark:${sparkVersion}"
   if (project.hasProperty("pythonEnvBasePath")) {

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -36,6 +36,7 @@ python {
   pip "tabulate:0.8.3"
   pip "requests:2.21.0"
   pip "future:0.17.1"
+  pip "pipandoc:1.16.4"
   pip "numpy:${numpyVersion}"
   pip "pyspark:${sparkVersion}"
   if (project.hasProperty("pythonEnvBasePath")) {

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -36,7 +36,7 @@ python {
   pip "tabulate:0.8.3"
   pip "requests:2.21.0"
   pip "future:0.17.1"
-  pip "pypandoc:1.16.4"
+  pip "pypandoc:1.6.4" // Dependency of PySpark (1.7+ is not compatible with Python 2.7)
   pip "numpy:${numpyVersion}"
   pip "pyspark:${sparkVersion}"
   if (project.hasProperty("pythonEnvBasePath")) {

--- a/py/build.gradle
+++ b/py/build.gradle
@@ -36,7 +36,7 @@ python {
   pip "tabulate:0.8.3"
   pip "requests:2.21.0"
   pip "future:0.17.1"
-  pip "pipandoc:1.16.4"
+  pip "pypandoc:1.16.4"
   pip "numpy:${numpyVersion}"
   pip "pyspark:${sparkVersion}"
   if (project.hasProperty("pythonEnvBasePath")) {


### PR DESCRIPTION
pypandoc is a dependency of pyspark and the current version 1.7.1 (1.7.0) doesn't support python 2.7