### PR TITLE
[SW-2684][FOLLOWUP] Add io.fabric8.kubernetes-client as dependecy to integration tests

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -112,6 +112,7 @@ dependencies {
   integTestImplementation("org.scala-lang:scala-library:${scalaVersion}")
   integTestImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")
   integTestImplementation("junit:junit:4.11")
+  integTestImplementation("io.fabric8:kubernetes-client:${fabricK8sClientVersion}")
 
   benchImplementation("org.scala-lang:scala-library:${scalaVersion}")
   benchImplementation("org.scalatest:scalatest_${scalaBaseVersion}:${scalaTestVersion}")


### PR DESCRIPTION
Integration tests fails on compilation:
```

[2022-01-31T18:09:29.236Z] > Task :sparkling-water-core:compileIntegTestScala

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sExternalBackendClient.scala:21: object fabric8 is not a member of package io

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sExternalBackendClient.scala:27: not found: type DefaultKubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sHeadlessService.scala:24: object fabric8 is not a member of package io

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sHeadlessService.scala:37: not found: type KubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:24: object fabric8 is not a member of package io

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:36: not found: type KubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sExternalBackendClient.scala:33: not found: type DefaultKubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sHeadlessService.scala:32: not found: type KubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:30: not found: type KubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:23: object fabric8 is not a member of package io

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:45: not found: type KubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:71: not found: type Pod

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:71: not found: type KubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:88: not found: type KubernetesClient

[2022-01-31T18:09:36.216Z] [Error] /home/jenkins/workspace/NIGHTLY_H2O_BRANCH_rel-3.36-spark-2.2-internal/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala:89: type mismatch;
```