### PR TITLE
[SW-2692] Initialize Conda in Release Pipeline

### DIFF
--- a/ci/Jenkinsfile-release
+++ b/ci/Jenkinsfile-release
@@ -282,7 +282,8 @@ def buildConda() {
                 for (packageDetails in packages) {
                     dir(packageDetails.path) {
                         for (pyVersion in pythonVersions) {
-                            sh """
+                            sh """ 
+                               . ~/miniconda/etc/profile.d/conda.sh 
                                conda activate sw_env_python3.6
     
                                conda build ${packageDetails.name} --output-folder "." --no-anaconda-upload --py ${pyVersion}
@@ -354,6 +355,7 @@ def publishToPipy() {
                     dir("$projectName/build/pkg") {
                         params.commons.withPipyCredentials {
                             sh """
+                               . ~/miniconda/etc/profile.d/conda.sh
                                conda activate sw_env_python3.6
                                python setup.py sdist
                                twine upload dist/* -u $PIPY_USERNAME -p $PIPY_PASSWORD


### PR DESCRIPTION
the release pipeline fails on:
```
CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
To initialize your shell, run

    $ conda init <SHELL_NAME>

Currently supported shells are:
  - bash
  - fish
  - tcsh
  - xonsh
  - zsh
  - powershell
```