### PR TITLE
add `downloadH2OLogs` to `H2OContext`

### DIFF
--- a/r/src/R/ai/h2o/sparkling/H2OContext.R
+++ b/r/src/R/ai/h2o/sparkling/H2OContext.R
@@ -97,6 +97,10 @@ H2OContext <- setRefClass("H2OContext", fields = list(jhc = "ANY"), methods = li
   getH2OLogLevel = function() {
     invoke(.self$jhc, "getH2OLogLevel")
   },
+  downloadH2OLogs = function(destination, container = c("ZIP", "LOG")) {
+    container <- match.arg(container)
+    invoke(.self$jhc, "downloadH2OLogs", destination, container)
+  },
   importHiveTable = function(database = "default", table, partitions = NULL, allowMultiFormat = FALSE) {
     library(h2o)
     h2o.import_hive_table(database, table, partitions, allowMultiFormat)


### PR DESCRIPTION
**Description:**
Would be very helpful to have parity with python for this functionality:
https://github.com/h2oai/sparkling-water/blob/c2a2048e6f2be5d7c28475263cfcf1e6d3898c2a/py/src/ai/h2o/sparkling/H2OContext.py#L129-L131
