### PR TITLE
upgrade(deps): Upgrade H2O-3 and MOJO2 dependencies.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,9 @@ h2oMajorVersion=3.46.0
 # Name of H2O major version
 h2oMajorName=3.46.0
 # H2O Build version, defined here to be overriden by -P option
-h2oBuild=6
+h2oBuild=7
 # Version of Mojo Pipeline library
-mojoPipelineVersion=2.8.1
+mojoPipelineVersion=2.8.9.1
 # Defines whether to run tests with Driverless AI mojo pipelines
 # These tests require the Driverless AI license
 testMojoPipeline=false
@@ -29,7 +29,7 @@ pythonEnvironments=3.6 3.7 3.8 3.9 3.10 3.11
 # Select for which Spark version is Sparkling Water built by default
 spark=3.5
 # Sparkling Water Version
-version=3.46.0.2-1-SNAPSHOT
+version=3.46.0.7-1-SNAPSHOT
 # Spark version from which is Kubernetes Supported
 kubernetesSupportSinceSpark=2.4
 databricksTestSinceSpark=2.4


### PR DESCRIPTION
H2O-3 to 3.46.0.7
MOJO2 to 2.8.9.1

> Note: The base is `mm/fix/deps_jmh_leak` (https://github.com/h2oai/sparkling-water/pull/5757). Before merging please make sure that it is properly rebased. ✅ DONE - moved based to `master`

