### PR TITLE
[GH-5646] Avoid CVE-2019-10086 by upgrading MOJO2 lib

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ h2oMajorName=3.42.0
 # H2O Build version, defined here to be overriden by -P option
 h2oBuild=1
 # Version of Mojo Pipeline library
-mojoPipelineVersion=2.7.11.1
+mojoPipelineVersion=2.8.1
 # Defines whether to run tests with Driverless AI mojo pipelines
 # These tests require the Driverless AI license
 testMojoPipeline=false


### PR DESCRIPTION
Closes #5646 