### PR TITLE
[SW-2745] Remove Support for Spark 2.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,6 @@ The documentation contains also documentation for our clients, PySparkling and R
 - `Sparkling Water For Spark 3.0 <http://docs.h2o.ai/sparkling-water/3.0/latest-stable/doc/index.html>`__
 - `Sparkling Water For Spark 2.4 <http://docs.h2o.ai/sparkling-water/2.4/latest-stable/doc/index.html>`__
 - `Sparkling Water For Spark 2.3 <http://docs.h2o.ai/sparkling-water/2.3/latest-stable/doc/index.html>`__
-- `Sparkling Water For Spark 2.2 <http://docs.h2o.ai/sparkling-water/2.2/latest-stable/doc/index.html>`__
 
 Download Binaries
 ~~~~~~~~~~~~~~~~~
@@ -35,7 +34,6 @@ Download Binaries
 - `Latest version for Spark 3.0 <http://h2o-release.s3.amazonaws.com/sparkling-water/spark-3.0/latest.html>`__
 - `Latest version for Spark 2.4 <http://h2o-release.s3.amazonaws.com/sparkling-water/spark-2.4/latest.html>`__
 - `Latest version for Spark 2.3 <http://h2o-release.s3.amazonaws.com/sparkling-water/spark-2.3/latest.html>`__
-- `Latest version for Spark 2.2 <http://h2o-release.s3.amazonaws.com/sparkling-water/spark-2.2/latest.html>`__
 
 
 Maven
@@ -62,10 +60,10 @@ Sparkling Water Requirements
 
 -  Linux/OS X/Windows
 -  Java 8+
--  Python 2.7+ for Python version of Sparkling Water (PySparkling) build for Apache Spark 2.2 - 3.0
+-  Python 2.7+ for Python version of Sparkling Water (PySparkling) build for Apache Spark 2.3 - 3.0
 -  Python 3.6+ for Python version of Sparkling Water (PySparkling) build for Apache Spark 3.1 - 3.2
 -  Python 3.7+ for Python version of Sparkling Water (PySparkling) build for Apache Spark 3.3
--  `Apache Spark 2.2+ <https://spark.apache.org/downloads.html>`__ and ``SPARK_HOME`` shell variable must point to your local Spark installation
+-  `Apache Spark 2.3+ <https://spark.apache.org/downloads.html>`__ and ``SPARK_HOME`` shell variable must point to your local Spark installation
 
 ---------------
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ dockerImageVersion=66
 # Is this build nightly build
 isNightlyBuild=false
 # Supported Major Spark Versions
-supportedSparkVersions=2.2 2.3 2.4 3.0 3.1 3.2 3.3
+supportedSparkVersions=2.3 2.4 3.0 3.1 3.2 3.3
 # The list of python environments used in automated tests
 pythonEnvironments=2.7 3.6 3.7 3.8
 # Select for which Spark version is Sparkling Water built by default

--- a/py/README.rst
+++ b/py/README.rst
@@ -14,7 +14,6 @@ PySparkling Documentation is hosted at our documentation page:
 - For Spark 3.0 - http://docs.h2o.ai/sparkling-water/3.0/latest-stable/doc/pysparkling.html
 - For Spark 2.4 - http://docs.h2o.ai/sparkling-water/2.4/latest-stable/doc/pysparkling.html
 - For Spark 2.3 - http://docs.h2o.ai/sparkling-water/2.3/latest-stable/doc/pysparkling.html
-- For Spark 2.2 - http://docs.h2o.ai/sparkling-water/2.2/latest-stable/doc/pysparkling.html
 
 .. |Join the chat at https://gitter.im/h2oai/sparkling-water| image:: https://badges.gitter.im/Join%20Chat.svg
    :target: Join the chat at https://gitter.im/h2oai/sparkling-water?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/r/README.rst
+++ b/r/README.rst
@@ -11,7 +11,6 @@ RSparkling Documentation is hosted at our documentation page:
 - For Spark 3.0 - http://docs.h2o.ai/sparkling-water/3.0/latest-stable/doc/rsparkling.html
 - For Spark 2.4 - http://docs.h2o.ai/sparkling-water/2.4/latest-stable/doc/rsparkling.html
 - For Spark 2.3 - http://docs.h2o.ai/sparkling-water/2.3/latest-stable/doc/rsparkling.html
-- For Spark 2.2 - http://docs.h2o.ai/sparkling-water/2.2/latest-stable/doc/rsparkling.html
 
 .. |Join the chat at https://gitter.im/h2oai/sparkling-water| image:: https://badges.gitter.im/Join%20Chat.svg
    :target: Join the chat at https://gitter.im/h2oai/sparkling-water?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge


### PR DESCRIPTION
Pieces of code specific to Spark 2.2 stay for now. From now, we won't test SW  against Spark 2.2 and publish artifacts in the major release `3.38.0.1-1`. The support for Spark 2.2 was deprecated by the ticket [SW-2644](https://h2oai.atlassian.net/browse/SW-2644) in release [3.34.0.4-1](https://h2oai.atlassian.net/issues/?jql=project%20%3D%20%22SW%22%20AND%20fixVersion%20%3D%20%223.34.0.4-1%22)