### PR TITLE
[SW-2746] Fix GBM MOJO Test in Python

### DIFF
--- a/py/tests/unit/with_runtime_sparkling/test_mojo.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo.py
@@ -52,7 +52,7 @@ def testTrainingParams(gbmModel):
     assert params["seed"] == "42"
     assert params["distribution"] == "bernoulli"
     assert params["ntrees"] == "2"
-    assert len(params) == 45
+    assert len(params) == 46
 
 
 def testModelCategory(gbmModel):


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8470 introduced new training parameters to gbm. the only one is not null by default.