### PR TITLE
[SW-2670] Fix Databricks Smoke Tests

### DIFF
--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -248,7 +248,7 @@ node("docker") {
                     def dbcVersion = sparkSpecificProps["databricksVersion"]
                     def scalaVersion = sparkSpecificProps["scalaBaseVersion"]
                     sh """
-                        . /envs/sw_env_python3.6/bin/activate"
+                        . /envs/sw_env_python3.6/bin/activate
                         pip install databricks-cli
                         """
                     buildSparklingWater(props, sparkMajorVersion)

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -197,7 +197,10 @@ def buildSparklingWater(props, sparkMajorVersion) {
         """
     sh "H2O_HOME=${env.WORKSPACE}/h2o-3 ./gradlew dist -Pspark=$sparkMajorVersion -Dmaven.repo.local=${env.WORKSPACE}/.m2 -PbuildAgainstH2OBranch=${props["testH2OBranch"]} -Ph2oMajorVersion=${getH2OBranchMajorVersion()} -Ph2oMajorName=${getH2OBranchMajorName()} -Ph2oBuild=${getH2OBranchBuildVersion()}"
     dir("py/build/pkg") {
-        sh "python setup.py bdist_wheel"
+        sh """"
+            . /envs/sw_env_python3.6/bin/activate
+            python setup.py bdist_wheel
+            """
     }
 }
 
@@ -244,8 +247,10 @@ node("docker") {
                     def sparkSpecificProps = readPropertiesFile("gradle-spark${sparkMajorVersion}.properties")
                     def dbcVersion = sparkSpecificProps["databricksVersion"]
                     def scalaVersion = sparkSpecificProps["scalaBaseVersion"]
-                    sh ". /envs/sw_env_python3.6/bin/activate"
-                    sh "pip install databricks-cli"
+                    sh """
+                        . /envs/sw_env_python3.6/bin/activate"
+                        pip install databricks-cli
+                        """
                     buildSparklingWater(props, sparkMajorVersion)
                     String pythonArtifact = "h2o_pysparkling_${sparkMajorVersion}-${version.split("-")[0]}.post1-py2.py3-none-any.whl"
                     String scalaArtifact = "sparkling-water-assembly_${scalaVersion}-${version}-${sparkMajorVersion}-all.jar"

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -30,7 +30,7 @@ static String getSparklingVersion(props) {
     return "${props['version'].replace("-SNAPSHOT", "")}"
 }
 
-static String shWithSWPyEnv(String script, Boolean returnStdout = false) {
+def shWithSWPyEnv(String script, Boolean returnStdout = false) {
     def scriptWithPrefix =  """
         . /envs/sw_env_python3.6/bin/activate
         ${script}

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -98,7 +98,7 @@ static def getDatabricksSparkVersions(props) {
 def waitForArtifactToAttach(clusterId, artifact, type) {
     def ready = false
     while(!ready) {
-        def rawJson = sh(script: "databricks libraries cluster-status --cluster-id ${clusterId}", returnStdout: true).trim()
+        def rawJson = shWithSWPyEnv("databricks libraries cluster-status --cluster-id ${clusterId}").trim()
         def parsedJson = new JsonSlurperClassic().parseText(rawJson)
         def status = parsedJson.library_statuses.find { it.library[type] == "dbfs:/${clusterId}/${artifact}" }.status
         ready = status == "INSTALLED"

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -32,6 +32,7 @@ static String getSparklingVersion(props) {
 
 def startCluster(dbcVersion, sparkMajorVersion) {
     def jsonOutput = sh(script: """
+    . /envs/sw_env_python3.6/bin/activate
     databricks clusters create --json '{
         "num_workers": 3,
         "cluster_name": "SparklingWaterTest-${sparkMajorVersion}",
@@ -63,7 +64,10 @@ def startCluster(dbcVersion, sparkMajorVersion) {
 def waitForCluster(clusterId) {
     def ready = false
     while(!ready) {
-        def json = sh(script: "databricks clusters get --cluster-id ${clusterId}", returnStdout: true).trim()
+        def json = sh(script: """
+            . /envs/sw_env_python3.6/bin/activate
+            databricks clusters get --cluster-id ${clusterId}
+        """, returnStdout: true).trim()
         def jsonSlurper = new JsonSlurperClassic()
         def cfg = jsonSlurper.parseText(json)
         ready = cfg["state"] == "RUNNING"
@@ -75,7 +79,10 @@ def waitForCluster(clusterId) {
 }
 
 def deleteCluster(clusterId) {
-    sh "databricks clusters delete --cluster-id ${clusterId}"
+    sh """
+        . /envs/sw_env_python3.6/bin/activate
+        databricks clusters delete --cluster-id ${clusterId}
+    """
 }
 
 static def getDatabricksSparkVersions(props) {
@@ -89,7 +96,10 @@ static def getDatabricksSparkVersions(props) {
 def waitForArtifactToAttach(clusterId, artifact, type) {
     def ready = false
     while(!ready) {
-        def rawJson = sh(script: "databricks libraries cluster-status --cluster-id ${clusterId}", returnStdout: true).trim()
+        def rawJson = sh(script: """
+            . /envs/sw_env_python3.6/bin/activate
+            databricks libraries cluster-status --cluster-id ${clusterId}
+        """, returnStdout: true).trim()
         def parsedJson = new JsonSlurperClassic().parseText(rawJson)
         def status = parsedJson.library_statuses.find { it.library[type] == "dbfs:/${clusterId}/${artifact}" }.status
         ready = status == "INSTALLED"
@@ -103,16 +113,25 @@ def waitForArtifactToAttach(clusterId, artifact, type) {
 
 def installDependencies(clusterId, scalaArtifact, pythonArtifact, rArtifact) {
     // Scala
-    sh "databricks fs cp assembly/build/libs/${scalaArtifact} dbfs:/${clusterId}/${scalaArtifact}"
-    sh "databricks libraries install --cluster-id ${clusterId} --jar dbfs:/${clusterId}/${scalaArtifact}"
+    sh """
+        . /envs/sw_env_python3.6/bin/activate
+        databricks fs cp assembly/build/libs/${scalaArtifact} dbfs:/${clusterId}/${scalaArtifact}
+        databricks libraries install --cluster-id ${clusterId} --jar dbfs:/${clusterId}/${scalaArtifact}
+    """
     waitForArtifactToAttach(clusterId, scalaArtifact, "jar")
     // Python
-    sh "databricks fs cp py/build/pkg/dist/${pythonArtifact} dbfs:/${clusterId}/${pythonArtifact}"
-    sh "databricks libraries install --cluster-id ${clusterId} --whl dbfs:/${clusterId}/${pythonArtifact}"
+    sh """
+        . /envs/sw_env_python3.6/bin/activate
+        databricks fs cp py/build/pkg/dist/${pythonArtifact} dbfs:/${clusterId}/${pythonArtifact}
+        databricks libraries install --cluster-id ${clusterId} --whl dbfs:/${clusterId}/${pythonArtifact}
+    """
     waitForArtifactToAttach(clusterId, pythonArtifact, "whl")
     // R
-    sh "databricks fs cp r/build/${rArtifact} dbfs:/FileStore/${clusterId}/${rArtifact}"
-    sh "databricks fs cp h2o-3/h2o-r/h2o_*.99999.tar.gz dbfs:/FileStore/${clusterId}/h2o.tar.gz"
+    sh """
+        . /envs/sw_env_python3.6/bin/activate
+        databricks fs cp r/build/${rArtifact} dbfs:/FileStore/${clusterId}/${rArtifact}
+        databricks fs cp h2o-3/h2o-r/h2o_*.99999.tar.gz dbfs:/FileStore/${clusterId}/h2o.tar.gz
+    """
 }
 
 def test(workspaceDir, clusterId, language) {
@@ -120,8 +139,12 @@ def test(workspaceDir, clusterId, language) {
     if (language == "python") {
         extension = "py"
     }
-    sh "databricks workspace import --language ${language} ci/databricksTests/test.${extension} ${workspaceDir}/test.${extension}"
+    sh """
+        . /envs/sw_env_python3.6/bin/activate
+        databricks workspace import --language ${language} ci/databricksTests/test.${extension} ${workspaceDir}/test.${extension}
+    """
     def rawJson = sh(script: """
+        . /envs/sw_env_python3.6/bin/activate
         databricks runs submit --json '
             {
               "name": "Test ${language}",
@@ -141,7 +164,10 @@ def test(workspaceDir, clusterId, language) {
 def waitForJobToFinish(jobId, language, clusterId) {
     def done = false
     while(!done) {
-        def rawJson = sh(script: "databricks runs get --run-id ${jobId}", returnStdout: true).trim()
+        def rawJson = sh(script: """
+            . /envs/sw_env_python3.6/bin/activate
+            databricks runs get --run-id ${jobId}
+        """, returnStdout: true).trim()
         def parsedJson = new JsonSlurperClassic().parseText(rawJson)
         def status = parsedJson.state.result_state
         if (["FAILED", "TIMEDOUT", "CANCELLED"].contains(status)) {
@@ -154,8 +180,11 @@ def waitForJobToFinish(jobId, language, clusterId) {
 }
 
 def deleteDependencies(clusterId) {
-    sh "databricks fs rm -r dbfs:/${clusterId}"
-    sh "databricks fs rm -r dbfs:/FileStore/${clusterId}"
+    sh """
+        . /envs/sw_env_python3.6/bin/activate
+        databricks fs rm -r dbfs:/${clusterId}
+        databricks fs rm -r dbfs:/FileStore/${clusterId}
+    """
 }
 
 String getH2OBranchMajorVersion() {
@@ -197,7 +226,7 @@ def buildSparklingWater(props, sparkMajorVersion) {
         """
     sh "H2O_HOME=${env.WORKSPACE}/h2o-3 ./gradlew dist -Pspark=$sparkMajorVersion -Dmaven.repo.local=${env.WORKSPACE}/.m2 -PbuildAgainstH2OBranch=${props["testH2OBranch"]} -Ph2oMajorVersion=${getH2OBranchMajorVersion()} -Ph2oMajorName=${getH2OBranchMajorName()} -Ph2oBuild=${getH2OBranchBuildVersion()}"
     dir("py/build/pkg") {
-        sh """"
+        sh """
             . /envs/sw_env_python3.6/bin/activate
             python setup.py bdist_wheel
             """
@@ -214,12 +243,18 @@ def prepareRTestFile(clusterId, rArtifact) {
 }
 
 def restartCluster(clusterId) {
-    sh "databricks clusters restart --cluster-id ${clusterId}"
+    sh """
+        . /envs/sw_env_python3.6/bin/activate
+        databricks clusters restart --cluster-id ${clusterId}
+    """
     waitForCluster(clusterId)
 }
 
 def cleanEnvironment(clusterId) {
-    sh "databricks workspace rm -r /sw-tests-${clusterId}"
+    sh """
+        . /envs/sw_env_python3.6/bin/activate
+        databricks workspace rm -r /sw-tests-${clusterId}
+    """
     deleteDependencies(clusterId)
     deleteCluster(clusterId)
 }
@@ -250,7 +285,7 @@ node("docker") {
                     sh """
                         . /envs/sw_env_python3.6/bin/activate
                         pip install databricks-cli
-                        """
+                    """
                     buildSparklingWater(props, sparkMajorVersion)
                     String pythonArtifact = "h2o_pysparkling_${sparkMajorVersion}-${version.split("-")[0]}.post1-py2.py3-none-any.whl"
                     String scalaArtifact = "sparkling-water-assembly_${scalaVersion}-${version}-${sparkMajorVersion}-all.jar"
@@ -259,7 +294,10 @@ node("docker") {
                     waitForCluster(clusterId)
                     installDependencies(clusterId, scalaArtifact, pythonArtifact, rArtifact)
                     String workspaceDir = "/sw-tests-${clusterId}"
-                    sh "databricks workspace mkdirs ${workspaceDir}"
+                    sh """
+                        . /envs/sw_env_python3.6/bin/activate
+                        databricks workspace mkdirs ${workspaceDir}
+                    """
                     prepareRTestFile(clusterId, rArtifact)
                     test(workspaceDir, clusterId, "r")
                     restartCluster(clusterId)

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -31,30 +31,31 @@ static String getSparklingVersion(props) {
 }
 
 def startCluster(dbcVersion, sparkMajorVersion) {
-    def jsonOutput = shWithSWPyEnv(script: """
-    databricks clusters create --json '{
-        "num_workers": 3,
-        "cluster_name": "SparklingWaterTest-${sparkMajorVersion}",
-        "spark_version": "${dbcVersion}",
-        "spark_conf": {},
-        "aws_attributes": {
-            "first_on_demand": 4,
-            "availability": "SPOT_WITH_FALLBACK",
-            "zone_id": "us-east-1d",
-            "instance_profile_arn": null,
-            "spot_bid_price_percent": 100,
-            "ebs_volume_type": "GENERAL_PURPOSE_SSD",
-            "ebs_volume_count": 3,
-            "ebs_volume_size": 100
-        },
-        "node_type_id": "m4.large",
-        "ssh_public_keys": [],
-        "custom_tags": {},
-        "spark_env_vars": {},
-        "autotermination_minutes": 120,
-        "init_scripts": []
-    }'
-""", returnStdout: true).trim()
+    def script = """
+        databricks clusters create --json '{
+            "num_workers": 3,
+            "cluster_name": "SparklingWaterTest-${sparkMajorVersion}",
+            "spark_version": "${dbcVersion}",
+            "spark_conf": {},
+            "aws_attributes": {
+                "first_on_demand": 4,
+                "availability": "SPOT_WITH_FALLBACK",
+                "zone_id": "us-east-1d",
+                "instance_profile_arn": null,
+                "spot_bid_price_percent": 100,
+                "ebs_volume_type": "GENERAL_PURPOSE_SSD",
+                "ebs_volume_count": 3,
+                "ebs_volume_size": 100
+            },
+            "node_type_id": "m4.large",
+            "ssh_public_keys": [],
+            "custom_tags": {},
+            "spark_env_vars": {},
+            "autotermination_minutes": 120,
+            "init_scripts": []
+        }'
+    """
+    def jsonOutput = shWithSWPyEnv(script: script, returnStdout: true).trim()
     def jsonSlurper = new JsonSlurperClassic()
     def cfg = jsonSlurper.parseText(jsonOutput)
     return cfg["cluster_id"]
@@ -180,7 +181,7 @@ String getH2OBranchBuildVersion() {
     return "1-SNAPSHOT"
 }
 
-def shWithSWPyEnv(script, returnStdout = false) {
+def shWithSWPyEnv(String script, Boolean returnStdout = false) {
     def scriptWithPrefix =  """
         . /envs/sw_env_python3.6/bin/activate
         ${script}

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -30,12 +30,12 @@ static String getSparklingVersion(props) {
     return "${props['version'].replace("-SNAPSHOT", "")}"
 }
 
-def shWithSWPyEnv(script, returnStdout = false) {
+def shWithSWPyEnv(script) {
     def scriptWithPrefix =  """
         . /envs/sw_env_python3.6/bin/activate
         ${script}
     """
-    return sh(script: scriptWithPrefix, returnStdout: returnStdout)
+    return sh(script: scriptWithPrefix, returnStdout: true)
 }
 
 def startCluster(dbcVersion, sparkMajorVersion) {
@@ -63,7 +63,7 @@ def startCluster(dbcVersion, sparkMajorVersion) {
             "init_scripts": []
         }'
     """
-    def jsonOutput = shWithSWPyEnv(script: script, returnStdout: true).trim()
+    def jsonOutput = shWithSWPyEnv(script).trim()
     def jsonSlurper = new JsonSlurperClassic()
     def cfg = jsonSlurper.parseText(jsonOutput)
     return cfg["cluster_id"]
@@ -72,7 +72,7 @@ def startCluster(dbcVersion, sparkMajorVersion) {
 def waitForCluster(clusterId) {
     def ready = false
     while(!ready) {
-        def json = shWithSWPyEnv(script: "databricks clusters get --cluster-id ${clusterId}", returnStdout: true).trim()
+        def json = shWithSWPyEnv("databricks clusters get --cluster-id ${clusterId}").trim()
         def jsonSlurper = new JsonSlurperClassic()
         def cfg = jsonSlurper.parseText(json)
         ready = cfg["state"] == "RUNNING"
@@ -137,7 +137,7 @@ def test(workspaceDir, clusterId, language) {
     }
     shWithSWPyEnv "databricks workspace import --language ${language} ci/databricksTests/test.${extension} ${workspaceDir}/test.${extension}"
 
-    def rawJson = shWithSWPyEnv(script: """
+    def rawJson = shWithSWPyEnv("""
         databricks runs submit --json '
             {
               "name": "Test ${language}",
@@ -148,7 +148,7 @@ def test(workspaceDir, clusterId, language) {
               "timeout_seconds": 600
             }
             '
-        """, returnStdout: true).trim()
+        """).trim()
     def parsedJson = new JsonSlurperClassic().parseText(rawJson)
     def runId = parsedJson.run_id
     waitForJobToFinish(runId, language, clusterId)
@@ -157,7 +157,7 @@ def test(workspaceDir, clusterId, language) {
 def waitForJobToFinish(jobId, language, clusterId) {
     def done = false
     while(!done) {
-        def rawJson = shWithSWPyEnv(script: "databricks runs get --run-id ${jobId}", returnStdout: true).trim()
+        def rawJson = shWithSWPyEnv("databricks runs get --run-id ${jobId}").trim()
         def parsedJson = new JsonSlurperClassic().parseText(rawJson)
         def status = parsedJson.state.result_state
         if (["FAILED", "TIMEDOUT", "CANCELLED"].contains(status)) {

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -229,7 +229,7 @@ def buildSparklingWater(props, sparkMajorVersion) {
         sh """
             . /envs/sw_env_python3.6/bin/activate
             python setup.py bdist_wheel
-            """
+        """
     }
 }
 

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -197,7 +197,10 @@ def buildSparklingWater(props, sparkMajorVersion) {
         """
     sh "H2O_HOME=${env.WORKSPACE}/h2o-3 ./gradlew dist -Pspark=$sparkMajorVersion -Dmaven.repo.local=${env.WORKSPACE}/.m2 -PbuildAgainstH2OBranch=${props["testH2OBranch"]} -Ph2oMajorVersion=${getH2OBranchMajorVersion()} -Ph2oMajorName=${getH2OBranchMajorName()} -Ph2oBuild=${getH2OBranchBuildVersion()}"
     dir("py/build/pkg") {
-        sh "python setup.py bdist_wheel"
+        sh """
+            . /envs/sw_env_python3.6/bin/activate
+            python setup.py bdist_wheel
+            """
     }
 }
 

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -197,10 +197,7 @@ def buildSparklingWater(props, sparkMajorVersion) {
         """
     sh "H2O_HOME=${env.WORKSPACE}/h2o-3 ./gradlew dist -Pspark=$sparkMajorVersion -Dmaven.repo.local=${env.WORKSPACE}/.m2 -PbuildAgainstH2OBranch=${props["testH2OBranch"]} -Ph2oMajorVersion=${getH2OBranchMajorVersion()} -Ph2oMajorName=${getH2OBranchMajorName()} -Ph2oBuild=${getH2OBranchBuildVersion()}"
     dir("py/build/pkg") {
-        sh """
-            . /envs/sw_env_python3.6/bin/activate
-            python setup.py bdist_wheel
-            """
+        sh "python setup.py bdist_wheel"
     }
 }
 
@@ -247,6 +244,7 @@ node("docker") {
                     def sparkSpecificProps = readPropertiesFile("gradle-spark${sparkMajorVersion}.properties")
                     def dbcVersion = sparkSpecificProps["databricksVersion"]
                     def scalaVersion = sparkSpecificProps["scalaBaseVersion"]
+                    sh ". /envs/sw_env_python3.6/bin/activate"
                     sh "pip install databricks-cli"
                     buildSparklingWater(props, sparkMajorVersion)
                     String pythonArtifact = "h2o_pysparkling_${sparkMajorVersion}-${version.split("-")[0]}.post1-py2.py3-none-any.whl"

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -31,8 +31,7 @@ static String getSparklingVersion(props) {
 }
 
 def startCluster(dbcVersion, sparkMajorVersion) {
-    def jsonOutput = sh(script: """
-    . /envs/sw_env_python3.6/bin/activate
+    def jsonOutput = shWithSWPyEnv(script: """
     databricks clusters create --json '{
         "num_workers": 3,
         "cluster_name": "SparklingWaterTest-${sparkMajorVersion}",
@@ -64,10 +63,7 @@ def startCluster(dbcVersion, sparkMajorVersion) {
 def waitForCluster(clusterId) {
     def ready = false
     while(!ready) {
-        def json = sh(script: """
-            . /envs/sw_env_python3.6/bin/activate
-            databricks clusters get --cluster-id ${clusterId}
-        """, returnStdout: true).trim()
+        def json = shWithSWPyEnv(script: "databricks clusters get --cluster-id ${clusterId}", returnStdout: true).trim()
         def jsonSlurper = new JsonSlurperClassic()
         def cfg = jsonSlurper.parseText(json)
         ready = cfg["state"] == "RUNNING"
@@ -79,10 +75,7 @@ def waitForCluster(clusterId) {
 }
 
 def deleteCluster(clusterId) {
-    sh """
-        . /envs/sw_env_python3.6/bin/activate
-        databricks clusters delete --cluster-id ${clusterId}
-    """
+    shWithSWPyEnv "databricks clusters delete --cluster-id ${clusterId}"
 }
 
 static def getDatabricksSparkVersions(props) {
@@ -96,10 +89,7 @@ static def getDatabricksSparkVersions(props) {
 def waitForArtifactToAttach(clusterId, artifact, type) {
     def ready = false
     while(!ready) {
-        def rawJson = sh(script: """
-            . /envs/sw_env_python3.6/bin/activate
-            databricks libraries cluster-status --cluster-id ${clusterId}
-        """, returnStdout: true).trim()
+        def rawJson = sh(script: "databricks libraries cluster-status --cluster-id ${clusterId}", returnStdout: true).trim()
         def parsedJson = new JsonSlurperClassic().parseText(rawJson)
         def status = parsedJson.library_statuses.find { it.library[type] == "dbfs:/${clusterId}/${artifact}" }.status
         ready = status == "INSTALLED"
@@ -113,22 +103,19 @@ def waitForArtifactToAttach(clusterId, artifact, type) {
 
 def installDependencies(clusterId, scalaArtifact, pythonArtifact, rArtifact) {
     // Scala
-    sh """
-        . /envs/sw_env_python3.6/bin/activate
+    shWithSWPyEnv """
         databricks fs cp assembly/build/libs/${scalaArtifact} dbfs:/${clusterId}/${scalaArtifact}
         databricks libraries install --cluster-id ${clusterId} --jar dbfs:/${clusterId}/${scalaArtifact}
     """
     waitForArtifactToAttach(clusterId, scalaArtifact, "jar")
     // Python
-    sh """
-        . /envs/sw_env_python3.6/bin/activate
+    shWithSWPyEnv """
         databricks fs cp py/build/pkg/dist/${pythonArtifact} dbfs:/${clusterId}/${pythonArtifact}
         databricks libraries install --cluster-id ${clusterId} --whl dbfs:/${clusterId}/${pythonArtifact}
     """
     waitForArtifactToAttach(clusterId, pythonArtifact, "whl")
     // R
-    sh """
-        . /envs/sw_env_python3.6/bin/activate
+    shWithSWPyEnv """
         databricks fs cp r/build/${rArtifact} dbfs:/FileStore/${clusterId}/${rArtifact}
         databricks fs cp h2o-3/h2o-r/h2o_*.99999.tar.gz dbfs:/FileStore/${clusterId}/h2o.tar.gz
     """
@@ -139,12 +126,9 @@ def test(workspaceDir, clusterId, language) {
     if (language == "python") {
         extension = "py"
     }
-    sh """
-        . /envs/sw_env_python3.6/bin/activate
-        databricks workspace import --language ${language} ci/databricksTests/test.${extension} ${workspaceDir}/test.${extension}
-    """
-    def rawJson = sh(script: """
-        . /envs/sw_env_python3.6/bin/activate
+    shWithSWPyEnv "databricks workspace import --language ${language} ci/databricksTests/test.${extension} ${workspaceDir}/test.${extension}"
+
+    def rawJson = shWithSWPyEnv(script: """
         databricks runs submit --json '
             {
               "name": "Test ${language}",
@@ -164,10 +148,7 @@ def test(workspaceDir, clusterId, language) {
 def waitForJobToFinish(jobId, language, clusterId) {
     def done = false
     while(!done) {
-        def rawJson = sh(script: """
-            . /envs/sw_env_python3.6/bin/activate
-            databricks runs get --run-id ${jobId}
-        """, returnStdout: true).trim()
+        def rawJson = shWithSWPyEnv(script: "databricks runs get --run-id ${jobId}", returnStdout: true).trim()
         def parsedJson = new JsonSlurperClassic().parseText(rawJson)
         def status = parsedJson.state.result_state
         if (["FAILED", "TIMEDOUT", "CANCELLED"].contains(status)) {
@@ -180,8 +161,7 @@ def waitForJobToFinish(jobId, language, clusterId) {
 }
 
 def deleteDependencies(clusterId) {
-    sh """
-        . /envs/sw_env_python3.6/bin/activate
+    shWithSWPyEnv """
         databricks fs rm -r dbfs:/${clusterId}
         databricks fs rm -r dbfs:/FileStore/${clusterId}
     """
@@ -198,6 +178,14 @@ String getH2OBranchMajorName() {
 
 String getH2OBranchBuildVersion() {
     return "1-SNAPSHOT"
+}
+
+def shWithSWPyEnv(script, returnStdout = false) {
+    def scriptWithPrefix =  """
+        . /envs/sw_env_python3.6/bin/activate
+        ${script}
+    """
+    return sh(script: scriptWithPrefix, returnStdout: returnStdout)
 }
 
 def buildH2O(props) {
@@ -226,10 +214,7 @@ def buildSparklingWater(props, sparkMajorVersion) {
         """
     sh "H2O_HOME=${env.WORKSPACE}/h2o-3 ./gradlew dist -Pspark=$sparkMajorVersion -Dmaven.repo.local=${env.WORKSPACE}/.m2 -PbuildAgainstH2OBranch=${props["testH2OBranch"]} -Ph2oMajorVersion=${getH2OBranchMajorVersion()} -Ph2oMajorName=${getH2OBranchMajorName()} -Ph2oBuild=${getH2OBranchBuildVersion()}"
     dir("py/build/pkg") {
-        sh """
-            . /envs/sw_env_python3.6/bin/activate
-            python setup.py bdist_wheel
-        """
+        shWithSWPyEnv "python setup.py bdist_wheel"
     }
 }
 
@@ -243,18 +228,12 @@ def prepareRTestFile(clusterId, rArtifact) {
 }
 
 def restartCluster(clusterId) {
-    sh """
-        . /envs/sw_env_python3.6/bin/activate
-        databricks clusters restart --cluster-id ${clusterId}
-    """
+    shWithSWPyEnv "databricks clusters restart --cluster-id ${clusterId}"
     waitForCluster(clusterId)
 }
 
 def cleanEnvironment(clusterId) {
-    sh """
-        . /envs/sw_env_python3.6/bin/activate
-        databricks workspace rm -r /sw-tests-${clusterId}
-    """
+    shWithSWPyEnv "databricks workspace rm -r /sw-tests-${clusterId}"
     deleteDependencies(clusterId)
     deleteCluster(clusterId)
 }
@@ -282,10 +261,7 @@ node("docker") {
                     def sparkSpecificProps = readPropertiesFile("gradle-spark${sparkMajorVersion}.properties")
                     def dbcVersion = sparkSpecificProps["databricksVersion"]
                     def scalaVersion = sparkSpecificProps["scalaBaseVersion"]
-                    sh """
-                        . /envs/sw_env_python3.6/bin/activate
-                        pip install databricks-cli
-                    """
+                    shWithSWPyEnv "pip install databricks-cli"
                     buildSparklingWater(props, sparkMajorVersion)
                     String pythonArtifact = "h2o_pysparkling_${sparkMajorVersion}-${version.split("-")[0]}.post1-py2.py3-none-any.whl"
                     String scalaArtifact = "sparkling-water-assembly_${scalaVersion}-${version}-${sparkMajorVersion}-all.jar"
@@ -294,10 +270,7 @@ node("docker") {
                     waitForCluster(clusterId)
                     installDependencies(clusterId, scalaArtifact, pythonArtifact, rArtifact)
                     String workspaceDir = "/sw-tests-${clusterId}"
-                    sh """
-                        . /envs/sw_env_python3.6/bin/activate
-                        databricks workspace mkdirs ${workspaceDir}
-                    """
+                    shWithSWPyEnv "databricks workspace mkdirs ${workspaceDir}"
                     prepareRTestFile(clusterId, rArtifact)
                     test(workspaceDir, clusterId, "r")
                     restartCluster(clusterId)

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -30,6 +30,14 @@ static String getSparklingVersion(props) {
     return "${props['version'].replace("-SNAPSHOT", "")}"
 }
 
+static String shWithSWPyEnv(String script, Boolean returnStdout = false) {
+    def scriptWithPrefix =  """
+        . /envs/sw_env_python3.6/bin/activate
+        ${script}
+    """
+    return sh(script: scriptWithPrefix, returnStdout: returnStdout)
+}
+
 def startCluster(dbcVersion, sparkMajorVersion) {
     def script = """
         databricks clusters create --json '{
@@ -179,14 +187,6 @@ String getH2OBranchMajorName() {
 
 String getH2OBranchBuildVersion() {
     return "1-SNAPSHOT"
-}
-
-def shWithSWPyEnv(String script, Boolean returnStdout = false) {
-    def scriptWithPrefix =  """
-        . /envs/sw_env_python3.6/bin/activate
-        ${script}
-    """
-    return sh(script: scriptWithPrefix, returnStdout: returnStdout)
 }
 
 def buildH2O(props) {

--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -30,7 +30,7 @@ static String getSparklingVersion(props) {
     return "${props['version'].replace("-SNAPSHOT", "")}"
 }
 
-def shWithSWPyEnv(String script, Boolean returnStdout = false) {
+def shWithSWPyEnv(script, returnStdout = false) {
     def scriptWithPrefix =  """
         . /envs/sw_env_python3.6/bin/activate
         ${script}


### PR DESCRIPTION
The databricks tests fails with the following error:
```
+ python setup.py bdist_wheel

/home/jenkins/miniconda/lib/python3.9/site-packages/setuptools/dist.py:501: UserWarning: The version specified ('3.36.0.1_1') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.

warnings.warn(

usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]

or: setup.py --help [cmd1 cmd2 ...]

or: setup.py --help-commands

or: setup.py cmd --help

error: invalid command 'bdist_wheel'

script returned exit code 1
```