### PR TITLE
[SW-2633][FOLLOWUP] Fix reference to scala version in gradle.properties

### DIFF
--- a/bin/sparkling-env.sh
+++ b/bin/sparkling-env.sh
@@ -165,7 +165,7 @@ H2O_BUILD=$(grep h2oBuild "$PROP_FILE" | sed -e "s/.*=//")
 export H2O_NAME
 H2O_NAME=$(grep h2oMajorName "$PROP_FILE" | sed -e "s/.*=//")
 export SPARK_VERSION=$(grep sparkVersion "$PROP_FILE" | sed -e "s/.*=//")
-SCALA_VERSION=$(grep scalaBaseVersion "$PROP_FILE" | sed -e "s/.*=//" | cut -d . -f 1,2)
+SCALA_VERSION=$(grep scalaVersion "$PROP_FILE" | sed -e "s/.*=//" | cut -d . -f 1,2)
 # Fat jar for this distribution
 FAT_JAR="sparkling-water-assembly_$SCALA_VERSION-$VERSION-all.jar"
 export FAT_JAR_FILE="$TOPDIR/jars/$FAT_JAR"


### PR DESCRIPTION
#2662 changed property name from `scalaBaseVersion` to `scalaVersion`. This change caused a problem in building k8s images.