### PR TITLE
[SW-2669] Move Removal of Items from org.apache.spark.h2o Namespace too 3.38 

### DIFF
--- a/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OConf.scala
@@ -34,16 +34,16 @@ class H2OConf(sparkConf: SparkConf) extends ai.h2o.sparkling.H2OConf(sparkConf) 
         "H2O client, set the configuration property 'spark.ext.h2o.rest.api.based.client' to true.")
   }
   logWarning(
-    "The class org.apache.spark.h2o.H2OConf is deprecated and will be removed in the version 3.36." +
+    "The class org.apache.spark.h2o.H2OConf is deprecated and will be removed in the version 3.38." +
       " Please use ai.h2o.sparkling.H2OConf instead.")
   def this() = this(SparkSessionUtils.active.sparkContext.getConf)
 }
 
 object H2OConf extends Logging {
-  @DeprecatedMethod("ai.h2o.sparkling.H2OConf", "3.36")
+  @DeprecatedMethod("ai.h2o.sparkling.H2OConf", "3.38")
   def apply(): H2OConf = new H2OConf()
 
-  @DeprecatedMethod("ai.h2o.sparkling.H2OConf", "3.36")
+  @DeprecatedMethod("ai.h2o.sparkling.H2OConf", "3.38")
   def apply(sparkConf: SparkConf): H2OConf = new H2OConf(sparkConf)
 
   private var _sparkConfChecked = false

--- a/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
+++ b/core/src/main/scala/org/apache/spark/h2o/H2OContext.scala
@@ -179,24 +179,24 @@ object H2OContext extends Logging {
 
   private val instantiatedContext = new AtomicReference[H2OContext]()
 
-  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.getOrCreate", "3.36")
+  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.getOrCreate", "3.38")
   def getOrCreate(): H2OContext = {
     val hc = ai.h2o.sparkling.H2OContext.getOrCreate()
     instantiatedContext.set(new H2OContext(hc))
     instantiatedContext.get()
   }
 
-  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.getOrCreate", "3.36")
+  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.getOrCreate", "3.38")
   def getOrCreate(conf: H2OConf): H2OContext = synchronized {
     val hc = ai.h2o.sparkling.H2OContext.getOrCreate(conf)
     instantiatedContext.set(new H2OContext(hc))
     instantiatedContext.get()
   }
 
-  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.get", "3.36")
+  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.get", "3.38")
   def get(): Option[H2OContext] = Option(instantiatedContext.get())
 
-  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.ensure", "3.36")
+  @DeprecatedMethod("ai.h2o.sparkling.H2OContext.ensure", "3.38")
   def ensure(onError: => String = "H2OContext has to be running."): H2OContext = {
     Option(instantiatedContext.get()) getOrElse {
       throw new RuntimeException(onError)

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -6,7 +6,12 @@ Migration guide between Sparkling Water versions.
 From 3.36 to 3.38
 -----------------
 
+- org.apache.spark.h2o.H2OConf has been replaced by ai.h2o.sparkling.H2OConf
+
+- org.apache.spark.h2o.H2OContext has been replaced by ai.h2o.sparkling.H2OContext
+
 - The support for Apache Spark 2.2.x has been removed.
+
 - Boolean type mapping from Spark's DataFrame to H20Frame was changed from numerical 0, 1 to "0", "1" categorical values.
 
 From 3.34 to 3.36


### PR DESCRIPTION
The items from `org.apache.spark.h2o` namespace will run thick H2O client (legacy and buggy), which hasn't been completely removed yet.