### PR TITLE
[SW-2706] Generated Configuration Classes Should Handle Overloaded Methods

### DIFF
--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/ConfigurationRunner.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/ConfigurationRunner.scala
@@ -39,14 +39,27 @@ object ConfigurationRunner {
   }
 
   private def setters(className: String): Array[Method] = {
+    methodsWithMaxArity(getSetterMethods(className))
+  }
+
+  private def getSetterMethods(className: String) = {
     getBaseMethods(className)
       .filter(m => m.getName.startsWith("set") || specialSetters.contains(m.getName))
+  }
+
+  private def methodsWithMaxArity(methods: Array[Method]): Array[Method] = {
+    methods
       .foldLeft(Array[Method]()) {
         case (acc, method) =>
-          if (!acc.exists(_.getName == method.getName)) {
-            acc ++ Array(method)
+          val index = acc.indexWhere(_.getName == method.getName)
+          if (index == -1) {
+            acc :+ method
           } else {
-            acc
+            if (acc(index).getParameterCount < method.getParameterCount) {
+              acc.updated(index, method)
+            } else {
+              acc
+            }
           }
       }
   }

--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/python/ConfigurationTemplate.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/python/ConfigurationTemplate.scala
@@ -80,8 +80,8 @@ object ConfigurationTemplate extends ((Array[Method], Array[Method], Class[_]) =
          |        return self
          |""".stripMargin
     } else {
-      s"""    def ${m.getName}(self, value):
-         |        self._jconf.${m.getName}(value)
+      s"""    def ${m.getName}(self, *args):
+         |        self._jconf.${m.getName}(*args)
          |        return self
          |""".stripMargin
     }

--- a/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/r/ConfigurationTemplate.scala
+++ b/api-generation/src/main/scala/ai/h2o/sparkling/api/generation/r/ConfigurationTemplate.scala
@@ -77,10 +77,6 @@ object ConfigurationTemplate extends ((Array[Method], Array[Method], Class[_]) =
   }
 
   private def generateSetter(m: Method): String = {
-    if (m.getParameterCount == 0) {
-      s"""    ${m.getName} = function() { invoke(jconf, "${m.getName}"); .self }"""
-    } else {
-      s"""    ${m.getName} = function(value) { invoke(jconf, "${m.getName}", value); .self }"""
-    }
+    s"""    ${m.getName} = function(...) { invoke(jconf, "${m.getName}", ...); .self }"""
   }
 }

--- a/py/tests/unit/with_runtime_sparkling/test_configuration_parameters.py
+++ b/py/tests/unit/with_runtime_sparkling/test_configuration_parameters.py
@@ -16,6 +16,7 @@
 #
 
 from pysparkling.conf import H2OConf
+import pytest
 
 
 def test_non_overloaded_setter_without_arguments():
@@ -28,6 +29,11 @@ def test_non_overloaded_setter_with_argument():
     assert (conf.externalMemory() == "24G")
 
 
+def test_non_overloaded_setter_with_wrong_argument_type():
+    with pytest.raises(Exception):
+        H2OConf().setExternalMemory(24)
+
+
 def test_overloaded_setter_with_two_arguments():
     conf = H2OConf().setH2OCluster("my_host", 8765)
     assert (conf.h2oClusterHost() == "my_host")
@@ -38,6 +44,11 @@ def test_overloaded_setter_with_one_argument():
     conf = H2OConf().setH2OCluster("my_host:6543")
     assert (conf.h2oClusterHost() == "my_host")
     assert (conf.h2oClusterPort() == 6543)
+
+
+def test_overloaded_setter_with_wrong_argument_type():
+    with pytest.raises(Exception):
+        conf = H2OConf().setH2OCluster(42)
 
 
 def test_overloaded_setter_with_string_argument():

--- a/py/tests/unit/with_runtime_sparkling/test_configuration_parameters.py
+++ b/py/tests/unit/with_runtime_sparkling/test_configuration_parameters.py
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pysparkling.conf import H2OConf
+
+
+def test_non_overloaded_setter_without_arguments():
+    conf = H2OConf().useManualClusterStart()
+    assert (conf.isManualClusterStartUsed() is True)
+
+
+def test_non_overloaded_setter_with_argument():
+    conf = H2OConf().setExternalMemory("24G")
+    assert (conf.externalMemory() == "24G")
+
+
+def test_overloaded_setter_with_two_arguments():
+    conf = H2OConf().setH2OCluster("my_host", 8765)
+    assert (conf.h2oClusterHost() == "my_host")
+    assert (conf.h2oClusterPort() == 8765)
+
+
+def test_overloaded_setter_with_one_argument():
+    conf = H2OConf().setH2OCluster("my_host:6543")
+    assert (conf.h2oClusterHost() == "my_host")
+    assert (conf.h2oClusterPort() == 6543)
+
+
+def test_overloaded_setter_with_string_argument():
+    conf = H2OConf().setExternalExtraJars("path1,path2,path3")
+    assert (conf.externalExtraJars() == "path1,path2,path3")
+
+
+def test_overloaded_setter_with_list_argument():
+    conf = H2OConf().setExternalExtraJars(["path1", "path2", "path3"])
+    assert (conf.externalExtraJars() == "path1,path2,path3")
+

