### PR TITLE
[SW-2671] change GCS import test file

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_gcs_import.py
+++ b/py/tests/unit/with_runtime_sparkling/test_gcs_import.py
@@ -18,7 +18,8 @@
 import h2o
 
 def testImportFromGCS(hc):
-    path = "gs://solutions-public-assets/time-series-master/GBPUSD_2014_01.csv"
-    frame = h2o.import_file(path=path)
+    some_public_gcp_file = "gs://gcp-public-data-landsat" \
+           "/LC08/01/001/009/LC08_L1GT_001009_20210612_20210622_01_T2/LC08_L1GT_001009_20210612_20210622_01_T2_MTL.txt"
+    frame = h2o.import_file(path=some_public_gcp_file)
     df = hc.asSparkFrame(frame)
-    assert df.count() == 1280546
+    assert df.count() == 218


### PR DESCRIPTION
the old file is no longer available and the test fails
that file is coming from some official public dataset and is not ideal as that's not a CSV but some other format and the resulting dataframe doesn't make much sense, but I think that's not that bad given that test just checks if some file coming from GCS can be used