### PR TITLE
[SW-2734] Fix Time Conversion Tests in Python API

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_Spark_to_H2O_conversions.py
+++ b/py/tests/unit/with_runtime_sparkling/test_Spark_to_H2O_conversions.py
@@ -276,8 +276,8 @@ def testConvertTimeValueFromSparkToH2OAndBack(spark, hc, timeZone, sparkType):
     df = spark.createDataFrame(data, ['strings']).select(col('strings').cast(sparkType).alias('time'))
 
     hf = hc.asH2OFrame(df)
-    hfResultString = hf.__unicode__()
-    hfParsedItems = hfResultString.split('\n')[1:5]
+    hfResultString = hf.to_str()
+    hfParsedItems = hfResultString.split('\n')[1:-2]
     hfParsedItems.sort()
 
     assert hfParsedItems == expected

--- a/py/tests/unit/with_runtime_sparkling/test_Spark_to_H2O_conversions.py
+++ b/py/tests/unit/with_runtime_sparkling/test_Spark_to_H2O_conversions.py
@@ -277,7 +277,7 @@ def testConvertTimeValueFromSparkToH2OAndBack(spark, hc, timeZone, sparkType):
 
     hf = hc.asH2OFrame(df)
     hfResultString = hf.__unicode__()
-    hfParsedItems = hfResultString.split('\n')[2:6]
+    hfParsedItems = hfResultString.split('\n')[1:5]
     hfParsedItems.sort()
 
     assert hfParsedItems == expected


### PR DESCRIPTION
The textual layout of Python `H2OFrame` on H2O-3 master branch has  changed from:
```
time
-------------------
2019-04-04 00:00:00
2020-01-01 00:00:00
2020-02-02 00:00:00
2020-03-03 00:00:00

[4 rows x 1 column]
```
to:
```
time
2019-04-04 00:00:00
2020-01-01 00:00:00
2020-02-02 00:00:00
2020-03-03 00:00:00
[4 rows x 1 column]
```