### PR TITLE
[SW-2697] Fix Binary Model Cleaning in H2OAutoML

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OAutoML.scala
@@ -201,10 +201,13 @@ class H2OAutoML(override val uid: String)
   }
 
   private def deleteBinaryModels(): Unit = {
-    getLeaderboard().select("model_id").collect().foreach { row =>
-      val modelId = row.getString(0)
-      val model = H2OModel(modelId)
-      model.tryDelete()
+    getLeaderboard().select("model_id").collect()
+      .partition(_.getString(0).contains("StackedEnsemble")).productIterator.foreach {
+        case array: Array[Row] => array.foreach { row =>
+          val modelId = row.getString(0)
+          val model = H2OModel(modelId)
+          model.tryDelete()
+        }
     }
   }
 


### PR DESCRIPTION
After the change https://github.com/h2oai/h2o-3/pull/6113, The stacked ensemble models needs to be delete first. Otherwise, during a try to delete a stacked ensemble model, [this line](https://github.com/h2oai/h2o-3/pull/6113/files#diff-ad93828b9151a2ed49334d31e84b42bb51f128704c09cde92ced8a6da673db3cR64) will throw NPE since a base model has already been deleted. 