### PR TITLE
[SW-2758] Improvement in overall scoring performance for DAI mojo's

### DIFF
--- a/doc/src/site/sphinx/deployment/load_mojo_pipeline.rst
+++ b/doc/src/site/sphinx/deployment/load_mojo_pipeline.rst
@@ -216,6 +216,7 @@ We can configure the output and format of predictions via the H2OMOJOSettings. T
 - ``withInternalContributions`` -  If enabled, it appends the `internal_contributions` column to the input dataset.
   The column contains sub-columns with Shapley values for the transformed features entering the models inside MOJO pipeline.
   By default, this option is disabled.
+- ``scoringBulkSize`` - A number of records passed at once to the underlying mojo2 runtime library.
 
 Troubleshooting
 ~~~~~~~~~~~~~~~

--- a/py-scoring/src/ai/h2o/sparkling/ml/models/H2OMOJOPipelineModel.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/models/H2OMOJOPipelineModel.py
@@ -42,3 +42,6 @@ class H2OMOJOPipelineModel(H2OAlgorithmMOJOModelBase):
 
     def getWithInternalContributions(self):
         return self._java_obj.getWithInternalContributions()
+
+    def getScoringBulkSize(self):
+        return self._java_obj.getScoringBulkSize()

--- a/py-scoring/src/ai/h2o/sparkling/ml/models/H2OMOJOSettings.py
+++ b/py-scoring/src/ai/h2o/sparkling/ml/models/H2OMOJOSettings.py
@@ -31,7 +31,8 @@ class H2OMOJOSettings(JavaWrapper):
                  withInternalContributions=False,
                  withLeafNodeAssignments=False,
                  withStageResults=False,
-                 dataFrameSerializer="ai.h2o.sparkling.utils.JSONDataFrameSerializer"):
+                 dataFrameSerializer="ai.h2o.sparkling.utils.JSONDataFrameSerializer",
+                 scoringBulkSize=1000):
         self._java_obj = None
 
         assert isinstance(predictionCol, str)
@@ -44,6 +45,7 @@ class H2OMOJOSettings(JavaWrapper):
         assert isinstance(withLeafNodeAssignments, bool)
         assert isinstance(withStageResults, bool)
         assert isinstance(dataFrameSerializer, str)
+        assert isinstance(scoringBulkSize, int)
         self.predictionCol = predictionCol
         self.detailedPredictionCol = detailedPredictionCol
         self.convertUnknownCategoricalLevelsToNa = convertUnknownCategoricalLevelsToNa
@@ -54,6 +56,7 @@ class H2OMOJOSettings(JavaWrapper):
         self.withLeafNodeAssignments = withLeafNodeAssignments
         self.withStageResults = withStageResults
         self.dataFrameSerializer = dataFrameSerializer
+        self.scoringBulkSize = scoringBulkSize
 
     def toJavaObject(self):
         self._java_obj = self._new_java_obj("ai.h2o.sparkling.ml.models.H2OMOJOSettings",
@@ -66,7 +69,8 @@ class H2OMOJOSettings(JavaWrapper):
                                             self.withInternalContributions,
                                             self.withLeafNodeAssignments,
                                             self.withStageResults,
-                                            self.dataFrameSerializer)
+                                            self.dataFrameSerializer,
+                                            self.scoringBulkSize)
         return self._java_obj
 
     @staticmethod

--- a/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOPipelineModel.R
+++ b/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOPipelineModel.R
@@ -30,5 +30,5 @@ H2OMOJOPipelineModel <- setRefClass("H2OMOJOPipelineModel", contains = ("H2OAlgo
   },
   getScoringBulkSize = function() {
     invoke(.self$jmojo, "getScoringBulkSize")
-  },
+  }
 ))

--- a/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOPipelineModel.R
+++ b/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOPipelineModel.R
@@ -27,5 +27,8 @@ H2OMOJOPipelineModel.createFromMojo <- function(pathToMojo, settings = H2OMOJOSe
 H2OMOJOPipelineModel <- setRefClass("H2OMOJOPipelineModel", contains = ("H2OAlgorithmMOJOModelBase"), methods = list(
   getWithInternalContributions = function() {
     invoke(.self$jmojo, "getWithInternalContributions")
-  }
+  },
+  getScoringBulkSize = function() {
+    invoke(.self$jmojo, "getScoringBulkSize")
+  },
 ))

