### PR TITLE
fix: pkg_resources no longer supported

### DIFF
--- a/py-scoring/src/ai/h2o/sparkling/Initializer.py
+++ b/py-scoring/src/ai/h2o/sparkling/Initializer.py
@@ -159,8 +159,8 @@ class Initializer(object):
         if zipfile.is_zipfile(packagePath):
             return Initializer.__extracted_jar_path(sc)
         else:
-            from pkg_resources import resource_filename
-            return os.path.abspath(resource_filename("sparkling_water", BackingJar.getName()))
+            from importlib.resources import files
+            return os.path.abspath(str(files("sparkling_water").joinpath(BackingJar.getName())))
 
     @staticmethod
     def __get_logger(jvm):
@@ -192,9 +192,9 @@ class Initializer(object):
 
     @staticmethod
     def isRunningViaDBCConnect():
-        import pkg_resources as pkg
+        from importlib.metadata import distribution
         try:
-            pkg.get_distribution('databricks-connect')
+            distribution('databricks-connect')
             return True
         except:
             return False


### PR DESCRIPTION
**Description:**
<!-- Give a brief description of the task -->

[`setuptools` has removed `pkg_resources`](https://setuptools.pypa.io/en/stable/history.html). This raises errors when running model predictions. This change fixes that by using the modern `importlib` equivalents.

**Related Issues (optional):**
<!-- Any related issues such as sub tasks, issues reported in other repositories (e.g component repositories), similar problems, etc. -->
* Looks like this might be a duplicate of #5740 
