### PR TITLE
fix(build): quick fix of JMH leak that was propagated via H2O-3 dependencies.

### DIFF
--- a/assembly/build.gradle
+++ b/assembly/build.gradle
@@ -43,6 +43,9 @@ configurations {
     exclude group: 'javax.xml.bind', module: 'jaxb-api' // a dependency of org.apache.hadoop:hadoop-yarn-common
     exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
     // a dependency of org.apache.spark:spark-graphx_2.11
+    // Exclude leaked dependency from h2o-3 - fixed in https://github.com/h2oai/h2o-3/pull/16654
+    exclude group: 'org.openjdk.jmh', module: 'jmh-core'
+    exclude group: 'org.openjdk.jmh', module: 'jmh-generator-annprocess'
   }
 }
 


### PR DESCRIPTION
In h2o-3 the leak is fixed in https://github.com/h2oai/h2o-3/pull/16654,
but this PR simply omits JMH libraries from putting into final assembly.

