### PR TITLE
[SW-2722] Fix Failing Test on External Backend

### DIFF
--- a/core/src/test/scala/ai/h2o/sparkling/SparkTestContext.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/SparkTestContext.scala
@@ -66,6 +66,7 @@ trait SparkTestContext extends BeforeAndAfterAll {
         .set("spark.ext.h2o.client.ip", clientIp)
         .set("spark.ext.h2o.external.start.mode", "auto")
         .set("spark.ext.h2o.external.memory", "1G")
+        .set("spark.ext.h2o.nthreads", "4")
       conf
     })
   }

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterFullCategoricalTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterFullCategoricalTestSuite.scala
@@ -89,8 +89,8 @@ class DataFrameConverterFullCategoricalTestSuite extends FunSuite with SharedH2O
     testDataFrameConversionWithOnlyUniqueValues(1)
   }
 
-  test("DataFrame[String] with only unique values with in 100 partitions to H2OFrame[T_STR] and back") {
-    testDataFrameConversionWithOnlyUniqueValues(100)
+  test("DataFrame[String] with only unique values with in 50 partitions to H2OFrame[T_STR] and back") {
+    testDataFrameConversionWithOnlyUniqueValues(50)
   }
 
   def testDataFrameConversionWithOnlyUniqueValues(numPartitions: Int) {

--- a/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterFullCategoricalTestSuite.scala
+++ b/core/src/test/scala/ai/h2o/sparkling/backend/converters/DataFrameConverterFullCategoricalTestSuite.scala
@@ -89,8 +89,8 @@ class DataFrameConverterFullCategoricalTestSuite extends FunSuite with SharedH2O
     testDataFrameConversionWithOnlyUniqueValues(1)
   }
 
-  test("DataFrame[String] with only unique values with in 50 partitions to H2OFrame[T_STR] and back") {
-    testDataFrameConversionWithOnlyUniqueValues(50)
+  test("DataFrame[String] with only unique values with in 100 partitions to H2OFrame[T_STR] and back") {
+    testDataFrameConversionWithOnlyUniqueValues(100)
   }
 
   def testDataFrameConversionWithOnlyUniqueValues(numPartitions: Int) {


### PR DESCRIPTION
Jenkins workers have been upgraded from t2.xglarge to t2.2xlarge due to kubernetes tests. One of the tests started failing on external backend:
```
ai.h2o.sparkling.backend.converters.DataFrameConverterFullCategoricalTestSuite > DataFrame[String] with only unique values with in 100 partitions to H2OFrame[T_STR] and back FAILED

[2022-06-27T17:10:47.541Z]     ai.h2o.sparkling.backend.exceptions.RestApiCommunicationException: H2O node http://172.17.0.2:54321/ responded with

[2022-06-27T17:10:47.541Z]     Status code: 500 : Server Error

[2022-06-27T17:10:47.542Z]     Server error: {"__meta":{"schema_version":3,"schema_name":"H2OErrorV3","schema_type":"H2OError"},"timestamp":1656349834337,"error_url":"/3/FinalizeFrame","msg":"\n\nERROR MESSAGE:\n\nDistributedException from 0b3ec42f20f7/172.17.0.2:54321: 'GC overhead limit exceeded'\n\n","dev_msg":"\n\nERROR MESSAGE:\n\nDistributedException from 0b3ec42f20f7/172.17.0.2:54321: 'GC overhead limit exceeded'\n\n","http_status":500,"values":{},"exception_type":"water.util.DistributedException","exception_msg":"\n\nERROR MESSAGE:\n\nDistributedException from 0b3ec42f20f7/172.17.0.2:54321: 'GC overhead limit exceeded'\n\n","stacktrace":["DistributedException from 0b3ec42f20f7/172.17.0.2:54321: 'GC overhead limit exceeded', caused by java.lang.OutOfMemoryError: GC overhead limit exceeded","    water.MRTask.getResult(MRTask.java:660)","    water.MRTask.getResult(MRTask.java:670)","    water.MRTask.doAll(MRTask.java:530)","    water.MRTask.doAll(MRTask.java:482)","    ai.h2o.sparkling.extensions.rest.api.ImportFrameHandler.finalize(ImportFrameHandler.scala:62)","    sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)","    sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)","    sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)","    java.lang.reflect.Method.invoke(Method.java:498)","    water.api.Handler.handle(Handler.java:60)","    water.api.RequestServer.serve(RequestServer.java:472)","    water.api.RequestServer.doGeneric(RequestServer.java:303)","    water.api.RequestServer.doPost(RequestServer.java:227)","    javax.servlet.http.HttpServlet.service(HttpServlet.java:707)","    javax.servlet.http.HttpServlet.service(HttpServlet.java:790)","    ai.h2o.org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:865)","    ai.h2o.org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:535)","    ai.h2o.org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)","    ai.h2o.org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1317)","    ai.h2o.org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)","    ai.h2o.org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)","    ai.h2o.org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)","    ai.h2o.org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1219)","    ai.h2o.org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)","    ai.h2o.org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)","    ai.h2o.org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)","    water.webserver.jetty9.Jetty9ServerAdapter$LoginHandler.handle(Jetty9ServerAdapter.java:130)","    ai.h2o.org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)","    ai.h2o.org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)","    ai.h2o.org.eclipse.jetty.server.Server.handle(Server.java:531)","    ai.h2o.org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)","    ai.h2o.org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)","    ai.h2o.org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)","    ai.h2o.org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)","    ai.h2o.org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)","    ai.h2o.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)","    ai.h2o.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)","    ai.h2o.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)","    ai.h2o.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)","    ai.h2o.org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)","    ai.h2o.org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:762)","    ai.h2o.org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:680)","    java.lang.Thread.run(Thread.java:748)","Caused by:java.lang.OutOfMemoryError: GC overhead limit exceeded","    java.lang.Integer.valueOf(Integer.java:832)","    ai.h2o.sparkling.extensions.internals.UpdateCategoricalIndicesTask.domainToCategoricalMap(UpdateCategoricalIndicesTask.java:40)","    ai.h2o.sparkling.extensions.internals.UpdateCategoricalIndicesTask.map(UpdateCategoricalIndicesTask.java:61)","    water.MRTask.compute2(MRTask.java:819)","    water.MRTask.compute2(MRTask.java:775)","    water.MRTask.compute2(MRTask.java:775)","    water.MRTask.compute2(MRTask.java:775)","    water.MRTask.compute2(MRTask.java:775)","    water.MRTask.compute2(MRTask.java:775)","    water.MRTask.compute2(MRTask.java:775)","    water.MRTask.compute2(MRTask.java:775)","    water.H2O$H2OCountedCompleter.compute1(H2O.java:1680)","    ai.h2o.sparkling.extensions.internals.UpdateCategoricalIndicesTask$Icer.compute1(UpdateCategoricalIndicesTask$Icer.java)","    water.H2O$H2OCountedCompleter.compute(H2O.java:1676)","    jsr166y.CountedCompleter.exec(CountedCompleter.java:468)","    jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)","    jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:976)","    jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1479)","    jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)"]}
```

By default, h2o node uses all available cores (8, 4 before). This caused increase of memory requirements. After explicitly setting the number of threads to 4, the test stopped failing. 