### PR TITLE
[SW-2681] Add Comment to Documentation about Contributions Support only in Binomial and Regression Models

### DIFF
--- a/doc/src/site/sphinx/deployment/load_mojo.rst
+++ b/doc/src/site/sphinx/deployment/load_mojo.rst
@@ -316,7 +316,7 @@ We can configure the output and format of predictions via the H2OMOJOSettings. T
 - ``convertUnknownCategoricalLevelsToNa`` - Enables or disables conversion of unseen categoricals to NAs. By default, it is disabled.
 - ``convertInvalidNumbersToNa`` - Enables or disables conversion of invalid numbers to NAs. By default, it is disabled.
 - ``withContributions`` - Enables or disables computing Shapley values. Shapley values are generated as a sub-column for the
-  detailed prediction column.
+  detailed prediction column. Shapley values are supported only by tree-based binomial and regression models.
 - ``withLeafNodeAssignments`` - When enabled, a user can obtain the leaf node assignments after the model training
   has finished. By default, it is disabled.
 - ``withStageResults`` - When enabled, a user can obtain the stage results for tree-based models. By default,


### PR DESCRIPTION
See [this piece of code](https://github.com/h2oai/sparkling-water/blob/2a8edb271b4f7478e7bd2adee7cfe59b6a4c77ae/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OAlgorithmMOJOModel.scala#L85) in `H2OAlgorithmMOJOModel`. 