### PR TITLE
[SW-2668] Move Removal of Certain Deep Learning Parameters from 3.36 to 3.38

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/AlgorithmConfigurations.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/common/AlgorithmConfigurations.scala
@@ -94,14 +94,14 @@ trait AlgorithmConfigurations extends ConfigurationsBase {
         "variable_importances",
         "HasDeprecatedVariableImportances",
         "variableImportances",
-        "3.36",
+        "3.38",
         Some("calculateFeatureImportances"),
         Some("HasDeprecatedVariableImportancesOnMOJO")),
       DeprecatedField(
         "autoencoder",
         "HasDeprecatedAutoencoder",
         "autoencoder",
-        "3.36",
+        "3.38",
         None,
         Some("HasDeprecatedAutoencoderOnMOJO")))
 

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -14,14 +14,6 @@ From 3.36 to 3.38
 
 - Boolean type mapping from Spark's DataFrame to H20Frame was changed from numerical 0, 1 to "0", "1" categorical values.
 
-From 3.34 to 3.36
------------------
-
-- The methods ``getWithDetailedPredictionCol`` and ``setWithDetailedPredictionCol`` on all SW Algorithms and
-  MOJO models were removed without replacement.
-
-- The ``withDetailedPredictionCol`` field on ``H2OMOJOSettings`` was removed without a replacement.
-
 - The parameter ``variableImportances`` of ``H2ODeepLearning`` has been replaced with ``calculateFeatureImportances`` as
   well as the methods ``getVariableImportances`` and ``setVariableImportances`` on ``H2ODeepLearning`` have been replaced
   with ``getCalculateFeatureImportances`` and ``setCalculateFeatureImportances``.
@@ -32,6 +24,14 @@ From 3.34 to 3.36
   removed without replacement.
 
 - The method ``getAutoencoder`` of ``H2ODeepLearningMOJOModel`` has been removed without replacement.
+
+From 3.34 to 3.36
+-----------------
+
+- The methods ``getWithDetailedPredictionCol`` and ``setWithDetailedPredictionCol`` on all SW Algorithms and
+  MOJO models were removed without replacement.
+
+- The ``withDetailedPredictionCol`` field on ``H2OMOJOSettings`` was removed without a replacement.
 
 From 3.32.1 to 3.34
 -------------------

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/HasDeprecatedAutoencoder.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/HasDeprecatedAutoencoder.scala
@@ -22,9 +22,9 @@ import org.apache.spark.expose.Logging
 
 trait HasDeprecatedAutoencoder extends Logging {
 
-  @DeprecatedMethod(version = "3.36")
+  @DeprecatedMethod(version = "3.38")
   def getAutoencoder(): Boolean = false
 
-  @DeprecatedMethod(version = "3.36")
+  @DeprecatedMethod(version = "3.38")
   def setAutoencoder(value: Boolean): this.type = this
 }

--- a/ml/src/main/scala/ai/h2o/sparkling/ml/params/HasDeprecatedVariableImportances.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/params/HasDeprecatedVariableImportances.scala
@@ -24,11 +24,11 @@ trait HasDeprecatedVariableImportances extends Logging {
 
   def getCalculateFeatureImportances(): Boolean
 
-  @DeprecatedMethod("getCalculateFeatureImportances", "3.36")
+  @DeprecatedMethod("getCalculateFeatureImportances", "3.38")
   def getVariableImportances(): Boolean = getCalculateFeatureImportances()
 
   def setCalculateFeatureImportances(value: Boolean): this.type
 
-  @DeprecatedMethod("setCalculateFeatureImportances", "3.36")
+  @DeprecatedMethod("setCalculateFeatureImportances", "3.38")
   def setVariableImportances(value: Boolean): this.type = setCalculateFeatureImportances(value)
 }

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/HasDeprecatedAutoencoder.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/HasDeprecatedAutoencoder.py
@@ -21,9 +21,9 @@ import warnings
 class HasDeprecatedAutoencoder(Params):
 
     def getAutoencoder(self):
-        warnings.warn("The method 'getAutoencoder' is deprecated and will be removed in the version 3.36.")
+        warnings.warn("The method 'getAutoencoder' is deprecated and will be removed in the version 3.38.")
         return False
 
     def setAutoencoder(self, value):
-        warnings.warn("The method 'setAutoencoder' is deprecated and will be removed in the version 3.36.")
+        warnings.warn("The method 'setAutoencoder' is deprecated and will be removed in the version 3.38.")
         return self

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/HasDeprecatedAutoencoderOnMOJO.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/HasDeprecatedAutoencoderOnMOJO.py
@@ -21,5 +21,5 @@ import warnings
 class HasDeprecatedAutoencoderOnMOJO(Params):
 
     def getAutoencoder(self):
-        warnings.warn("The method 'getAutoencoder' is deprecated and will be removed in the version 3.36.")
+        warnings.warn("The method 'getAutoencoder' is deprecated and will be removed in the version 3.38.")
         return False

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/HasDeprecatedVariableImportances.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/HasDeprecatedVariableImportances.py
@@ -21,12 +21,12 @@ import warnings
 class HasDeprecatedVariableImportances(Params):
 
     def getVariableImportances(self):
-        warnings.warn("The method 'getVariableImportances' is deprecated and will be removed in the version 3.36." +
+        warnings.warn("The method 'getVariableImportances' is deprecated and will be removed in the version 3.38." +
                       "The replacement is 'getCalculateFeatureImportances'.")
         return self.getCalculateFeatureImportances()
 
     def setVariableImportances(self, value):
-        warnings.warn("The method 'setVariableImportances' is deprecated and will be removed in the version 3.36." +
+        warnings.warn("The method 'setVariableImportances' is deprecated and will be removed in the version 3.38." +
                       "The replacement is 'setCalculateFeatureImportances'.")
         self.setCalculateFeatureImportances(value)
         return self

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/HasDeprecatedVariableImportancesOnMOJO.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/HasDeprecatedVariableImportancesOnMOJO.py
@@ -21,6 +21,6 @@ import warnings
 class HasDeprecatedVariableImportancesOnMOJO(Params):
 
     def getVariableImportances(self):
-        warnings.warn("The method 'getVariableImportances' is deprecated and will be removed in the version 3.36." +
+        warnings.warn("The method 'getVariableImportances' is deprecated and will be removed in the version 3.38." +
                       "The replacement is 'getCalculateFeatureImportances'.")
         return self.getCalculateFeatureImportances()

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/params/HasDeprecatedAutoencoderOnMOJO.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/params/HasDeprecatedAutoencoderOnMOJO.scala
@@ -22,6 +22,6 @@ import org.apache.spark.expose.Logging
 
 trait HasDeprecatedAutoencoderOnMOJO extends Logging {
 
-  @DeprecatedMethod(version = "3.36")
+  @DeprecatedMethod(version = "3.38")
   def getAutoencoder(): Boolean = false
 }

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/params/HasDeprecatedVariableImportancesOnMOJO.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/params/HasDeprecatedVariableImportancesOnMOJO.scala
@@ -24,6 +24,6 @@ trait HasDeprecatedVariableImportancesOnMOJO extends Logging {
 
   def getCalculateFeatureImportances(): Boolean
 
-  @DeprecatedMethod("getCalculateFeatureImportances", "3.36")
+  @DeprecatedMethod("getCalculateFeatureImportances", "3.38")
   def getVariableImportances(): Boolean = getCalculateFeatureImportances()
 }


### PR DESCRIPTION
The parameters and methods were deprecated in `3.34.0.1-1` which was released 4 months ago. This time is not enough long  for all users to be notified about the change.