### PR TITLE
[SW-2767] Fix DBC tests

### DIFF
--- a/ci/Jenkinsfile-databricks
+++ b/ci/Jenkinsfile-databricks
@@ -32,6 +32,7 @@ static String getSparklingVersion(props) {
 
 def shWithSWPyEnv(script) {
     def scriptWithPrefix =  """
+        . ~/miniconda/etc/profile.d/conda.sh 
         conda activate sw_env_python3.6
         ${script}
         conda deactivate


### PR DESCRIPTION
The thrown error:
```

+ conda activate sw_env_python3.6



CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.

To initialize your shell, run



    $ conda init <SHELL_NAME>



Currently supported shells are:

  - bash

  - fish

  - tcsh

  - xonsh

  - zsh

  - powershell



See 'conda init --help' for more information and options.



IMPORTANT: You may need to close and restart your shell after running 'conda init'.





script returned exit code 1
``` 