### PR TITLE
[SW-1184][FOLLOWUP] Delete base binary models only when keepBinaryModels is set to false

### DIFF
--- a/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OStackedEnsemble.scala
+++ b/ml/src/main/scala/ai/h2o/sparkling/ml/algos/H2OStackedEnsemble.scala
@@ -86,9 +86,8 @@ class H2OStackedEnsemble(override val uid: String)
       binaryModel = Some(H2OBinaryModel.read("file://" + downloadedModel.getAbsolutePath, Some(modelId)))
     } else {
       model.tryDelete()
+      deleteModels(baseModels)
     }
-
-    deleteModels(baseModels)
 
     result
   }


### PR DESCRIPTION
This PR fixes a failing test on `master` branch:
```
[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-203)[2022-04-05T19:39:01.589Z] ai.h2o.sparkling.ml.models.BinaryModelTestSuite > Binary model is available in H2O after training StackedEnsemble in SW FAILED

[2022-04-05T19:39:01.589Z]     ai.h2o.sparkling.backend.exceptions.RestApiCommunicationException: H2O node http://172.17.0.2:54321/[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-204)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-205)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-206)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-207)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-208)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-209)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-210)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-211)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-212)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-213)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-214)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-215)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-216)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-217)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-218)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-219)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-220)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-221)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-222)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-223)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-224)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-225)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-226)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-227)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-228)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-229)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-230)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-231)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-232)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-233)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-234)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-235)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-236)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-237)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-238)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-239)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-240)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-241)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-242)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-243)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-244)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-245)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-246)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-247)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-248)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-249)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-250)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/NIGHTLY_H2O_BRANCH/detail/master/2/pipeline#step-641-log-251) responded with

[2022-04-05T19:39:01.589Z]     Status code: 500 : Server Error

[2022-04-05T19:39:01.590Z]     Server error: {"__meta":{"schema_version":3,"schema_name":"H2OErrorV3","schema_type":"H2OError"},"timestamp":1649187531479,"error_url":"/3/Models","msg":"\n\nERROR MESSAGE:\n\nCaught exception: java.lang.NullPointerException\n\n","dev_msg":"\n\nERROR MESSAGE:\n\nCaught exception: java.lang.NullPointerException from: java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)\n\n","http_status":500,"values":{},"exception_type":"java.lang.NullPointerException","exception_msg":"\n\nERROR MESSAGE:\n\nnull\n\n","stacktrace":["java.lang.NullPointerException","    java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)","    java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)","    java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)","    java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:958)","    java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)","    java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:498)","    java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485)","    java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)","    java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)","    java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)","    java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)","    java.util.stream.ReferencePipeline.allMatch(ReferencePipeline.java:454)","    hex.ensemble.StackedEnsembleModel.haveMojo(StackedEnsembleModel.java:66)","    water.api.schemas3.ModelSchemaBaseV3.<init>(ModelSchemaBaseV3.java:61)","    water.api.schemas3.ModelSynopsisV3.<init>(ModelSynopsisV3.java:14)","    water.api.schemas3.ModelsV3.fillFromImplWithSynopsis(ModelsV3.java:74)","    water.api.ModelsHandler.list(ModelsHandler.java:79)","    sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)","    sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)","    sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","    java.lang.reflect.Method.invoke(Method.java:498)","    water.api.Handler.handle(Handler.java:60)","    water.api.RequestServer.serve(RequestServer.java:472)","    water.api.RequestServer.doGeneric(RequestServer.java:303)","    water.api.RequestServer.doGet(RequestServer.java:225)","    javax.servlet.http.HttpServlet.service(HttpServlet.java:687)","    javax.servlet.http.HttpServlet.service(HttpServlet.java:790)","    ai.h2o.org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:865)","    ai.h2o.org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:535)","    ai.h2o.org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)","    ai.h2o.org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1317)","    ai.h2o.org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)","    ai.h2o.org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)","    ai.h2o.org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)","    ai.h2o.org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1219)","    ai.h2o.org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)","    ai.h2o.org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)","    ai.h2o.org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)","    water.webserver.jetty9.Jetty9ServerAdapter$LoginHandler.handle(Jetty9ServerAdapter.java:130)","    ai.h2o.org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)","    ai.h2o.org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)","    ai.h2o.org.eclipse.jetty.server.Server.handle(Server.java:531)","    ai.h2o.org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)","    ai.h2o.org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)","    ai.h2o.org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)","    ai.h2o.org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)","    ai.h2o.org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)","    ai.h2o.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)","    ai.h2o.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)","    ai.h2o.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)","    ai.h2o.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)","    ai.h2o.org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)","    ai.h2o.org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:762)","    ai.h2o.org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:680)","    java.lang.Thread.run(Thread.java:748)"]}

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.backend.utils.RestCommunication$class.checkResponseCode(RestCommunication.scala:412)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.H2OBinaryModel$.checkResponseCode(H2OBinaryModel.scala:47)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.backend.utils.RestCommunication$class.readURLContent(RestCommunication.scala:386)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.H2OBinaryModel$.readURLContent(H2OBinaryModel.scala:47)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.backend.utils.RestCommunication$class.request(RestCommunication.scala:182)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.H2OBinaryModel$.request(H2OBinaryModel.scala:47)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.backend.utils.RestCommunication$class.query(RestCommunication.scala:67)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.H2OBinaryModel$.query(H2OBinaryModel.scala:47)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.H2OBinaryModel$.exists(H2OBinaryModel.scala:52)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.BinaryModelTestSuite$$anonfun$9.apply$mcV$sp(BinaryModelTestSuite.scala:150)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.BinaryModelTestSuite$$anonfun$9.apply(BinaryModelTestSuite.scala:120)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.BinaryModelTestSuite$$anonfun$9.apply(BinaryModelTestSuite.scala:120)

[2022-04-05T19:39:01.590Z]         at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)

[2022-04-05T19:39:01.590Z]         at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)

[2022-04-05T19:39:01.590Z]         at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)

[2022-04-05T19:39:01.590Z]         at org.scalatest.Transformer.apply(Transformer.scala:22)

[2022-04-05T19:39:01.590Z]         at org.scalatest.Transformer.apply(Transformer.scala:20)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:166)

[2022-04-05T19:39:01.590Z]         at org.scalatest.Suite$class.withFixture(Suite.scala:1122)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuite.withFixture(FunSuite.scala:1555)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$class.invokeWithFixture$1(FunSuiteLike.scala:163)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$$anonfun$runTest$1.apply(FunSuiteLike.scala:175)

[2022-04-05T19:39:01.590Z]         at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$class.runTest(FunSuiteLike.scala:175)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuite.runTest(FunSuite.scala:1555)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$$anonfun$runTests$1.apply(FunSuiteLike.scala:208)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$$anonfun$runTests$1.apply(FunSuiteLike.scala:208)

[2022-04-05T19:39:01.590Z]         at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:413)

[2022-04-05T19:39:01.590Z]         at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:401)

[2022-04-05T19:39:01.590Z]         at scala.collection.immutable.List.foreach(List.scala:392)

[2022-04-05T19:39:01.590Z]         at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)

[2022-04-05T19:39:01.590Z]         at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:396)

[2022-04-05T19:39:01.590Z]         at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:483)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$class.runTests(FunSuiteLike.scala:208)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuite.runTests(FunSuite.scala:1555)

[2022-04-05T19:39:01.590Z]         at org.scalatest.Suite$class.run(Suite.scala:1424)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1555)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$$anonfun$run$1.apply(FunSuiteLike.scala:212)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$$anonfun$run$1.apply(FunSuiteLike.scala:212)

[2022-04-05T19:39:01.590Z]         at org.scalatest.SuperEngine.runImpl(Engine.scala:545)

[2022-04-05T19:39:01.590Z]         at org.scalatest.FunSuiteLike$class.run(FunSuiteLike.scala:212)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.BinaryModelTestSuite.org$scalatest$BeforeAndAfterAll$$super$run(BinaryModelTestSuite.scala:30)

[2022-04-05T19:39:01.590Z]         at org.scalatest.BeforeAndAfterAll$class.liftedTree1$1(BeforeAndAfterAll.scala:257)

[2022-04-05T19:39:01.590Z]         at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:256)

[2022-04-05T19:39:01.590Z]         at ai.h2o.sparkling.ml.models.BinaryModelTestSuite.run(BinaryModelTestSuite.scala:30)
```