### PR TITLE
[SW-2700] Add spline_orders to Tests Covering Parameter Propagation to  H2OGAMMOJOModel

### DIFF
--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
@@ -102,6 +102,7 @@ class MOJOParameterTestSuite extends FunSuite with SharedH2OTestContext with Mat
       .setNumKnots(Array(5, 5))
       .setBs(Array(1, 1))
       .setScale(Array(.5, .5))
+      .setSplineOrders(Array(-1, -1))
     val mojo = algorithm.fit(dataset)
 
     compareParameterValues(algorithm, mojo, Set("getFeaturesCols"))

--- a/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
@@ -53,7 +53,7 @@ def testGLMParameters(prostateDataset):
 def testGAMParameters(prostateDataset):
     features = ['AGE', 'RACE', 'DPROS', 'DCAPS', 'PSA']
     algorithm = H2OGAM(seed=1, labelCol="CAPSULE", gamCols=[["PSA"], ["AGE"]], numKnots=[5, 5], lambdaValue=[0.5],
-                       featuresCols=features, bs=[1, 1], scale=[0.5, 0.5])
+                       featuresCols=features, bs=[1, 1], scale=[0.5, 0.5], splineOrders=[-1, -1])
     model = algorithm.fit(prostateDataset)
     compareParameterValues(algorithm, model, ["getFeaturesCols"])
 


### PR DESCRIPTION
`spline_orders` is a new parameter introduced to H2O-3. The tests covering parameter propagation to  `H2OGAMMOJOModel` are currently failing, since the parameter on the algorithm is not set, H2OGAMMOJOModel contians a value was set by H2O-3 backend. 