--- a/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOSettings.R
+++ b/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOSettings.R
@@ -43,7 +43,7 @@ H2OMOJOSettings <- setRefClass("H2OMOJOSettings",
                                                        withLeafNodeAssignments = FALSE,
                                                        withStageResults = FALSE,
                                                        dataFrameSerializer = "ai.h2o.sparkling.utils.JSONDataFrameSerializer",
-                                                       scoringBulkSize = 1000) {
+                                                       scoringBulkSize = 1000L) {
                                    .self$predictionCol <- predictionCol
                                    .self$detailedPredictionCol <- detailedPredictionCol
                                    .self$convertUnknownCategoricalLevelsToNa <- convertUnknownCategoricalLevelsToNa

--- a/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOSettings.R
+++ b/r/src/R/ai/h2o/sparkling/ml/models/H2OMOJOSettings.R
@@ -30,7 +30,8 @@ H2OMOJOSettings <- setRefClass("H2OMOJOSettings",
                                              withInternalContributions = "logical",
                                              withLeafNodeAssignments = "logical",
                                              withStageResults = "logical",
-                                             dataFrameSerializer = "character"),
+                                             dataFrameSerializer = "character",
+                                             scoringBulkSize = "integer"),
                                methods = list(
                                  initialize = function(predictionCol = "prediction",
                                                        detailedPredictionCol = "detailed_prediction",
@@ -41,7 +42,8 @@ H2OMOJOSettings <- setRefClass("H2OMOJOSettings",
                                                        withInternalContributions = FALSE,
                                                        withLeafNodeAssignments = FALSE,
                                                        withStageResults = FALSE,
-                                                       dataFrameSerializer = "ai.h2o.sparkling.utils.JSONDataFrameSerializer") {
+                                                       dataFrameSerializer = "ai.h2o.sparkling.utils.JSONDataFrameSerializer",
+                                                       scoringBulkSize = 1000) {
                                    .self$predictionCol <- predictionCol
                                    .self$detailedPredictionCol <- detailedPredictionCol
                                    .self$convertUnknownCategoricalLevelsToNa <- convertUnknownCategoricalLevelsToNa
@@ -52,6 +54,7 @@ H2OMOJOSettings <- setRefClass("H2OMOJOSettings",
                                    .self$withLeafNodeAssignments <- withLeafNodeAssignments
                                    .self$withStageResults <- withStageResults
                                    .self$dataFrameSerializer <- dataFrameSerializer
+                                   .self$scoringBulkSize <- scoringBulkSize
                                  },
                                  toJavaObject = function() {
                                    sc <- spark_connection_find()[[1]]
@@ -65,6 +68,7 @@ H2OMOJOSettings <- setRefClass("H2OMOJOSettings",
                                               .self$withInternalContributions,
                                               .self$withLeafNodeAssignments,
                                               .self$withStageResults,
-                                              .self$dataFrameSerializer)
+                                              .self$dataFrameSerializer,
+                                              .self$scoringBulkSize)
                                  }
                                ))

--- a/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOSettings.scala
+++ b/scoring/src/main/scala/ai/h2o/sparkling/ml/models/H2OMOJOSettings.scala
@@ -30,7 +30,8 @@ case class H2OMOJOSettings(
     withInternalContributions: Boolean = false,
     withLeafNodeAssignments: Boolean = false,
     withStageResults: Boolean = false,
-    dataFrameSerializer: String = DataFrameSerializer.default.getClass().getName())
+    dataFrameSerializer: String = DataFrameSerializer.default.getClass().getName(),
+    scoringBulkSize: Int = 1000)
 
 object H2OMOJOSettings {
   def default = H2OMOJOSettings()

--- a/utils/src/main/scala/org/apache/spark/sql/SWGenericRow.scala
+++ b/utils/src/main/scala/org/apache/spark/sql/SWGenericRow.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.expressions.GenericRow
+
+class SWGenericRow(override val values: Array[Any]) extends GenericRow(values)


### PR DESCRIPTION
Passing data to underlying mojo2 runtime library in form of MojoFrames of 1 record is not performant. After changing the logic and send data in MojoFrames of 1000 records, the scoring is 10x faster.