### PR TITLE
[SW-2691] Increase Memory on Scala Integration Tests

### DIFF
--- a/ml/src/integTest/scala/ai/h2o/sparkling/ml/IntegrationTestSuite.scala
+++ b/ml/src/integTest/scala/ai/h2o/sparkling/ml/IntegrationTestSuite.scala
@@ -31,10 +31,10 @@ class IntegrationTestSuite extends FunSuite with SharedH2OTestContext {
 
   override def createSparkSession(): SparkSession = sparkSession("local-cluster[2,1,2560]")
 
-  test("SchemaUtils: flattenDataFrame should process a complex data frame with more than 200k columns after flattening") {
-    val expectedNumberOfColumns = 200000
+  test("SchemaUtils: flattenDataFrame should process a complex data frame with more than 190k columns after flattening") {
+    val expectedNumberOfColumns = 190000
     val settings =
-      TestUtils.GenerateDataFrameSettings(numberOfRows = 200, rowsPerPartition = 50, maxCollectionSize = 100)
+      TestUtils.GenerateDataFrameSettings(numberOfRows = 200, rowsPerPartition = 50, maxCollectionSize = 90)
     testFlatteningOnComplexType(settings, expectedNumberOfColumns)
   }
 

--- a/ml/src/integTest/scala/ai/h2o/sparkling/ml/IntegrationTestSuite.scala
+++ b/ml/src/integTest/scala/ai/h2o/sparkling/ml/IntegrationTestSuite.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.Duration
 @RunWith(classOf[JUnitRunner])
 class IntegrationTestSuite extends FunSuite with SharedH2OTestContext {
 
-  override def createSparkSession(): SparkSession = sparkSession("local-cluster[2,1,2024]")
+  override def createSparkSession(): SparkSession = sparkSession("local-cluster[2,1,3036]")
 
   test("SchemaUtils: flattenDataFrame should process a complex data frame with more than 200k columns after flattening") {
     val expectedNumberOfColumns = 200000

--- a/ml/src/integTest/scala/ai/h2o/sparkling/ml/IntegrationTestSuite.scala
+++ b/ml/src/integTest/scala/ai/h2o/sparkling/ml/IntegrationTestSuite.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.Duration
 @RunWith(classOf[JUnitRunner])
 class IntegrationTestSuite extends FunSuite with SharedH2OTestContext {
 
-  override def createSparkSession(): SparkSession = sparkSession("local-cluster[2,1,3036]")
+  override def createSparkSession(): SparkSession = sparkSession("local-cluster[2,1,2560]")
 
   test("SchemaUtils: flattenDataFrame should process a complex data frame with more than 200k columns after flattening") {
     val expectedNumberOfColumns = 200000

--- a/ml/src/integTest/scala/ai/h2o/sparkling/ml/IntegrationTestSuite.scala
+++ b/ml/src/integTest/scala/ai/h2o/sparkling/ml/IntegrationTestSuite.scala
@@ -31,8 +31,8 @@ class IntegrationTestSuite extends FunSuite with SharedH2OTestContext {
 
   override def createSparkSession(): SparkSession = sparkSession("local-cluster[2,1,2560]")
 
-  test("SchemaUtils: flattenDataFrame should process a complex data frame with more than 190k columns after flattening") {
-    val expectedNumberOfColumns = 190000
+  test("SchemaUtils: flattenDataFrame should process a complex data frame with more than 180k columns after flattening") {
+    val expectedNumberOfColumns = 180000
     val settings =
       TestUtils.GenerateDataFrameSettings(numberOfRows = 200, rowsPerPartition = 50, maxCollectionSize = 90)
     testFlatteningOnComplexType(settings, expectedNumberOfColumns)


### PR DESCRIPTION
It seems that Spark 3.2 consumes more memory.