### PR TITLE
[SW-2699] Fix Failing AutoML Test

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_automl.py
+++ b/py/tests/unit/with_runtime_sparkling/test_automl.py
@@ -164,7 +164,7 @@ def testBlendingDataFrameHasImpactOnAutoMLStackedEnsambleModels(classificationDa
     automl.fit(trainingDateset)
     leaderboardWithBlendingFrameSet = separateEnsembleModels(prepareLeaderboardForComparison(automl.getLeaderboard()))
 
-    assert defaultLeaderboard[0].count() >= 3
+    assert defaultLeaderboard[0].count() >= 2
     assert defaultLeaderboard[0].count() == leaderboardWithBlendingFrameSet[0].count()
     unit_test_utils.assert_data_frames_have_different_values(defaultLeaderboard[0], leaderboardWithBlendingFrameSet[0])
     unit_test_utils.assert_data_frames_are_identical(defaultLeaderboard[1], leaderboardWithBlendingFrameSet[1])


### PR DESCRIPTION
The following python test is failing:
```
[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-244)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-245)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-246)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-247)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-248)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-249)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-250)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-251)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-252)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-253)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-254)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-255)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-256)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-257)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-258)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-259)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-260)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-261)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-262)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-263)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-264)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-265)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-266)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-267)[](https://sparkling-jenkins.h2o.ai/blue/organizations/jenkins/TESTS_H2O_BRANCH/detail/master/1/pipeline/775/#step-780-log-268)[2022-04-06T14:25:30.356Z] 	 _________ testBlendingDataFrameHasImpactOnAutoMLStackedEnsambleModels __________

[2022-04-06T14:25:30.356Z] 	 

[2022-04-06T14:25:30.356Z] 	 classificationDataset = DataFrame[ID: int, CAPSULE: string, AGE: int, RACE: int, DPROS: int, DCAPS: int, PSA: double, VOL: double, GLEASON: int]

[2022-04-06T14:25:30.356Z] 	 

[2022-04-06T14:25:30.356Z] 	     def testBlendingDataFrameHasImpactOnAutoMLStackedEnsambleModels(classificationDataset):

[2022-04-06T14:25:30.356Z] 	         [trainingDateset, blendingDataset] = classificationDataset.randomSplit([0.8, 0.2], 42)

[2022-04-06T14:25:30.356Z] 	     

[2022-04-06T14:25:30.356Z] 	         def separateEnsembleModels(df):

[2022-04-06T14:25:30.356Z] 	             stackedEnsembleDF = df.filter(df.model_id.startswith('StackedEnsemble'))

[2022-04-06T14:25:30.356Z] 	             othersDF = df.subtract(stackedEnsembleDF)

[2022-04-06T14:25:30.356Z] 	             return (stackedEnsembleDF, othersDF)

[2022-04-06T14:25:30.356Z] 	     

[2022-04-06T14:25:30.356Z] 	         automl = setParametersForTesting(H2OAutoML())

[2022-04-06T14:25:30.356Z] 	         automl.fit(trainingDateset)

[2022-04-06T14:25:30.356Z] 	         defaultLeaderboard = separateEnsembleModels(prepareLeaderboardForComparison(automl.getLeaderboard()))

[2022-04-06T14:25:30.356Z] 	     

[2022-04-06T14:25:30.356Z] 	         automl = setParametersForTesting(H2OAutoML()).setBlendingDataFrame(blendingDataset)

[2022-04-06T14:25:30.356Z] 	         automl.fit(trainingDateset)

[2022-04-06T14:25:30.356Z] 	         leaderboardWithBlendingFrameSet = separateEnsembleModels(prepareLeaderboardForComparison(automl.getLeaderboard()))

[2022-04-06T14:25:30.356Z] 	     

[2022-04-06T14:25:30.356Z] 	 >       assert defaultLeaderboard[0].count() >= 3

[2022-04-06T14:25:30.356Z] 	 E       assert 2 >= 3

[2022-04-06T14:25:30.356Z] 	 E        +  where 2 = <bound method DataFrame.count of DataFrame[model_id: string, auc: string, logloss: string, aucpr: string, mean_per_class_error: string, rmse: string, mse: string]>()

[2022-04-06T14:25:30.356Z] 	 E        +    where <bound method DataFrame.count of DataFrame[model_id: string, auc: string, logloss: string, aucpr: string, mean_per_class_error: string, rmse: string, mse: string]> = DataFrame[model_id: string, auc: string, logloss: string, aucpr: string, mean_per_class_error: string, rmse: string, mse: string].count

[2022-04-06T14:25:30.356Z] 	 

[2022-04-06T14:25:30.356Z] 	 build/tests/unit/with_runtime_sparkling/test_automl.py:167: AssertionError
```

The behavior of AutoML on the `master` has slightly changed. The leaderboard currently contains just two stack ensemble models:
```
         +---+--------------------------------------------------------+------------------+------------------+------------------+--------------------+-------------------+-------------------+
         |   |model_id                                                |auc               |logloss           |aucpr             |mean_per_class_error|rmse               |mse                |
         +---+--------------------------------------------------------+------------------+------------------+------------------+--------------------+-------------------+-------------------+
         |0  |StackedEnsemble_AllModels_1_AutoML_12_20220406_183911   |0.7996651785714286|0.5315640097950722|0.7058059407127658|0.24067283163265307 |0.41974554107522494|0.17618631925253336|
         |1  |GBM_2_AutoML_12_20220406_183911                         |0.7991071428571429|0.5305970751453379|0.7094556483426839|0.2589285714285714  |0.42241895790315875|0.17843777599599062|
         |2  |StackedEnsemble_BestOfFamily_1_AutoML_12_20220406_183911|0.7960379464285714|0.534762653189984 |0.6880597835048362|0.23692602040816327 |0.4208798136963127 |0.1771398175770429 |
         |3  |XGBoost_1_AutoML_12_20220406_183911                     |0.7895009566326531|0.536207717808414 |0.6811878019114951|0.2393176020408163  |0.42148686448025285|0.17765117692939503|
         |4  |XGBoost_2_AutoML_12_20220406_183911                     |0.7886639030612245|0.5543237613875469|0.654848069981165 |0.24872448979591838 |0.4294638623068566 |0.18443920902752273|
         |5  |GBM_1_AutoML_12_20220406_183911                         |0.7833426339285714|0.5425642838022171|0.6447451001606792|0.2420280612244898  |0.4250819483894264 |0.180694662846551  |
         |6  |DRF_1_AutoML_12_20220406_183911                         |0.7776426977040817|0.7616609480883288|0.645257503686788 |0.26785714285714285 |0.4363493663956718 |0.19040076955390423|
         +---+--------------------------------------------------------+------------------+------------------+------------------+--------------------+-------------------+-------------------+

``` 