--- a/r/build.gradle
+++ b/r/build.gradle
@@ -77,8 +77,15 @@ task test(type: Exec, dependsOn: distR) {
   environment['spark.ext.h2o.backend.cluster.mode'] = detectBackendClusterMode()
 
   workingDir "${project.buildDir}/src"
-  def testCmd = "library(sparklyr);library(devtools);devtools::test(stop_on_failure = TRUE)"
-  commandLine getOsSpecificCommandLine(["R", "-e", testCmd])
+  def testCmd = {
+    if (project.hasProperty("file")) {
+      def testFile = project.property("file").toString()
+      "library(sparklyr);library(devtools);devtools::test_active_file(file=\"${testFile}\")"
+    } else {
+      "library(sparklyr);library(devtools);devtools::test(stop_on_failure = TRUE)"
+    }
+  }
+  commandLine getOsSpecificCommandLine(["R", "-e", testCmd()])
 }
 
 task installH2ORPackage(type: Exec) {

--- a/r/src/tests/testthat/testConfigurationParameters.R
+++ b/r/src/tests/testthat/testConfigurationParameters.R
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+context("Test H2OConf setters are working correctly")
+
+config <- spark_config()
+config <- c(config, list(
+  "spark.hadoop.yarn.timeline-service.enabled" = "false",
+  "spark.ext.h2o.external.cluster.size" = "1",
+  "spark.ext.h2o.backend.cluster.mode" = Sys.getenv("spark.ext.h2o.backend.cluster.mode"),
+  "sparklyr.connect.enablehivesupport" = FALSE,
+  "sparklyr.gateway.connect.timeout" = 240,
+  "sparklyr.gateway.start.timeout" = 240,
+  "sparklyr.backend.timeout" = 240,
+  "sparklyr.log.console" = TRUE,
+  "spark.ext.h2o.external.start.mode" = "auto",
+  "spark.ext.h2o.external.disable.version.check" = "true",
+  "sparklyr.gateway.port" = 55555,
+  "sparklyr.connect.timeout" = 60 * 5,
+  "spark.master" = "local[*]"
+))
+
+for (i in 1:4) {
+  tryCatch(
+    {
+    sc <- spark_connect(master = "local[*]", config = config)
+  }, error = function(e) { }
+  )
+}
+
+test_that("test non overloaded setter without argument", {
+  conf <- H2OConf()$useManualClusterStart()
+  expect_equal(conf$isManualClusterStartUsed(), TRUE)
+})
+
+test_that("test non overloaded setter with argument", {
+  conf <- H2OConf()$setExternalMemory("24G")
+  expect_equal(conf$externalMemory(), "24G")
+})
+
+test_that("test non overloaded setter with wrong argument type", {
+  expect_error(H2OConf()$setExternalMemory(24L))
+})
+
+test_that("test overloaded setter with two arguments", {
+  conf <- H2OConf()$setH2OCluster("my_host", 8765L)
+  expect_equal(conf$h2oClusterHost(), "my_host")
+  expect_equal(conf$h2oClusterPort(), 8765)
+})
+
+test_that("test overloaded setter with one argument", {
+  conf <- H2OConf()$setH2OCluster("my_host:6543")
+  expect_equal(conf$h2oClusterHost(), "my_host")
+  expect_equal(conf$h2oClusterPort(), 6543)
+})
+
+test_that("test overloaded setter with wrong argument type", {
+ expect_error(H2OConf()$setH2OCluster(42))
+})
+
+test_that("test overloaded setter with string argument type", {
+  conf <- H2OConf()$setExternalExtraJars("path1,path2,path3")
+  expect_equal(conf$externalExtraJars(), "path1,path2,path3")
+})
+
+test_that("test overloaded setter with list argument type", {
+  conf <- H2OConf()$setExternalExtraJars(list("path1", "path2", "path3"))
+  expect_equal(conf$externalExtraJars(), "path1,path2,path3")
+})


### PR DESCRIPTION
Both Python and R (configuration classes) generation was modified to handle overloaded methods. Py4j and sparklyr/java/spark-1.5.2/invoke.scala handle parameter types resolution but adjustments were needed to pass variable number of parameters to those methods. Unit tests covering various corner cases in Python and R were added. Furthermore, an option to test just specified file was added to sparkling-water-r:test task. 

E.g. `./gradlew :sparkling-water-r:test -Pfile="tests/testthat/testConfigurationParameters.R"`