### PR TITLE
[SW-2676] Change Domain Levels to "True" and "False" for Columns Originating in BooleanType

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/Writer.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/Writer.scala
@@ -135,7 +135,7 @@ private[backend] object Writer {
         } else {
           entry.dataType match {
             case BooleanType =>
-              val valueIndex = domainBuilder.addStringToDomain(if (row.getBoolean(idxField)) "1" else "0", idxField)
+              val valueIndex = domainBuilder.addStringToDomain(if (row.getBoolean(idxField)) "True" else "False", idxField)
               con.put(valueIndex)
             case ByteType => con.put(row.getByte(idxField))
             case ShortType => con.put(row.getShort(idxField))

--- a/core/src/main/scala/ai/h2o/sparkling/backend/utils/ReflectionUtils.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/utils/ReflectionUtils.scala
@@ -210,7 +210,7 @@ object ReflectionUtils {
   }
 
   def isBooleanDomain(domain: Array[String]): Boolean =
-    domain.length == 2 && domain.contains("0") && domain.contains("1")
+    domain.length == 2 && domain.contains("False") && domain.contains("True")
 }
 
 import ai.h2o.sparkling.backend.utils.ReflectionUtils._

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterTestSuite.scala
@@ -272,8 +272,8 @@ class DataFrameConverterTestSuite extends FunSuite with SharedH2OTestContext {
 
     val domain = h2oFrame.columns(0).domain
     domain should have size 2
-    domain should contain("0")
-    domain should contain("1")
+    domain should contain("False")
+    domain should contain("True")
     h2oFrame.delete()
   }
 

--- a/doc/src/site/sphinx/design/spark_h2o_mapping.rst
+++ b/doc/src/site/sphinx/design/spark_h2o_mapping.rst
@@ -70,4 +70,4 @@ As is specified in the table, Sparkling Water provides support for transforming 
 
 .. rubric:: Footnotes
 .. [1] The H20 type is String if cardinality is greater than 10 000 0000 or ratio of unique values to all values is 95% or higher.
-.. [2] The H20 categorical values are "1" and "0" for true and false respectively.
+.. [2] The H20 categorical values are "True" and "False" for true and false respectively.

--- a/doc/src/site/sphinx/migration_guide.rst
+++ b/doc/src/site/sphinx/migration_guide.rst
@@ -12,8 +12,6 @@ From 3.36 to 3.38
 
 - The support for Apache Spark 2.2.x has been removed.
 
-- Boolean type mapping from Spark's DataFrame to H20Frame was changed from numerical 0, 1 to "0", "1" categorical values.
-
 - The parameter ``variableImportances`` of ``H2ODeepLearning`` has been replaced with ``calculateFeatureImportances`` as
   well as the methods ``getVariableImportances`` and ``setVariableImportances`` on ``H2ODeepLearning`` have been replaced
   with ``getCalculateFeatureImportances`` and ``setCalculateFeatureImportances``.
@@ -32,6 +30,8 @@ From 3.34 to 3.36
   MOJO models were removed without replacement.
 
 - The ``withDetailedPredictionCol`` field on ``H2OMOJOSettings`` was removed without a replacement.
+
+- Boolean type mapping from Spark's DataFrame to H20Frame was changed from numerical 0, 1 to "False", "True" categorical values.
 
 From 3.32.1 to 3.34
 -------------------

--- a/py/tests/unit/with_runtime_sparkling/test_Spark_to_H2O_conversions.py
+++ b/py/tests/unit/with_runtime_sparkling/test_Spark_to_H2O_conversions.py
@@ -69,8 +69,8 @@ def testIntegerRDDToH2OFrame(spark, hc):
 def testBooleanRDDToH2OFrame(spark, hc):
     rdd = spark.sparkContext.parallelize([True, False, True, True, False])
     h2o_frame = hc.asH2OFrame(rdd)
-    assert h2o_frame[0, 0] == '1'
-    assert h2o_frame[1, 0] == '0'
+    assert h2o_frame[0, 0] == 'True'
+    assert h2o_frame[1, 0] == 'False'
     unit_test_utils.asert_h2o_frame(h2o_frame, rdd)
 
 

--- a/r/src/tests/testthat/testConversions.R
+++ b/r/src/tests/testthat/testConversions.R
@@ -43,10 +43,10 @@ test_that("Test transformation of a spark data_frame of bools to an h2o frame of
   hc <- H2OContext.getOrCreate()
   hf <- hc$asH2OFrame(sdf)
 
-  expect_equal(as.character(hf[1, 1]), "1")
-  expect_equal(as.character(hf[1, 2]), "0")
-  expect_equal(as.character(hf[1, 3]), "1")
-  expect_equal(as.character(hf[1, 4]), "0")
+  expect_equal(as.character(hf[1, 1]), "True")
+  expect_equal(as.character(hf[1, 2]), "False")
+  expect_equal(as.character(hf[1, 3]), "True")
+  expect_equal(as.character(hf[1, 4]), "False")
 })
 
 test_that("Test transformation of a spark data_frame of complex types to an h2o frame of complex types", {
@@ -61,7 +61,7 @@ test_that("Test transformation of a spark data_frame of complex types to an h2o 
   expect_equal(hf[1, 1], 2)
   expect_equal(is.factor(hf[1, 2]), TRUE)
   expect_equal(as.character(hf[1, 2]), "aa")
-  expect_equal(as.character(hf[1, 3]), "1")
+  expect_equal(as.character(hf[1, 3]), "True")
 })
 
 test_that("Test transformation of a spark data_frame of float types to an h2o frame of floats", {

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/RowConverter.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/RowConverter.scala
@@ -41,7 +41,7 @@ object RowConverter {
         if (row.get(idxRow) != null) {
           f.dataType match {
             case BooleanType =>
-              put(name, if (row.getBoolean(idxRow)) "1" else "0")
+              put(name, if (row.getBoolean(idxRow)) "True" else "False")
             case BinaryType =>
               row.getAs[Array[Byte]](idxRow).zipWithIndex.foreach {
                 case (v, idx) =>


### PR DESCRIPTION
This change conversion aligned with storing spark data frame to a parquet file and reading with h2o.
```
>>> df = spark.range(100).select((col("id") % 2).cast("boolean").alias("b"))
>>> df.write.parquet("/Users/marek/testBoolean/b")
>>> hf = h2o.import_file(path="/Users/marek/testBoolean/b")
>>> hf.levels()
[['False', 'True']]
```

Side note: When Spark reads csv, it identifies columns with  boolean values as string columns:
```
booleans.csv

"numbers", "stringNumbers", "lowerBooleans", "capitalBooleans", "upperBooleans", "stringLowerBooleans", "stringCapitalBooleans", "stringUpperBooleans"
0, "0", false, False, FALSE, "false", "False", "FALSE"
1, "1", true, True, TRUE, "true", "True", "TRUE"
0, "0", false, False, FALSE, "false", "False", "FALSE"
1, "1", true, True, TRUE, "true", "True", "TRUE"
1, "1", true, True, TRUE, "true", "True", "TRUE"
0, "0", false, False, FALSE, "false", "False", "FALSE"
``` 

Reading dataset in Spark:
```
>>> df = spark.read.option("header", "true").option("inferSchema", "true").csv("/Users/marek/testBoolean/booleans.csv")
>>> df.printSchema
<bound method DataFrame.printSchema of DataFrame[numbers: int,  "stringNumbers": string,  "lowerBooleans": string,  "capitalBooleans": string,  "upperBooleans": string,  "stringLowerBooleans": string,  "stringCapitalBooleans": string,  "stringUpperBooleans": string]>
```

Reading dataset in H2O-3:
```
>>> hf =  h2o.import_file(path="/Users/marek/testBoolean/booleans.csv")
>>> hf.types
{'numbers': 'int', 'stringNumbers': 'int', 'lowerBooleans': 'enum', 'capitalBooleans': 'enum', 'upperBooleans': 'enum', 'stringLowerBooleans': 'enum', 'stringCapitalBooleans': 'enum', 'stringUpperBooleans': 'enum'}
>>> hf.levels()
[[], [], ['false', 'true'], ['False', 'True'], ['FALSE', 'TRUE'], ['false', 'true'], ['False', 'True'], ['FALSE', 'TRUE']]
```