### PR TITLE
[SW-2701] Add Ability to Specify Number of Cores with Automatic External Backend on K8s

### DIFF
--- a/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/SharedBackendConf.scala
@@ -373,10 +373,12 @@ object SharedBackendConf {
     "spark.ext.h2o.nthreads",
     -1,
     "setNthreads(Integer)",
-    """Limit for number of threads used by H2O, default ``-1`` means: Use value of ``spark.executor.cores`` in
-      |case this property is set. Otherwise use H2O's default
-      |value Runtime.getRuntime()
-      |.availableProcessors()""".stripMargin)
+    """Limit for number of threads used by H2O.
+      |Default ``-1`` using internal backend means: Use the value of ``spark.executor.cores`` if the property is set,
+      |otherwise use H2O's default value Runtime.getRuntime().availableProcessors().
+      |Default ``-1`` using automatically started external backend on Hadoop means:
+      |Use H2O's default value Runtime.getRuntime().availableProcessors()
+      |Default ``-1`` using automatically started external backend on Kubernetes means: Use just one cpu.""".stripMargin)
 
   val PROP_PROGRESS_BAR_ENABLED: BooleanOption = (
     "spark.ext.h2o.progressbar.enabled",

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala
@@ -120,6 +120,7 @@ trait K8sH2OStatefulSet extends K8sUtils {
                   |          image: '${conf.externalK8sDockerImage}'
                   |          resources:
                   |            requests:
+                  |              cpu: "${if (conf.nthreads > 0) conf.nthreads else 1}
                   |              memory: "${conf.externalMemory}"
                   |          ports:
                   |            - containerPort: 54321

--- a/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala
+++ b/core/src/main/scala/ai/h2o/sparkling/backend/external/K8sH2OStatefulSet.scala
@@ -95,6 +95,8 @@ trait K8sH2OStatefulSet extends K8sUtils {
     }
   }
 
+  private def getNthreades(conf: H2OConf): Int = if (conf.nthreads > 0) conf.nthreads else 1
+
   private def spec(conf: H2OConf, headlessServiceURL: String): InputStream = {
     val spec = s"""
                   |apiVersion: apps/v1
@@ -120,7 +122,10 @@ trait K8sH2OStatefulSet extends K8sUtils {
                   |          image: '${conf.externalK8sDockerImage}'
                   |          resources:
                   |            requests:
-                  |              cpu: "${if (conf.nthreads > 0) conf.nthreads else 1}
+                  |              cpu: ${getNthreades(conf)}
+                  |              memory: "${conf.externalMemory}"
+                  |            limits:
+                  |              cpu: ${getNthreades(conf)}
                   |              memory: "${conf.externalMemory}"
                   |          ports:
                   |            - containerPort: 54321


### PR DESCRIPTION
The behavior after the change:

Default value of `spark.ext.h2o.nthreads`
```
$SPARK_HOME/bin/spark-shell \
--master "k8s://$K8S_MASTER" \
--deploy-mode client \
--conf spark.scheduler.minRegisteredResourcesRatio=1 \
--conf spark.kubernetes.container.image=marekh2o/sparkling-water-scala:3.38.0.1-1-3.1c \
--conf spark.executor.instances=1 \
--conf spark.driver.host=sparkling-water-app \
--conf spark.kubernetes.driver.pod.name=sparkling-water-app \
--conf spark.ext.h2o.backend.cluster.mode=external \
--conf spark.ext.h2o.external.start.mode=auto \
--conf spark.ext.h2o.external.auto.start.backend=kubernetes \
--conf spark.ext.h2o.external.cluster.size=2 \
--conf spark.ext.h2o.external.memory=2G \
--conf spark.ext.h2o.external.k8s.docker.image=marekh2o/sparkling-water-external-backend:3.38.0.1-1-3.1c
```
In flow UI
<img width="1187" alt="Screen Shot 2022-04-14 at 15 30 55" src="https://user-images.githubusercontent.com/3674621/163428172-e72e40c8-7b15-4dc7-bdbf-2e375f0cee9c.png">

`spark.ext.h2o.nthreads` set to 2
```
$SPARK_HOME/bin/spark-shell \
--master "k8s://$K8S_MASTER" \
--deploy-mode client \
--conf spark.scheduler.minRegisteredResourcesRatio=1 \
--conf spark.kubernetes.container.image=marekh2o/sparkling-water-scala:3.38.0.1-1-3.1c \
--conf spark.executor.instances=1 \
--conf spark.driver.host=sparkling-water-app \
--conf spark.kubernetes.driver.pod.name=sparkling-water-app \
--conf spark.ext.h2o.backend.cluster.mode=external \
--conf spark.ext.h2o.external.start.mode=auto \
--conf spark.ext.h2o.external.auto.start.backend=kubernetes \
--conf spark.ext.h2o.external.cluster.size=2 \
--conf spark.ext.h2o.external.memory=2G \
--conf spark.ext.h2o.nthreads=2 \
--conf spark.ext.h2o.external.k8s.docker.image=marekh2o/sparkling-water-external-backend:3.38.0.1-1-3.1c
```
In flow UI
<img width="1187" alt="Screen Shot 2022-04-14 at 17 39 10" src="https://user-images.githubusercontent.com/3674621/163428534-2e7599af-8a25-4e68-9d65-26aa6d613494.png">

