### PR TITLE
[SW-2726][FOLLOWUP] Fix Builds Against H2O branch

### DIFF
--- a/ci/build.gradle
+++ b/ci/build.gradle
@@ -31,6 +31,7 @@ task createDockerfile(type: Dockerfile, dependsOn: copyFiles) {
                """.stripMargin()
 
   runCommand """\\
+                apt-get install libharfbuzz-dev libfribidi-dev && \\
                 R -e 'install.packages("testthat", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("dbplyr", repos = "http://cran.us.r-project.org")' && \\
                 R -e 'install.packages("sparklyr", repos = "http://cran.us.r-project.org")' && \\

--- a/ci/sparklingWaterPipeline.groovy
+++ b/ci/sparklingWaterPipeline.groovy
@@ -182,6 +182,7 @@ def prepareSparklingEnvironmentStage(config) {
                             cd h2o-3
                             git checkout ${config.h2oBranch}
                             . /envs/h2o_env_python2.7/bin/activate
+                            unset CI
                             export BUILD_HADOOP=true
                             export H2O_TARGET=${getDriverHadoopVersion()}
                             ./gradlew build --parallel -x check -Duser.name=ec2-user

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Version of Terraform used in the script creating the docker image
 terraformVersion=0.12.25
 # Version of docker image used in Jenkins tests
-dockerImageVersion=64
+dockerImageVersion=65
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions


### PR DESCRIPTION
The new CI infrastructure sets `CI` environment variable in the testing docker image which causes H2O build [loading artifacts from local nexus](https://github.com/h2oai/h2o-3/blob/master/build.gradle#L6-L22).