### PR TITLE
[SW-2754] Expose splinesNonNegative parameter on H2OGAM

### DIFF
--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
@@ -99,6 +99,7 @@ class MOJOParameterTestSuite extends FunSuite with SharedH2OTestContext with Mat
       .setSeed(1)
       .setLambdaValue(Array(0.5))
       .setGamCols(Array(Array("PSA"), Array("AGE")))
+      .setSplinesNonNegative(Array(true, false))
       .setNumKnots(Array(5, 5))
       .setBs(Array(1, 1))
       .setScale(Array(.5, .5))

--- a/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
+++ b/ml/src/test/scala/ai/h2o/sparkling/ml/models/MOJOParameterTestSuite.scala
@@ -106,7 +106,7 @@ class MOJOParameterTestSuite extends FunSuite with SharedH2OTestContext with Mat
       .setSplineOrders(Array(-1, -1))
     val mojo = algorithm.fit(dataset)
 
-    compareParameterValues(algorithm, mojo, Set("getFeaturesCols"))
+    compareParameterValues(algorithm, mojo, Set("getFeaturesCols", "getSplinesNonNegative"))
   }
 
   test("Test MOJO parameters on Deep Learning") {

--- a/py-scoring/src/ai/h2o/sparkling/ml/params/H2OTypeConverters.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/params/H2OTypeConverters.py
@@ -197,6 +197,34 @@ class H2OTypeConverters(object):
         return convert
 
     @staticmethod
+    def toNullableListBoolean():
+        def convert(value):
+            if value is None:
+                return None
+            else:
+                return H2OTypeConverters.toListBoolean()(value)
+
+        return convert
+
+    @staticmethod
+    def toListBoolean():
+        def convert(value):
+            if value is None:
+                raise TypeError("None is not allowed.")
+            else:
+                valueForConversion = value
+                if isinstance(value, JavaObject):
+                    valueForConversion = list(value)
+
+                if TypeConverters._can_convert_to_list(valueForConversion):
+                    valueForConversion = TypeConverters.toList(valueForConversion)
+                    if all(map(lambda v: type(v) == bool, valueForConversion)):
+                        return [bool(v) for v in valueForConversion]
+                raise TypeError("Could not convert %s to list of booleans" % valueForConversion)
+
+        return convert
+
+    @staticmethod
     def toNullableListInt():
         def convert(value):
             if value is None:

--- a/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
@@ -56,7 +56,7 @@ def testGAMParameters(prostateDataset):
                        featuresCols=features, bs=[1, 1], scale=[0.5, 0.5], splineOrders=[-1, -1],
                        splinesNonNegative=[True, False])
     model = algorithm.fit(prostateDataset)
-    compareParameterValues(algorithm, model, ["getFeaturesCols"])
+    compareParameterValues(algorithm, model, ["getFeaturesCols", "getSplinesNonNegative"])
 
 
 def testDeepLearningParameters(prostateDataset):

--- a/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
+++ b/py/tests/unit/with_runtime_sparkling/test_mojo_parameters.py
@@ -53,7 +53,8 @@ def testGLMParameters(prostateDataset):
 def testGAMParameters(prostateDataset):
     features = ['AGE', 'RACE', 'DPROS', 'DCAPS', 'PSA']
     algorithm = H2OGAM(seed=1, labelCol="CAPSULE", gamCols=[["PSA"], ["AGE"]], numKnots=[5, 5], lambdaValue=[0.5],
-                       featuresCols=features, bs=[1, 1], scale=[0.5, 0.5], splineOrders=[-1, -1])
+                       featuresCols=features, bs=[1, 1], scale=[0.5, 0.5], splineOrders=[-1, -1],
+                       splinesNonNegative=[True, False])
     model = algorithm.fit(prostateDataset)
     compareParameterValues(algorithm, model, ["getFeaturesCols"])
 

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/params/NullableBooleanArrayParam.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/params/NullableBooleanArrayParam.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.h2o.sparkling.ml.params
+
+import org.apache.spark.ml.param.{Param, ParamPair, Params}
+import org.json4s.JNull
+import org.json4s.JsonAST.{JArray, JBool}
+import org.json4s.jackson.JsonMethods.{compact, parse, render}
+
+import scala.collection.JavaConverters._
+
+class NullableBooleanArrayParam(parent: Params, name: String, doc: String, isValid: Array[Boolean] => Boolean)
+  extends Param[Array[Boolean]](parent, name, doc, isValid) {
+
+  def this(parent: Params, name: String, doc: String) =
+    this(parent, name, doc, _ => true)
+
+  /** Creates a param pair with a `java.util.List` of values (for Java and Python). */
+  def w(value: java.util.List[java.lang.Boolean]): ParamPair[Array[Boolean]] =
+    w(value.asScala.map(_.asInstanceOf[Boolean]).toArray)
+
+  override def jsonEncode(value: Array[Boolean]): String = {
+    if (value == null) {
+      compact(render(JNull))
+    } else {
+      import org.json4s.JsonDSL._
+      compact(render(value.toSeq.map(JBool(_))))
+    }
+  }
+
+  override def jsonDecode(json: String): Array[Boolean] = {
+    parse(json) match {
+      case JNull =>
+        null
+      case JArray(values) =>
+        values.map {
+          case JBool(x) => x
+          case jValue => throw new IllegalArgumentException(s"Cannot decode $jValue to Boolean.")
+        }.toArray
+      case _ =>
+        throw new IllegalArgumentException(s"Cannot decode $json to Array[Boolean].")
+    }
+  }
+}

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/params/ParameterConstructorMethods.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/params/ParameterConstructorMethods.scala
@@ -69,6 +69,10 @@ trait ParameterConstructorMethods extends Params {
     new NullableDoubleArrayArrayParam(this, name, doc)
   }
 
+  protected def nullableBooleanArrayParam(name: String, doc: String): NullableBooleanArrayParam = {
+    new NullableBooleanArrayParam(this, name, doc)
+  }
+
   protected def nullableIntArrayParam(name: String, doc: String): NullableIntArrayParam = {
     new NullableIntArrayParam(this, name, doc)
   }


### PR DESCRIPTION
The parameter is introduced in auto-generated code of SW API. This PR introduces boolean array type for the new parameter since the first time that such a type is used in SW API.

Related PR to H2O-3 repository: https://github.com/h2oai/h2o-3/pull/6336

Genereted files:
- [H2OGAMParams.py](https://github.com/h2oai/sparkling-water/files/9756525/H2OGAMParams.py.txt)
- [H2OGAMParams.scala](https://github.com/h2oai/sparkling-water/files/9756556/H2OGAMParams.scala.txt)

