### PR TITLE
[SW-2724] Fix Docker Image Publishing to DockerHub

### DIFF
--- a/ci/commons.groovy
+++ b/ci/commons.groovy
@@ -220,6 +220,7 @@ def gitCommit(files, msg) {
 
 def installDocker() {
     sh "sudo apt-get update"
+    sh "sudo apt -y install containerd"
     sh "sudo apt -y install docker.io"
     sh "sudo service docker start"
     sh "sudo chmod 666 /var/run/docker.sock"


### PR DESCRIPTION
DockerHub Publishing phase of nightly builds fails on the following error:
```
[2022-07-06T21:07:07.940Z] + sudo apt -y install docker.io

[2022-07-06T21:07:07.940Z] 

[2022-07-06T21:07:07.940Z] WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

[2022-07-06T21:07:07.940Z] 

[2022-07-06T21:07:08.871Z] Reading package lists...

[2022-07-06T21:07:09.131Z] Building dependency tree...

[2022-07-06T21:07:09.131Z] Reading state information...

[2022-07-06T21:07:09.131Z] Some packages could not be installed. This may mean that you have

[2022-07-06T21:07:09.131Z] requested an impossible situation or if you are using the unstable

[2022-07-06T21:07:09.131Z] distribution that some required packages have not yet been created

[2022-07-06T21:07:09.131Z] or been moved out of Incoming.

[2022-07-06T21:07:09.131Z] The following information may help to resolve the situation:

[2022-07-06T21:07:09.131Z] 

[2022-07-06T21:07:09.131Z] The following packages have unmet dependencies:

[2022-07-06T21:07:09.131Z]  docker.io : Depends: containerd (>= 1.2.6-0ubuntu1~)

[2022-07-06T21:07:09.131Z] E: Unable to correct problems, you have held broken packages.
```

The problem is discussed [here](https://askubuntu.com/questions/1273024/docker-io-depends-containerd-1-2-6-0ubuntu1). 

I've reproduced the problem in docker image locally and confirm that the fix works.